### PR TITLE
perf: reduce token consumption

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ export default {
   },
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",
+    "^@toon-format/toon$": "<rootDir>/tests/__mocks__/@toon-format/toon.ts",
   },
   collectCoverageFrom: [
     "src/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "author": "Certinia",
   "license": "SEE LICENSE IN ../LICENSE.txt",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.17.3"
+    "@modelcontextprotocol/sdk": "1.17.3",
+    "@toon-format/toon": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: 1.17.3
         version: 1.17.3
+      '@toon-format/toon':
+        specifier: ^1.0.0
+        version: 1.0.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -434,6 +437,9 @@ packages:
 
   '@sinonjs/fake-timers@13.0.5':
     resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
+
+  '@toon-format/toon@1.0.0':
+    resolution: {integrity: sha512-2gIk8LaqrzpurNDaDWZ72kucAGcBbxJxUnp+4ZP+Pny/QVNdMVf97yzSDTI3ed2q8ypjj8T271P6iE3bRmQBNw==}
 
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
@@ -2598,6 +2604,8 @@ snapshots:
   '@sinonjs/fake-timers@13.0.5':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@toon-format/toon@1.0.0': {}
 
   '@tsconfig/node10@1.0.11': {}
 

--- a/src/tools/analyzeLogPerformance.ts
+++ b/src/tools/analyzeLogPerformance.ts
@@ -4,6 +4,7 @@
 
 import { promises as fs } from "fs";
 import { parse, ApexLog, LogLine } from "../ApexLogParser.js";
+import { encode } from "@toon-format/toon";
 
 export interface AnalyzeLogArgs {
   logFilePath: string;
@@ -99,7 +100,7 @@ export async function analyzeLogPerformance(args: AnalyzeLogArgs) {
     content: [
       {
         type: "text",
-        text: JSON.stringify(result, null, 2),
+        text: encode(result)
       },
     ],
   };

--- a/src/tools/findPerformanceBottlenecks.ts
+++ b/src/tools/findPerformanceBottlenecks.ts
@@ -5,13 +5,14 @@
 import { promises as fs } from "fs";
 import { parse, ApexLog } from "../ApexLogParser.js";
 import { SlowMethod, extractMethods } from "./analyzeLogPerformance.js";
+import { encode } from "@toon-format/toon";
 
 export interface BottleneckArgs {
   logFilePath: string;
   analysisType?: "cpu" | "database" | "methods" | "all";
 }
 
-interface BottleneckResult {
+export interface BottleneckResult {
   cpuBottlenecks?: Record<string, unknown>;
   databaseBottlenecks?: Record<string, unknown>;
   methodBottlenecks?: Record<string, unknown>;
@@ -72,7 +73,7 @@ export async function findPerformanceBottlenecks(args: BottleneckArgs) {
     content: [
       {
         type: "text",
-        text: JSON.stringify(bottlenecks, null, 2),
+        text: encode(bottlenecks)
       },
     ],
   };

--- a/src/tools/getLogSummary.ts
+++ b/src/tools/getLogSummary.ts
@@ -5,6 +5,7 @@
 import { promises as fs } from "fs";
 import path from "path";
 import { parse, ApexLog, LogLine } from "../ApexLogParser.js";
+import { encode } from "@toon-format/toon";
 
 export interface LogSummaryArgs {
   logFilePath: string;
@@ -61,7 +62,7 @@ export async function getLogSummary(args: LogSummaryArgs) {
     content: [
       {
         type: "text",
-        text: JSON.stringify(summary, null, 2),
+        text: encode(summary)
       },
     ],
   };

--- a/tests/__mocks__/@toon-format/toon.ts
+++ b/tests/__mocks__/@toon-format/toon.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+// Manual mock for @toon-format/toon to avoid ESM/CommonJS compatibility issues in Jest
+
+export const encode = (data: any): string => {
+  return JSON.stringify(data);
+};
+
+export const decode = (data: string): any => {
+  return JSON.parse(data);
+};
+
+export const DEFAULT_DELIMITER = "\n";
+export const DELIMITERS = {
+  NEWLINE: "\n",
+  PIPE: "|",
+  COMMA: ",",
+};

--- a/tests/analyzeLogPerformance.test.ts
+++ b/tests/analyzeLogPerformance.test.ts
@@ -12,6 +12,7 @@ import {
   analyzeLogPerformanceTool,
 } from "../src/tools/analyzeLogPerformance";
 import { parse } from "../src/ApexLogParser";
+import { decode } from "@toon-format/toon";
 
 // Mock file system operations
 jest.mock("fs", () => ({
@@ -98,9 +99,7 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = JSON.parse(
-        result.content[0].text
-      );
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.totalMethods).toBe(3);
       expect(parsedResult.totalExecutionTime).toBe(1000000000); // 1 second in ns
@@ -120,9 +119,7 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = JSON.parse(
-        result.content[0].text
-      );
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.slowestMethods).toHaveLength(2);
       expect(parsedResult.slowestMethods[0].name).toBe("SlowMethod");
@@ -139,9 +136,7 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = JSON.parse(
-        result.content[0].text
-      );
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.totalMethods).toBe(2); // Only SlowMethod and MediumMethod
       expect(parsedResult.slowestMethods).toHaveLength(2);
@@ -162,9 +157,7 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = JSON.parse(
-        result.content[0].text
-      );
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.totalMethods).toBe(1);
       expect(parsedResult.slowestMethods).toHaveLength(1);
@@ -238,9 +231,7 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = JSON.parse(
-        result.content[0].text
-      );
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.summary).toContain("Analysis found 3 methods");
       expect(parsedResult.summary).toContain("SlowMethod");
@@ -259,9 +250,7 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = JSON.parse(
-        result.content[0].text
-      );
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.summary).toBe(
         "No methods found matching the criteria."
@@ -278,9 +267,9 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = JSON.parse(
+      const parsedResult: LogAnalysisResult = decode(
         result.content[0].text
-      );
+      ) as unknown as LogAnalysisResult;
 
       const soqlRecommendation = parsedResult.recommendations.find(
         (rec) =>
@@ -296,9 +285,7 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = JSON.parse(
-        result.content[0].text
-      );
+      const parsedResult = toonDecode(result);
 
       const dmlRecommendation = parsedResult.recommendations.find(
         (rec) => rec.includes("DML operations") && rec.includes("bulkifying")
@@ -313,9 +300,7 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = JSON.parse(
-        result.content[0].text
-      );
+      const parsedResult = toonDecode(result);
 
       const rowsRecommendation = parsedResult.recommendations.find(
         (rec) => rec.includes("SOQL rows") && rec.includes("WHERE clauses")
@@ -330,9 +315,7 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = JSON.parse(
-        result.content[0].text
-      );
+      const parsedResult = toonDecode(result);
 
       const percentageRecommendation = parsedResult.recommendations.find(
         (rec) =>
@@ -349,9 +332,7 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = JSON.parse(
-        result.content[0].text
-      );
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.recommendations).toContain(
         "Performance looks good! No obvious bottlenecks detected in the analyzed methods."
@@ -368,9 +349,7 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = JSON.parse(
-        result.content[0].text
-      );
+      const parsedResult = toonDecode(result);
 
       // Should only mention first 3 methods in recommendations
       const methodMentions = parsedResult.recommendations.filter(
@@ -396,9 +375,7 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = JSON.parse(
-        result.content[0].text
-      );
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.totalMethods).toBe(0);
       expect(parsedResult.slowestMethods).toHaveLength(0);
@@ -417,9 +394,7 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = JSON.parse(
-        result.content[0].text
-      );
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.totalMethods).toBe(0);
       expect(parsedResult.slowestMethods).toHaveLength(0);
@@ -459,9 +434,7 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = JSON.parse(
-        result.content[0].text
-      );
+      const parsedResult = toonDecode(result);
 
       const method = parsedResult.slowestMethods[0];
       expect(typeof method.name).toBe("string");
@@ -485,9 +458,7 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = JSON.parse(
-        result.content[0].text
-      );
+      const parsedResult = toonDecode(result);
 
       expect(typeof parsedResult.totalMethods).toBe("number");
       expect(typeof parsedResult.totalExecutionTime).toBe("number");
@@ -496,6 +467,13 @@ describe("analyzeLogPerformance", () => {
       expect(Array.isArray(parsedResult.recommendations)).toBe(true);
     });
   });
+
+  // Helper function for decoding TOON-formatted data
+  function toonDecode(result: any): LogAnalysisResult {
+    return decode(
+      result.content[0].text
+    ) as unknown as LogAnalysisResult;
+  }
 
   // Helper functions for creating mock data
   function setupMocksForSuccess(mockApexLog: any): void {

--- a/tests/analyzeLogPerformance.test.ts
+++ b/tests/analyzeLogPerformance.test.ts
@@ -267,9 +267,7 @@ describe("analyzeLogPerformance", () => {
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
-      const parsedResult: LogAnalysisResult = decode(
-        result.content[0].text
-      ) as unknown as LogAnalysisResult;
+      const parsedResult = toonDecode(result);
 
       const soqlRecommendation = parsedResult.recommendations.find(
         (rec) =>

--- a/tests/findPerformanceBottlenecks.test.ts
+++ b/tests/findPerformanceBottlenecks.test.ts
@@ -7,9 +7,11 @@ import { jest } from "@jest/globals";
 import {
   findPerformanceBottlenecks,
   BottleneckArgs,
+  BottleneckResult
 } from "../src/tools/findPerformanceBottlenecks";
 import { parse, ApexLog, Limits, GovernorLimits } from "../src/ApexLogParser";
 import { extractMethods, SlowMethod } from "../src/tools/analyzeLogPerformance";
+import { decode } from "@toon-format/toon";
 
 // Mock dependencies
 jest.mock("fs", () => ({
@@ -206,7 +208,7 @@ describe("findPerformanceBottlenecks", () => {
       expect(result.content).toHaveLength(1);
       expect(result.content[0].type).toBe("text");
 
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       // Should contain all analysis types
       expect(parsedResult).toHaveProperty("cpuBottlenecks");
@@ -223,12 +225,12 @@ describe("findPerformanceBottlenecks", () => {
       });
 
       // Verify database analysis
-      expect(parsedResult.databaseBottlenecks.soqlQueries).toMatchObject({
+      expect(parsedResult.databaseBottlenecks!.soqlQueries).toMatchObject({
         used: 90,
         limit: 100,
         percentage: 90,
       });
-      expect(parsedResult.databaseBottlenecks.dmlStatements).toMatchObject({
+      expect(parsedResult.databaseBottlenecks!.dmlStatements).toMatchObject({
         used: 120,
         limit: 150,
         percentage: 80,
@@ -268,7 +270,7 @@ describe("findPerformanceBottlenecks", () => {
       mockExtractMethods.mockReturnValue([]);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult).toHaveProperty("cpuBottlenecks");
       expect(parsedResult).toHaveProperty("databaseBottlenecks");
@@ -291,7 +293,7 @@ describe("findPerformanceBottlenecks", () => {
       mockParse.mockReturnValue(mockLog);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       // Should only contain CPU analysis and governor limit warnings
       expect(parsedResult).toHaveProperty("cpuBottlenecks");
@@ -320,7 +322,7 @@ describe("findPerformanceBottlenecks", () => {
       mockParse.mockReturnValue(mockLog);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.cpuBottlenecks).toMatchObject({
         cpuTimeUsed: 5000,
@@ -343,7 +345,7 @@ describe("findPerformanceBottlenecks", () => {
       mockParse.mockReturnValue(mockLog);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.cpuBottlenecks).toMatchObject({
         cpuTimeUsed: 1000,
@@ -370,7 +372,7 @@ describe("findPerformanceBottlenecks", () => {
       mockParse.mockReturnValue(mockLog);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       // Should only contain database analysis and governor limit warnings
       expect(parsedResult).not.toHaveProperty("cpuBottlenecks");
@@ -412,7 +414,7 @@ describe("findPerformanceBottlenecks", () => {
       mockParse.mockReturnValue(mockLog);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.databaseBottlenecks).toMatchObject({
         soqlQueries: {
@@ -448,7 +450,7 @@ describe("findPerformanceBottlenecks", () => {
       mockExtractMethods.mockReturnValue(mockMethods);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       // Should only contain method analysis and governor limit warnings
       expect(parsedResult).not.toHaveProperty("cpuBottlenecks");
@@ -487,7 +489,7 @@ describe("findPerformanceBottlenecks", () => {
       mockExtractMethods.mockReturnValue([]);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.methodBottlenecks).toMatchObject({
         totalMethods: 0,
@@ -533,11 +535,12 @@ describe("findPerformanceBottlenecks", () => {
       mockExtractMethods.mockReturnValue(methodsWithSingleNamespace);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
+      const methodBottlenecks = parsedResult.methodBottlenecks as any;
 
-      expect(parsedResult.methodBottlenecks.methodsByNamespace).toHaveLength(1);
+      expect(methodBottlenecks.methodsByNamespace).toHaveLength(1);
       expect(
-        parsedResult.methodBottlenecks.methodsByNamespace[0]
+        methodBottlenecks.methodsByNamespace[0]
       ).toMatchObject({
         namespace: "TestNamespace",
         methodCount: 2,
@@ -562,7 +565,7 @@ describe("findPerformanceBottlenecks", () => {
       mockExtractMethods.mockReturnValue([]);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.governorLimitWarnings.warnings).toContain(
         "cpuTime: 85.0% of limit used (8500/10000)"
@@ -595,7 +598,7 @@ describe("findPerformanceBottlenecks", () => {
       mockExtractMethods.mockReturnValue([]);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.governorLimitWarnings.warnings).toHaveLength(0);
     });
@@ -613,7 +616,7 @@ describe("findPerformanceBottlenecks", () => {
       mockExtractMethods.mockReturnValue([]);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.governorLimitWarnings.warnings).toHaveLength(0);
     });
@@ -632,7 +635,7 @@ describe("findPerformanceBottlenecks", () => {
       mockExtractMethods.mockReturnValue([]);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.governorLimitWarnings.details).toMatchObject(
         expect.objectContaining(customLimits)
@@ -650,7 +653,7 @@ describe("findPerformanceBottlenecks", () => {
       mockExtractMethods.mockReturnValue([]);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       // Should not generate warning for exactly 80% (warning threshold is > 80%)
       expect(parsedResult.governorLimitWarnings.warnings).toHaveLength(0);
@@ -667,7 +670,7 @@ describe("findPerformanceBottlenecks", () => {
       mockExtractMethods.mockReturnValue([]);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       // Should generate warning for just over 80%
       expect(parsedResult.governorLimitWarnings.warnings).toContain(
@@ -723,28 +726,31 @@ describe("findPerformanceBottlenecks", () => {
       mockExtractMethods.mockReturnValue(mockMethods);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
+      const databaseBottlenecks = parsedResult.databaseBottlenecks as any;
+      const methodBottlenecks = parsedResult.methodBottlenecks as any;
+      const governorLimitWarnings = parsedResult.governorLimitWarnings as any;
 
       // Should identify all bottleneck types
-      expect(parsedResult.cpuBottlenecks.warning).toBe(
+      expect(parsedResult.cpuBottlenecks!.warning).toBe(
         "High CPU usage detected - consider optimizing algorithms"
       );
-      expect(parsedResult.cpuBottlenecks.cpuUsagePercentage).toBe(95);
+      expect(parsedResult.cpuBottlenecks!.cpuUsagePercentage).toBe(95);
 
       // Database bottlenecks should show high usage
-      expect(parsedResult.databaseBottlenecks.soqlQueries.percentage).toBe(95);
+      expect(databaseBottlenecks.soqlQueries.percentage).toBe(95);
       expect(
-        parsedResult.databaseBottlenecks.dmlStatements.percentage
+        databaseBottlenecks.dmlStatements.percentage
       ).toBeCloseTo(93.33, 1);
-      expect(parsedResult.databaseBottlenecks.queryRows.percentage).toBe(96);
+      expect(databaseBottlenecks.queryRows.percentage).toBe(96);
 
       // Method analysis should show multiple namespaces
-      expect(parsedResult.methodBottlenecks.totalMethods).toBe(2);
-      expect(parsedResult.methodBottlenecks.methodsByNamespace).toHaveLength(2);
+      expect(methodBottlenecks.totalMethods).toBe(2);
+      expect(methodBottlenecks.methodsByNamespace).toHaveLength(2);
 
       // Multiple governor limit warnings
       expect(
-        parsedResult.governorLimitWarnings.warnings.length
+        governorLimitWarnings.warnings.length
       ).toBeGreaterThan(3);
       expect(parsedResult.governorLimitWarnings.warnings).toContain(
         "cpuTime: 95.0% of limit used (9500/10000)"
@@ -788,21 +794,23 @@ describe("findPerformanceBottlenecks", () => {
       mockExtractMethods.mockReturnValue(mockMethods);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
+      const databaseBottlenecks = parsedResult.databaseBottlenecks as any;
+      const methodBottlenecks = parsedResult.methodBottlenecks as any;
 
       // No CPU warning
-      expect(parsedResult.cpuBottlenecks.warning).toBeNull();
-      expect(parsedResult.cpuBottlenecks.cpuUsagePercentage).toBe(10);
+      expect(parsedResult.cpuBottlenecks!.warning).toBeNull();
+      expect(parsedResult.cpuBottlenecks!.cpuUsagePercentage).toBe(10);
 
       // Low database usage
-      expect(parsedResult.databaseBottlenecks.soqlQueries.percentage).toBe(5);
+      expect(databaseBottlenecks.soqlQueries.percentage).toBe(5);
       expect(
-        parsedResult.databaseBottlenecks.dmlStatements.percentage
+        databaseBottlenecks.dmlStatements.percentage
       ).toBeCloseTo(6.67, 1);
-      expect(parsedResult.databaseBottlenecks.queryRows.percentage).toBe(2);
+      expect(databaseBottlenecks.queryRows.percentage).toBe(2);
 
       // Simple method analysis
-      expect(parsedResult.methodBottlenecks.totalMethods).toBe(1);
+      expect(methodBottlenecks.totalMethods).toBe(1);
 
       // No governor limit warnings
       expect(parsedResult.governorLimitWarnings.warnings).toHaveLength(0);
@@ -826,7 +834,7 @@ describe("findPerformanceBottlenecks", () => {
       expect(result.content[0]).toHaveProperty("text");
 
       // Validate JSON structure
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
       expect(parsedResult).toHaveProperty("governorLimitWarnings");
       expect(parsedResult.governorLimitWarnings).toHaveProperty("warnings");
       expect(parsedResult.governorLimitWarnings).toHaveProperty("details");
@@ -846,7 +854,7 @@ describe("findPerformanceBottlenecks", () => {
       mockExtractMethods.mockReturnValue([]);
 
       const result = await findPerformanceBottlenecks(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       // Should still work without errors
       expect(parsedResult).toHaveProperty("governorLimitWarnings");
@@ -855,4 +863,11 @@ describe("findPerformanceBottlenecks", () => {
       );
     });
   });
+
+  // Helper function for decoding TOON-formatted data
+  function toonDecode(result: any): BottleneckResult {
+    return decode(
+      result.content[0].text
+    ) as unknown as BottleneckResult;
+  }
 });

--- a/tests/getLogSummary.test.ts
+++ b/tests/getLogSummary.test.ts
@@ -15,6 +15,7 @@ import {
   LogIssue,
   ApexLogParser,
 } from "../src/ApexLogParser";
+import { decode, encode } from "@toon-format/toon";
 
 // Mock the dependencies
 jest.mock("fs", () => ({
@@ -193,7 +194,7 @@ describe("getLogSummary", () => {
         content: [
           {
             type: "text",
-            text: JSON.stringify(
+            text: encode(
               {
                 file: "test-log.log",
                 totalExecutionTime: 12500,
@@ -211,9 +212,7 @@ describe("getLogSummary", () => {
                 namespaces: ["default", "MyNamespace"],
                 logIssues: 0,
                 parsingErrors: 0,
-              },
-              null,
-              2
+              }
             ),
           },
         ],
@@ -235,7 +234,7 @@ describe("getLogSummary", () => {
       };
 
       const result = await getLogSummary(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.namespaces).toEqual([
         "default",
@@ -270,7 +269,7 @@ describe("getLogSummary", () => {
       };
 
       const result = await getLogSummary(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.logIssues).toBe(1);
       expect(parsedResult.parsingErrors).toBe(1);
@@ -303,7 +302,7 @@ describe("getLogSummary", () => {
       };
 
       const result = await getLogSummary(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       // Should count: 3 METHOD_ENTRY + 1 with subCategory 'Method' + 1 CONSTRUCTOR_ENTRY with subCategory 'Method' = 5
       expect(parsedResult.totalMethods).toBe(5);
@@ -348,7 +347,7 @@ describe("getLogSummary", () => {
       };
 
       const result = await getLogSummary(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.totalExecutionTime).toBe(0);
       expect(parsedResult.totalMethods).toBe(0);
@@ -390,7 +389,7 @@ describe("getLogSummary", () => {
         };
 
         const result = await getLogSummary(args);
-        const parsedResult = JSON.parse(result.content[0].text);
+        const parsedResult = toonDecode(result);
 
         expect(parsedResult.file).toBe(testCase.expected);
         expect(mockPath.basename).toHaveBeenCalledWith(testCase.path);
@@ -488,7 +487,7 @@ describe("getLogSummary", () => {
       };
 
       const result = await getLogSummary(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.namespaces).toEqual([]);
       expect(parsedResult.logIssues).toBe(0);
@@ -522,7 +521,7 @@ describe("getLogSummary", () => {
       };
 
       const result = await getLogSummary(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       // Should count: 1 METHOD_ENTRY + 1 with subCategory 'Method' = 2
       expect(parsedResult.totalMethods).toBe(2);
@@ -559,7 +558,7 @@ describe("getLogSummary", () => {
       };
 
       const result = await getLogSummary(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       // Should count: 6 METHOD_ENTRY nodes + 1 with subCategory 'Method' + 1 nested METHOD_ENTRY = 8
       expect(parsedResult.totalMethods).toBe(8);
@@ -588,7 +587,7 @@ describe("getLogSummary", () => {
       };
 
       const result = await getLogSummary(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.totalMethods).toBe(0);
     });
@@ -627,7 +626,7 @@ describe("getLogSummary", () => {
       };
 
       const result = await getLogSummary(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.governorLimits).toEqual({
         cpuTime: { used: 8000, limit: 10000 },
@@ -669,7 +668,7 @@ describe("getLogSummary", () => {
       };
 
       const result = await getLogSummary(args);
-      const parsedResult = JSON.parse(result.content[0].text);
+      const parsedResult = toonDecode(result);
 
       expect(parsedResult.governorLimits.cpuTime.used).toBe(10000);
       expect(parsedResult.governorLimits.cpuTime.limit).toBe(10000);
@@ -681,4 +680,11 @@ describe("getLogSummary", () => {
       expect(parsedResult.governorLimits.dmlStatements.limit).toBe(150);
     });
   });
+
+  // Helper function for decoding TOON-formatted data
+  function toonDecode(result: any): any {
+    return decode(
+      result.content[0].text
+    ) as any;
+  }
 });


### PR DESCRIPTION
Reduces token consumption in `getLogSummary`, `findPerformanceBottlenecks`, and `analyzeLogPerformance` by implementing [TOON (token-oriented object notation)](https://github.com/toon-format/toon#readme) encoding on the return objects.

Addresses #5 (and #6, #7, #8 - all reliant on the main change of adding TOON). 

closes #5 
closes #6 
closes #7 
closes #8 