### PR TITLE
feat: apply 80% threshold to bottleneck analysis

### DIFF
--- a/src/tools/findPerformanceBottlenecks.ts
+++ b/src/tools/findPerformanceBottlenecks.ts
@@ -85,14 +85,16 @@ function analyzeCPUBottlenecks(apexLog: ApexLog): Record<string, unknown> {
   const { used, limit } = apexLog.governorLimits.cpuTime;
   const cpuUsagePercent = limit > 0 ? (used / limit) * 100 : 0;
 
-  return cpuUsagePercent > WARNING_THRESHOLD
-    ? {
-        cpuTimeUsed: used,
-        cpuTimeLimit: limit,
-        cpuUsagePercentage: cpuUsagePercent,
-        warning: "High CPU usage detected - consider optimizing algorithms",
-      }
-    : {};
+  if (cpuUsagePercent > WARNING_THRESHOLD) {
+    return {
+      cpuTimeUsed: used,
+      cpuTimeLimit: limit,
+      cpuUsagePercentage: cpuUsagePercent,
+      warning: "High CPU usage detected - consider optimizing algorithms",
+    };
+  }
+
+  return {};
 }
 
 function analyzeDatabaseBottlenecks(apexLog: ApexLog): Record<string, unknown> {

--- a/src/tools/findPerformanceBottlenecks.ts
+++ b/src/tools/findPerformanceBottlenecks.ts
@@ -82,16 +82,13 @@ export async function findPerformanceBottlenecks(args: BottleneckArgs) {
 }
 
 function analyzeCPUBottlenecks(apexLog: ApexLog): Record<string, unknown> {
-  const governorLimits = apexLog.governorLimits;
-  const cpuUsagePercent =
-    governorLimits.cpuTime.limit > 0
-      ? (governorLimits.cpuTime.used / governorLimits.cpuTime.limit) * 100
-      : 0;
+  const { used, limit } = apexLog.governorLimits.cpuTime;
+  const cpuUsagePercent = limit > 0 ? (used / limit) * 100 : 0;
 
   return cpuUsagePercent > WARNING_THRESHOLD
     ? {
-        cpuTimeUsed: governorLimits.cpuTime.used,
-        cpuTimeLimit: governorLimits.cpuTime.limit,
+        cpuTimeUsed: used,
+        cpuTimeLimit: limit,
         cpuUsagePercentage: cpuUsagePercent,
         warning: "High CPU usage detected - consider optimizing algorithms",
       }

--- a/src/tools/findPerformanceBottlenecks.ts
+++ b/src/tools/findPerformanceBottlenecks.ts
@@ -85,50 +85,61 @@ function analyzeCPUBottlenecks(apexLog: ApexLog): Record<string, unknown> {
       ? (governorLimits.cpuTime.used / governorLimits.cpuTime.limit) * 100
       : 0;
 
-  return {
-    cpuTimeUsed: governorLimits.cpuTime.used,
-    cpuTimeLimit: governorLimits.cpuTime.limit,
-    cpuUsagePercentage: cpuUsagePercent,
-    warning:
-      cpuUsagePercent > 80
-        ? "High CPU usage detected - consider optimizing algorithms"
-        : null,
-  };
+  return cpuUsagePercent > 80
+    ? {
+        cpuTimeUsed: governorLimits.cpuTime.used,
+        cpuTimeLimit: governorLimits.cpuTime.limit,
+        cpuUsagePercentage: cpuUsagePercent,
+        warning: "High CPU usage detected - consider optimizing algorithms",
+      }
+    : {};
+
 }
 
 function analyzeDatabaseBottlenecks(apexLog: ApexLog): Record<string, unknown> {
   const governorLimits = apexLog.governorLimits;
-  return {
-    soqlQueries: {
+  const bottlenecks: Record<string, unknown> = {};
+
+  const soqlPercentage =
+    governorLimits.soqlQueries.limit > 0
+      ? (governorLimits.soqlQueries.used / governorLimits.soqlQueries.limit) * 100
+      : 0;
+
+  if (soqlPercentage > 80) {
+    bottlenecks.soqlQueries = {
       used: governorLimits.soqlQueries.used,
       limit: governorLimits.soqlQueries.limit,
-      percentage:
-        governorLimits.soqlQueries.limit > 0
-          ? (governorLimits.soqlQueries.used /
-              governorLimits.soqlQueries.limit) *
-            100
-          : 0,
-    },
-    dmlStatements: {
+      percentage: soqlPercentage,
+    };
+  }
+
+  const dmlPercentage =
+    governorLimits.dmlStatements.limit > 0
+      ? (governorLimits.dmlStatements.used / governorLimits.dmlStatements.limit) * 100
+      : 0;
+
+  if (dmlPercentage > 80) {
+    bottlenecks.dmlStatements = {
       used: governorLimits.dmlStatements.used,
       limit: governorLimits.dmlStatements.limit,
-      percentage:
-        governorLimits.dmlStatements.limit > 0
-          ? (governorLimits.dmlStatements.used /
-              governorLimits.dmlStatements.limit) *
-            100
-          : 0,
-    },
-    queryRows: {
+      percentage: dmlPercentage,
+    };
+  }
+
+  const queryRowsPercentage =
+    governorLimits.queryRows.limit > 0
+      ? (governorLimits.queryRows.used / governorLimits.queryRows.limit) * 100
+      : 0;
+
+  if (queryRowsPercentage > 80) {
+    bottlenecks.queryRows = {
       used: governorLimits.queryRows.used,
       limit: governorLimits.queryRows.limit,
-      percentage:
-        governorLimits.queryRows.limit > 0
-          ? (governorLimits.queryRows.used / governorLimits.queryRows.limit) *
-            100
-          : 0,
-    },
-  };
+      percentage: queryRowsPercentage,
+    };
+  }
+
+  return bottlenecks;
 }
 
 function analyzeMethodBottlenecks(apexLog: ApexLog): Record<string, unknown> {
@@ -183,6 +194,7 @@ function analyzeGovernorLimits(apexLog: ApexLog): Record<string, unknown> {
     },
     {}
   );
+
 
   return {
     warnings,

--- a/src/tools/findPerformanceBottlenecks.ts
+++ b/src/tools/findPerformanceBottlenecks.ts
@@ -41,6 +41,8 @@ export const findPerformanceBottlenecksTool = {
   },
 };
 
+export const WARNING_THRESHOLD = 80;
+
 export async function findPerformanceBottlenecks(args: BottleneckArgs) {
   const { logFilePath, analysisType = "all" } = args;
 
@@ -86,7 +88,7 @@ function analyzeCPUBottlenecks(apexLog: ApexLog): Record<string, unknown> {
       ? (governorLimits.cpuTime.used / governorLimits.cpuTime.limit) * 100
       : 0;
 
-  return cpuUsagePercent > 80
+  return cpuUsagePercent > WARNING_THRESHOLD
     ? {
         cpuTimeUsed: governorLimits.cpuTime.used,
         cpuTimeLimit: governorLimits.cpuTime.limit,
@@ -106,7 +108,7 @@ function analyzeDatabaseBottlenecks(apexLog: ApexLog): Record<string, unknown> {
         100
       : 0;
 
-  if (soqlPercentage > 80) {
+  if (soqlPercentage > WARNING_THRESHOLD) {
     bottlenecks.soqlQueries = {
       used: governorLimits.soqlQueries.used,
       limit: governorLimits.soqlQueries.limit,
@@ -121,7 +123,7 @@ function analyzeDatabaseBottlenecks(apexLog: ApexLog): Record<string, unknown> {
         100
       : 0;
 
-  if (dmlPercentage > 80) {
+  if (dmlPercentage > WARNING_THRESHOLD) {
     bottlenecks.dmlStatements = {
       used: governorLimits.dmlStatements.used,
       limit: governorLimits.dmlStatements.limit,
@@ -134,7 +136,7 @@ function analyzeDatabaseBottlenecks(apexLog: ApexLog): Record<string, unknown> {
       ? (governorLimits.queryRows.used / governorLimits.queryRows.limit) * 100
       : 0;
 
-  if (queryRowsPercentage > 80) {
+  if (queryRowsPercentage > WARNING_THRESHOLD) {
     bottlenecks.queryRows = {
       used: governorLimits.queryRows.used,
       limit: governorLimits.queryRows.limit,
@@ -178,7 +180,7 @@ function analyzeGovernorLimits(apexLog: ApexLog): Record<string, unknown> {
   Object.entries(limits).forEach(([key, value]: [string, any]) => {
     if (key !== "byNamespace" && value.limit > 0) {
       const percentage = (value.used / value.limit) * 100;
-      if (percentage > 80) {
+      if (percentage > WARNING_THRESHOLD) {
         warnings.push(
           `${key}: ${percentage.toFixed(1)}% of limit used (${value.used}/${
             value.limit
@@ -192,7 +194,7 @@ function analyzeGovernorLimits(apexLog: ApexLog): Record<string, unknown> {
     (acc: Record<string, unknown>, [key, value]: [string, any]) => {
       if (key !== "byNamespace" && value.limit > 0) {
         const percentage = (value.used / value.limit) * 100;
-        if (percentage > 80) {
+        if (percentage > WARNING_THRESHOLD) {
           acc[key] = value;
         }
       }

--- a/src/tools/findPerformanceBottlenecks.ts
+++ b/src/tools/findPerformanceBottlenecks.ts
@@ -73,7 +73,7 @@ export async function findPerformanceBottlenecks(args: BottleneckArgs) {
     content: [
       {
         type: "text",
-        text: encode(bottlenecks)
+        text: encode(bottlenecks),
       },
     ],
   };
@@ -94,7 +94,6 @@ function analyzeCPUBottlenecks(apexLog: ApexLog): Record<string, unknown> {
         warning: "High CPU usage detected - consider optimizing algorithms",
       }
     : {};
-
 }
 
 function analyzeDatabaseBottlenecks(apexLog: ApexLog): Record<string, unknown> {
@@ -103,7 +102,8 @@ function analyzeDatabaseBottlenecks(apexLog: ApexLog): Record<string, unknown> {
 
   const soqlPercentage =
     governorLimits.soqlQueries.limit > 0
-      ? (governorLimits.soqlQueries.used / governorLimits.soqlQueries.limit) * 100
+      ? (governorLimits.soqlQueries.used / governorLimits.soqlQueries.limit) *
+        100
       : 0;
 
   if (soqlPercentage > 80) {
@@ -116,7 +116,9 @@ function analyzeDatabaseBottlenecks(apexLog: ApexLog): Record<string, unknown> {
 
   const dmlPercentage =
     governorLimits.dmlStatements.limit > 0
-      ? (governorLimits.dmlStatements.used / governorLimits.dmlStatements.limit) * 100
+      ? (governorLimits.dmlStatements.used /
+          governorLimits.dmlStatements.limit) *
+        100
       : 0;
 
   if (dmlPercentage > 80) {
@@ -188,22 +190,23 @@ function analyzeGovernorLimits(apexLog: ApexLog): Record<string, unknown> {
 
   const reducedLimits = Object.entries(limits).reduce(
     (acc: Record<string, unknown>, [key, value]: [string, any]) => {
-      if (value.used > 0) {
-        acc[key] = value;
+      if (key !== "byNamespace" && value.limit > 0) {
+        const percentage = (value.used / value.limit) * 100;
+        if (percentage > 80) {
+          acc[key] = value;
+        }
       }
       return acc;
     },
     {}
   );
 
-
-  return {
-    warnings,
-    // Only include limits with usage
-    details: reducedLimits,
-    note:
-      warnings.length === 0
-        ? "No governor limits approaching their thresholds detected."
-        : undefined,
-  };
+  return warnings.length === 0
+    ? { note: "No governor limits approaching their thresholds." }
+    : {
+        warnings,
+        // Only include limits with usage
+        details: reducedLimits,
+        note: undefined,
+      };
 }

--- a/tests/findPerformanceBottlenecks.test.ts
+++ b/tests/findPerformanceBottlenecks.test.ts
@@ -7,7 +7,7 @@ import { jest } from "@jest/globals";
 import {
   findPerformanceBottlenecks,
   BottleneckArgs,
-  BottleneckResult
+  BottleneckResult,
 } from "../src/tools/findPerformanceBottlenecks";
 import { parse, ApexLog, Limits, GovernorLimits } from "../src/ApexLogParser";
 import { extractMethods, SlowMethod } from "../src/tools/analyzeLogPerformance";
@@ -309,7 +309,7 @@ describe("findPerformanceBottlenecks", () => {
       });
     });
 
-    it("should not show CPU warning when usage is below 80%", async () => {
+    it("should not show CPU information when usage is below 80%", async () => {
       const args: BottleneckArgs = {
         logFilePath: mockLogFilePath,
         analysisType: "cpu",
@@ -324,12 +324,7 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.cpuBottlenecks).toMatchObject({
-        cpuTimeUsed: 5000,
-        cpuTimeLimit: 10000,
-        cpuUsagePercentage: 50,
-        warning: null,
-      });
+      expect(parsedResult.cpuBottlenecks).toMatchObject({});
     });
 
     it("should handle zero CPU limit", async () => {
@@ -539,9 +534,7 @@ describe("findPerformanceBottlenecks", () => {
       const methodBottlenecks = parsedResult.methodBottlenecks as any;
 
       expect(methodBottlenecks.methodsByNamespace).toHaveLength(1);
-      expect(
-        methodBottlenecks.methodsByNamespace[0]
-      ).toMatchObject({
+      expect(methodBottlenecks.methodsByNamespace[0]).toMatchObject({
         namespace: "TestNamespace",
         methodCount: 2,
         totalDuration: 300000000,
@@ -739,9 +732,10 @@ describe("findPerformanceBottlenecks", () => {
 
       // Database bottlenecks should show high usage
       expect(databaseBottlenecks.soqlQueries.percentage).toBe(95);
-      expect(
-        databaseBottlenecks.dmlStatements.percentage
-      ).toBeCloseTo(93.33, 1);
+      expect(databaseBottlenecks.dmlStatements.percentage).toBeCloseTo(
+        93.33,
+        1
+      );
       expect(databaseBottlenecks.queryRows.percentage).toBe(96);
 
       // Method analysis should show multiple namespaces
@@ -749,9 +743,7 @@ describe("findPerformanceBottlenecks", () => {
       expect(methodBottlenecks.methodsByNamespace).toHaveLength(2);
 
       // Multiple governor limit warnings
-      expect(
-        governorLimitWarnings.warnings.length
-      ).toBeGreaterThan(3);
+      expect(governorLimitWarnings.warnings.length).toBeGreaterThan(3);
       expect(parsedResult.governorLimitWarnings.warnings).toContain(
         "cpuTime: 95.0% of limit used (9500/10000)"
       );
@@ -799,15 +791,13 @@ describe("findPerformanceBottlenecks", () => {
       const methodBottlenecks = parsedResult.methodBottlenecks as any;
 
       // No CPU warning
-      expect(parsedResult.cpuBottlenecks!.warning).toBeNull();
-      expect(parsedResult.cpuBottlenecks!.cpuUsagePercentage).toBe(10);
+      expect(parsedResult.cpuBottlenecks!.warning).toBeUndefined();
+      expect(parsedResult).toBeUndefined();
 
       // Low database usage
-      expect(databaseBottlenecks.soqlQueries.percentage).toBe(5);
-      expect(
-        databaseBottlenecks.dmlStatements.percentage
-      ).toBeCloseTo(6.67, 1);
-      expect(databaseBottlenecks.queryRows.percentage).toBe(2);
+      expect(databaseBottlenecks.soqlQueries.percentage).toBeUndefined();
+      expect(databaseBottlenecks.dmlStatements.percentage).toBeUndefined();
+      expect(databaseBottlenecks.queryRows.percentage).toBeUndefined();
 
       // Simple method analysis
       expect(methodBottlenecks.totalMethods).toBe(1);
@@ -859,15 +849,13 @@ describe("findPerformanceBottlenecks", () => {
       // Should still work without errors
       expect(parsedResult).toHaveProperty("governorLimitWarnings");
       expect(Array.isArray(parsedResult.governorLimitWarnings.warnings)).toBe(
-        true
+        false
       );
     });
   });
 
   // Helper function for decoding TOON-formatted data
   function toonDecode(result: any): BottleneckResult {
-    return decode(
-      result.content[0].text
-    ) as unknown as BottleneckResult;
+    return decode(result.content[0].text) as unknown as BottleneckResult;
   }
 });

--- a/tests/findPerformanceBottlenecks.test.ts
+++ b/tests/findPerformanceBottlenecks.test.ts
@@ -224,17 +224,13 @@ describe("findPerformanceBottlenecks", () => {
         warning: "High CPU usage detected - consider optimizing algorithms",
       });
 
-      // Verify database analysis
+      // Verify database analysis - only soqlQueries should be present (>80%)
       expect(parsedResult.databaseBottlenecks!.soqlQueries).toMatchObject({
         used: 90,
         limit: 100,
         percentage: 90,
       });
-      expect(parsedResult.databaseBottlenecks!.dmlStatements).toMatchObject({
-        used: 120,
-        limit: 150,
-        percentage: 80,
-      });
+      expect(parsedResult.databaseBottlenecks!.dmlStatements).toBeUndefined();
 
       // Verify method analysis
       expect(parsedResult.methodBottlenecks).toMatchObject({
@@ -342,12 +338,8 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.cpuBottlenecks).toMatchObject({
-        cpuTimeUsed: 1000,
-        cpuTimeLimit: 0,
-        cpuUsagePercentage: 0,
-        warning: null,
-      });
+      // When limit is 0, percentage is 0, which is not > 80%, so no bottleneck info
+      expect(parsedResult.cpuBottlenecks).toMatchObject({});
     });
   });
 
@@ -375,23 +367,8 @@ describe("findPerformanceBottlenecks", () => {
       expect(parsedResult).not.toHaveProperty("methodBottlenecks");
       expect(parsedResult).toHaveProperty("governorLimitWarnings");
 
-      expect(parsedResult.databaseBottlenecks).toMatchObject({
-        soqlQueries: {
-          used: 75,
-          limit: 100,
-          percentage: 75,
-        },
-        dmlStatements: {
-          used: 100,
-          limit: 150,
-          percentage: expect.closeTo(66.67, 1),
-        },
-        queryRows: {
-          used: 30000,
-          limit: 50000,
-          percentage: 60,
-        },
-      });
+      // None of these exceed 80%, so should return empty object
+      expect(parsedResult.databaseBottlenecks).toMatchObject({});
     });
 
     it("should handle zero database limits", async () => {
@@ -411,23 +388,7 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.databaseBottlenecks).toMatchObject({
-        soqlQueries: {
-          used: 10,
-          limit: 0,
-          percentage: 0,
-        },
-        dmlStatements: {
-          used: 5,
-          limit: 0,
-          percentage: 0,
-        },
-        queryRows: {
-          used: 1000,
-          limit: 0,
-          percentage: 0,
-        },
-      });
+      expect(parsedResult.databaseBottlenecks).toMatchObject({});
     });
   });
 
@@ -593,7 +554,9 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.governorLimitWarnings.warnings).toHaveLength(0);
+      // When usage is low, governorLimitWarnings should have a note instead of warnings
+      expect(parsedResult.governorLimitWarnings).toHaveProperty("note");
+      expect(parsedResult.governorLimitWarnings).not.toHaveProperty("warnings");
     });
 
     it("should not generate warnings for zero limits", async () => {
@@ -611,7 +574,8 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.governorLimitWarnings.warnings).toHaveLength(0);
+      expect(parsedResult.governorLimitWarnings).toHaveProperty("note");
+      expect(parsedResult.governorLimitWarnings).not.toHaveProperty("warnings");
     });
 
     it("should include governor limit details in the response", async () => {
@@ -630,9 +594,8 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.governorLimitWarnings.details).toMatchObject(
-        expect.objectContaining(customLimits)
-      );
+      expect(parsedResult.governorLimitWarnings).toHaveProperty("note");
+      expect(parsedResult.governorLimitWarnings).not.toHaveProperty("details");
     });
 
     it("should handle edge case of exactly 80% usage", async () => {
@@ -648,8 +611,8 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      // Should not generate warning for exactly 80% (warning threshold is > 80%)
-      expect(parsedResult.governorLimitWarnings.warnings).toHaveLength(0);
+      expect(parsedResult.governorLimitWarnings).toHaveProperty("note");
+      expect(parsedResult.governorLimitWarnings).not.toHaveProperty("warnings");
     });
 
     it("should handle edge case of just over 80% usage", async () => {
@@ -790,20 +753,18 @@ describe("findPerformanceBottlenecks", () => {
       const databaseBottlenecks = parsedResult.databaseBottlenecks as any;
       const methodBottlenecks = parsedResult.methodBottlenecks as any;
 
-      // No CPU warning
-      expect(parsedResult.cpuBottlenecks!.warning).toBeUndefined();
-      expect(parsedResult).toBeUndefined();
+      // No CPU bottleneck (below 80%)
+      expect(parsedResult.cpuBottlenecks).toMatchObject({});
 
-      // Low database usage
-      expect(databaseBottlenecks.soqlQueries.percentage).toBeUndefined();
-      expect(databaseBottlenecks.dmlStatements.percentage).toBeUndefined();
-      expect(databaseBottlenecks.queryRows.percentage).toBeUndefined();
+      // Low database usage - no bottlenecks
+      expect(databaseBottlenecks).toMatchObject({});
 
       // Simple method analysis
       expect(methodBottlenecks.totalMethods).toBe(1);
 
       // No governor limit warnings
-      expect(parsedResult.governorLimitWarnings.warnings).toHaveLength(0);
+      expect(parsedResult.governorLimitWarnings).toHaveProperty("note");
+      expect(parsedResult.governorLimitWarnings).not.toHaveProperty("warnings");
     });
   });
 
@@ -826,11 +787,7 @@ describe("findPerformanceBottlenecks", () => {
       // Validate JSON structure
       const parsedResult = toonDecode(result);
       expect(parsedResult).toHaveProperty("governorLimitWarnings");
-      expect(parsedResult.governorLimitWarnings).toHaveProperty("warnings");
-      expect(parsedResult.governorLimitWarnings).toHaveProperty("details");
-      expect(Array.isArray(parsedResult.governorLimitWarnings.warnings)).toBe(
-        true
-      );
+      expect(parsedResult.governorLimitWarnings).toHaveProperty("note");
     });
 
     it("should handle undefined values gracefully", async () => {
@@ -848,9 +805,6 @@ describe("findPerformanceBottlenecks", () => {
 
       // Should still work without errors
       expect(parsedResult).toHaveProperty("governorLimitWarnings");
-      expect(Array.isArray(parsedResult.governorLimitWarnings.warnings)).toBe(
-        false
-      );
     });
   });
 


### PR DESCRIPTION
# Implement Sensible Warning Thresholds for Performance Bottleneck Detection

### Description
This PR  removes the flagged as a bottleneck if the usage is above 80%.

The current implementation sets all detection thresholds to 0, resulting in the inclusion of every non-zero usage entry, even those that are too small to be considered significant performance bottlenecks. This leads to noise in the analysis results,  leading the LLM's to use more tokens. 


Resolves: [Examine limits in findPerformanceBottlenecks](https://github.com/certinia/debug-log-analyzer-mcp/issues/11)