### PR TITLE
feat: execute and analyse tool

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+**/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,4 +77,4 @@ The server provides four main capabilities:
 4. **Execute Anonymous**: Executes anonymous Apex code snippets and retrieves the resulting debug log
 
 Log analysis tools (1-3) accept absolute file paths to `.log` files and return structured JSON for AI processing.
-Anonymous execution accepts multi-line strings containing Apex and returns the entire contents of the log.
+Anonymous execution (4) accepts multi-line strings containing Apex and returns the entire contents of the log.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,9 @@ npm start
 ### Core Components
 
 - **src/index.ts**: Main MCP server implementation (`LanaServer` class)
-  - Implements 3 MCP tools: `analyze_apex_log_performance`, `get_apex_log_summary`, `find_performance_bottlenecks`
+  - Implements 4 MCP tools: `analyze_apex_log_performance`, `get_apex_log_summary`, `find_performance_bottlenecks`, `execute_anonymous`
   - Uses stdio transport for communication
-  - Handles file validation, log parsing, and analysis
+  - Handles file validation, log parsing, analysis, and anonymous Apex execution
 
 - **src/ApexLogParser.ts**: Complex log parsing engine (33k+ tokens)
   - Exports `parse()` function and `ApexLogParser` class
@@ -67,12 +67,14 @@ src/
 dist/               # Compiled JavaScript output
 ```
 
-## Performance Analysis Tools
+## Tools
 
-The server provides three main analysis capabilities:
+The server provides four main capabilities:
 
 1. **Performance Analysis**: Identifies slowest methods with detailed metrics
 2. **Log Summary**: High-level execution statistics and governor limit usage
 3. **Bottleneck Detection**: Analyzes CPU, database, and method performance patterns
+4. **Execute Anonymous**: Executes anonymous Apex code snippets and retrieves the resulting debug log
 
-All tools accept absolute file paths to `.log` files and return structured JSON for AI processing.
+Log analysis tools (1-3) accept absolute file paths to `.log` files and return structured JSON for AI processing.
+Anonymous execution accepts multi-line strings containing Apex and returns the entire contents of the log.

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.17.3",
     "@salesforce/core": "^8.23.4",
-    "@toon-format/toon": "^1.0.0",
-    "dotenv": "^17.2.3"
+    "@toon-format/toon": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@toon-format/toon':
         specifier: ^1.0.0
         version: 1.0.0
-      dotenv:
-        specifier: ^17.2.3
-        version: 17.2.3
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -1045,10 +1042,6 @@ packages:
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
-
-  dotenv@17.2.3:
-    resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
-    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3736,8 +3729,6 @@ snapshots:
     dependencies:
       no-case: 3.0.4
       tslib: 2.8.1
-
-  dotenv@17.2.3: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,14 +117,6 @@ class LanaServer {
   }
 
   private async initializeConnection(): Promise<void> {
-    const username = process.env.ORG_USERNAME;
-
-    if (!username) {
-      throw new Error(
-        "Please set a valid ORG_USERNAME environment variable in your .env file"
-      );
-    }
-
     this.connection = await connect();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { Connection } from "@salesforce/core";
 import {
   analyzeLogPerformance,
   analyzeLogPerformanceTool,
@@ -25,9 +26,16 @@ import {
   findPerformanceBottlenecksTool,
   BottleneckArgs,
 } from "./tools/findPerformanceBottlenecks.js";
+import {
+  executeAnonymous,
+  executeAnonymousTool,
+  ExecuteAnonymousArgs,
+} from "./tools/executeAnonymous.js";
+import { connect } from "./salesforce/connection.js";
 
 class LanaServer {
   private server: Server;
+  private connection: Connection | null = null;
 
   constructor() {
     this.server = new Server(
@@ -62,6 +70,7 @@ class LanaServer {
         analyzeLogPerformanceTool,
         getLogSummaryTool,
         findPerformanceBottlenecksTool,
+        executeAnonymousTool,
       ],
     }));
 
@@ -79,6 +88,14 @@ class LanaServer {
           case "find_performance_bottlenecks":
             return await findPerformanceBottlenecks(
               args as unknown as BottleneckArgs
+            );
+          case "execute_anonymous":
+            if (!this.connection) {
+              throw new Error("Connection not initialised!");
+            }
+            return await executeAnonymous(
+              this.connection,
+              args as unknown as ExecuteAnonymousArgs
             );
           default:
             throw new Error(`Unknown tool: ${name}`);
@@ -99,9 +116,22 @@ class LanaServer {
     });
   }
 
+  private async initializeConnection(): Promise<void> {
+    const username = process.env.ORG_USERNAME;
+
+    if (!username) {
+      throw new Error(
+        "Please set a valid ORG_USERNAME environment variable in your .env file"
+      );
+    }
+
+    this.connection = await connect();
+  }
+
   async run(): Promise<void> {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
+    await this.initializeConnection();
 
     console.error("LANA MCP Server running on stdio");
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,9 @@ class LanaServer {
             );
           case "execute_anonymous":
             if (!this.connection) {
-              throw new Error("Connection not initialised!");
+              throw new Error(
+                "Salesforce connection not initialized. Ensure a default org is configured with 'sf config set target-org <username>'.",
+              );
             }
             return await executeAnonymous(
               this.connection,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,6 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { Connection } from "@salesforce/core";
 import {
   analyzeLogPerformance,
   analyzeLogPerformanceTool,
@@ -31,11 +30,9 @@ import {
   executeAnonymousTool,
   ExecuteAnonymousArgs,
 } from "./tools/executeAnonymous.js";
-import { connect } from "./salesforce/connection.js";
 
 class LanaServer {
   private server: Server;
-  private connection: Connection | null = null;
 
   constructor() {
     this.server = new Server(
@@ -47,7 +44,7 @@ class LanaServer {
         capabilities: {
           tools: {},
         },
-      }
+      },
     );
 
     this.setupToolHandlers();
@@ -81,23 +78,17 @@ class LanaServer {
         switch (name) {
           case "analyze_apex_log_performance":
             return await analyzeLogPerformance(
-              args as unknown as AnalyzeLogArgs
+              args as unknown as AnalyzeLogArgs,
             );
           case "get_apex_log_summary":
             return await getLogSummary(args as unknown as LogSummaryArgs);
           case "find_performance_bottlenecks":
             return await findPerformanceBottlenecks(
-              args as unknown as BottleneckArgs
+              args as unknown as BottleneckArgs,
             );
           case "execute_anonymous":
-            if (!this.connection) {
-              throw new Error(
-                "Salesforce connection not initialized. Ensure a default org is configured with 'sf config set target-org <username>'.",
-              );
-            }
             return await executeAnonymous(
-              this.connection,
-              args as unknown as ExecuteAnonymousArgs
+              args as unknown as ExecuteAnonymousArgs,
             );
           default:
             throw new Error(`Unknown tool: ${name}`);
@@ -118,14 +109,9 @@ class LanaServer {
     });
   }
 
-  private async initializeConnection(): Promise<void> {
-    this.connection = await connect();
-  }
-
   async run(): Promise<void> {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
-    await this.initializeConnection();
 
     console.error("LANA MCP Server running on stdio");
   }

--- a/src/salesforce/connection.ts
+++ b/src/salesforce/connection.ts
@@ -1,24 +1,17 @@
-import { Connection, AuthInfo } from "@salesforce/core";
-import env from "dotenv";
+import { Connection, AuthInfo, ConfigAggregator } from "@salesforce/core";
 
-env.config();
+export async function connect(): Promise<Connection> {
+  // Get default org from SF CLI configuration
+  const aggregator = await ConfigAggregator.create();
+  const defaultOrg = aggregator.getPropertyValue("target-org") as string | undefined;
 
-function getUserDetails() {
-  const orgUsername = process.env.ORG_USERNAME;
-
-  if (!orgUsername) {
+  if (!defaultOrg) {
     throw new Error(
-      "Please set a valid ORG_USERNAME environment variable in your .env file"
+      "No default org configured. Please set a default org using 'sf config set target-org <username>'."
     );
   }
 
-  return orgUsername;
-}
-
-export async function connect(): Promise<Connection> {
-  const orgUsername = getUserDetails();
-
-  const authInfo = await AuthInfo.create({ username: orgUsername });
+  const authInfo = await AuthInfo.create({ username: defaultOrg });
   const connection = await Connection.create({ authInfo });
 
   return connection;

--- a/src/salesforce/traceFlags.ts
+++ b/src/salesforce/traceFlags.ts
@@ -3,12 +3,23 @@ import { Connection } from "@salesforce/core";
 const TRACE_FLAG_SOBJECT = "TraceFlag";
 const USER_DEBUG = "USER_DEBUG";
 
+type TraceFlag = {
+  Id: string;
+  TracedEntityId: string;
+  DebugLevelId: string;
+  StartDate: string;
+  ExpirationDate: string;
+};
+
 export async function ensureTraceFlag(
   connection: Connection,
   tracedEntityId: string,
-  debugLevelId: string
+  debugLevelId: string,
 ): Promise<void> {
-  const existingTraceFlag = await findActiveTraceFlag(connection, tracedEntityId);
+  const existingTraceFlag = await findActiveTraceFlag(
+    connection,
+    tracedEntityId,
+  );
 
   if (existingTraceFlag) {
     return;
@@ -17,37 +28,35 @@ export async function ensureTraceFlag(
   const createResult = await createTraceFlag(
     connection,
     tracedEntityId,
-    debugLevelId
+    debugLevelId,
   );
 
   if (!createResult.success) {
     throw new Error(
-      `Failed to create TraceFlag: ${JSON.stringify(createResult.errors)}`
+      `Failed to create TraceFlag: ${JSON.stringify(createResult.errors)}`,
     );
   }
 }
 
 async function findActiveTraceFlag(
   connection: Connection,
-  tracedEntityId: string
-): Promise<any | null> {
+  tracedEntityId: string,
+): Promise<TraceFlag | null> {
   const now = new Date().toISOString();
-  const result = await connection.tooling.query(
-    `SELECT Id, TracedEntityId, DebugLevelId, StartDate, ExpirationDate
-     FROM ${TRACE_FLAG_SOBJECT}
-     WHERE TracedEntityId = '${tracedEntityId}'
-     AND ExpirationDate > ${now}
-     AND LogType = '${USER_DEBUG}'
-     LIMIT 1`
+  return await connection.tooling.sobject(TRACE_FLAG_SOBJECT).findOne(
+    {
+      TracedEntityId: tracedEntityId,
+      ExpirationDate: { $gt: now },
+      LogType: USER_DEBUG,
+    },
+    ["Id", "TracedEntityId", "DebugLevelId", "StartDate", "ExpirationDate"],
   );
-
-  return result.records.length > 0 ? result.records[0] : null;
 }
 
 async function createTraceFlag(
   connection: Connection,
   tracedEntityId: string,
-  debugLevelId: string
+  debugLevelId: string,
 ): Promise<any> {
   return await connection.tooling.sobject(TRACE_FLAG_SOBJECT).create({
     TracedEntityId: tracedEntityId,

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -2,6 +2,7 @@ import { Connection } from "@salesforce/core";
 import { getUserIdByUsername } from "../salesforce/users.js";
 import { getOrCreateDebugLevelId } from "../salesforce/debugLevels.js";
 import { ensureTraceFlag } from "../salesforce/traceFlags.js";
+import { connect } from "../salesforce/connection.js";
 
 export interface ExecuteAnonymousArgs {
   apex: string;
@@ -27,11 +28,10 @@ export const executeAnonymousTool = {
   },
 };
 
-export async function executeAnonymous(
-  connection: Connection,
-  args: ExecuteAnonymousArgs,
-) {
+export async function executeAnonymous(args: ExecuteAnonymousArgs) {
   const { apex } = args;
+
+  const connection = await connect();
 
   const username = connection.getUsername();
   if (!username) {

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -7,6 +7,10 @@ export interface ExecuteAnonymousArgs {
   apex: string;
 }
 
+type ApexLogRecord = {
+  Id: string;
+};
+
 export const executeAnonymousTool = {
   name: "execute_anonymous",
   description:
@@ -49,9 +53,11 @@ export async function executeAnonymous(
   // We retrieve the most recent log for this user, which could be incorrect
   // if another process creates a log between execution and this query.
   // Future enhancement: present a list of recent logs for user selection.
-  const logRecord = await connection
+  const logRecord = (await connection
     .sobject("ApexLog")
-    .findOne({ LogUserId: userId }, ["Id"], { sort: { StartTime: -1 } });
+    .findOne({ LogUserId: userId }, ["Id"], {
+      sort: { StartTime: -1 },
+    })) as ApexLogRecord | null;
 
   if (!logRecord) {
     throw new Error(`Could not retrieve log from anonymous execution.`);

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -27,9 +27,15 @@ export async function executeAnonymous(
   connection: Connection,
   args: ExecuteAnonymousArgs
 ) {
-  await validateTraceFlag(connection);
-
   const { apex } = args;
+
+  const username = connection.getUsername();
+  if (!username) {
+    throw new Error("Could not determine username from connection");
+  }
+
+  await validateTraceFlag(connection, username);
+
   const apexResult = await connection.tooling.executeAnonymous(apex);
 
   if (!apexResult || !apexResult.compiled) {
@@ -38,13 +44,7 @@ export async function executeAnonymous(
     );
   }
 
-  // Get the user ID from the connection
-  const username = process.env.ORG_USERNAME;
-  if (!username) {
-    throw new Error("ORG_USERNAME environment variable is not set");
-  }
   const userId = await getUserIdByUsername(connection, username);
-
   const logResult = await connection.query(
     `SELECT Id FROM ApexLog
      WHERE LogUserId = '${userId}'
@@ -69,15 +69,7 @@ export async function executeAnonymous(
   };
 }
 
-async function validateTraceFlag(connection: Connection) {
-  const username = process.env.ORG_USERNAME;
-
-  if (!username) {
-    throw new Error(
-      "Please set a valid ORG_USERNAME environment variable in your .env file"
-    );
-  }
-
+async function validateTraceFlag(connection: Connection, username: string) {
   const userId = await getUserIdByUsername(connection, username);
   const debugLevelId = await getOrCreateDebugLevelId(connection);
 

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -1,0 +1,85 @@
+import { Connection } from "@salesforce/core";
+import { getUserIdByUsername } from "../salesforce/users.js";
+import { getOrCreateDebugLevelId } from "../salesforce/debugLevels.js";
+import { ensureTraceFlag } from "../salesforce/traceFlags.js";
+
+export interface ExecuteAnonymousArgs {
+  apex: string;
+}
+
+export const executeAnonymousTool = {
+  name: "execute_anonymous",
+  description:
+    "Execute a snippet of anonymous Apex and retrieve the resulting log",
+  inputSchema: {
+    type: "object",
+    properties: {
+      apex: {
+        type: "string",
+        description: "The anonymous Apex to be executed",
+      },
+    },
+    required: ["apex"],
+  },
+};
+
+export async function executeAnonymous(
+  connection: Connection,
+  args: ExecuteAnonymousArgs
+) {
+  await validateTraceFlag(connection);
+
+  const { apex } = args;
+  const apexResult = await connection.tooling.executeAnonymous(apex);
+
+  if (!apexResult || !apexResult.compiled) {
+    throw new Error(
+      `Apex could not be compiled at line ${apexResult.line}, column ${apexResult.column}: ${apexResult.compileProblem}`
+    );
+  }
+
+  // Get the user ID from the connection
+  const username = process.env.ORG_USERNAME;
+  if (!username) {
+    throw new Error("ORG_USERNAME environment variable is not set");
+  }
+  const userId = await getUserIdByUsername(connection, username);
+
+  const logResult = await connection.query(
+    `SELECT Id FROM ApexLog
+     WHERE LogUserId = '${userId}'
+     ORDER BY StartTime DESC
+     LIMIT 1`
+  );
+
+  if (!logResult || !logResult.records || logResult.records.length <= 0) {
+    throw new Error(`Could not retrieve log from anonymous execution.`);
+  }
+
+  const logId = logResult.records[0].Id;
+  const logBody = await connection.request(`/sobjects/ApexLog/${logId}/Body/`);
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: logBody,
+      },
+    ],
+  };
+}
+
+async function validateTraceFlag(connection: Connection) {
+  const username = process.env.ORG_USERNAME;
+
+  if (!username) {
+    throw new Error(
+      "Please set a valid ORG_USERNAME environment variable in your .env file"
+    );
+  }
+
+  const userId = await getUserIdByUsername(connection, username);
+  const debugLevelId = await getOrCreateDebugLevelId(connection);
+
+  await ensureTraceFlag(connection, userId, debugLevelId);
+}

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -34,7 +34,8 @@ export async function executeAnonymous(
     throw new Error("Could not determine username from connection");
   }
 
-  await validateTraceFlag(connection, username);
+  const userId = await getUserIdByUsername(connection, username);
+  await validateTraceFlag(connection, userId);
 
   const apexResult = await connection.tooling.executeAnonymous(apex);
 
@@ -43,8 +44,6 @@ export async function executeAnonymous(
       `Apex could not be compiled at line ${apexResult.line}, column ${apexResult.column}: ${apexResult.compileProblem}`,
     );
   }
-
-  const userId = await getUserIdByUsername(connection, username);
 
   // Note: There's no way to get the specific log ID from executeAnonymous.
   // We retrieve the most recent log for this user, which could be incorrect
@@ -71,9 +70,7 @@ export async function executeAnonymous(
   };
 }
 
-async function validateTraceFlag(connection: Connection, username: string) {
-  const userId = await getUserIdByUsername(connection, username);
+async function validateTraceFlag(connection: Connection, userId: string) {
   const debugLevelId = await getOrCreateDebugLevelId(connection);
-
   await ensureTraceFlag(connection, userId, debugLevelId);
 }

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -25,7 +25,7 @@ export const executeAnonymousTool = {
 
 export async function executeAnonymous(
   connection: Connection,
-  args: ExecuteAnonymousArgs
+  args: ExecuteAnonymousArgs,
 ) {
   const { apex } = args;
 
@@ -40,23 +40,25 @@ export async function executeAnonymous(
 
   if (!apexResult || !apexResult.compiled) {
     throw new Error(
-      `Apex could not be compiled at line ${apexResult.line}, column ${apexResult.column}: ${apexResult.compileProblem}`
+      `Apex could not be compiled at line ${apexResult.line}, column ${apexResult.column}: ${apexResult.compileProblem}`,
     );
   }
 
   const userId = await getUserIdByUsername(connection, username);
-  const logResult = await connection.query(
-    `SELECT Id FROM ApexLog
-     WHERE LogUserId = '${userId}'
-     ORDER BY StartTime DESC
-     LIMIT 1`
-  );
 
-  if (!logResult || !logResult.records || logResult.records.length <= 0) {
+  // Note: There's no way to get the specific log ID from executeAnonymous.
+  // We retrieve the most recent log for this user, which could be incorrect
+  // if another process creates a log between execution and this query.
+  // Future enhancement: present a list of recent logs for user selection.
+  const logRecord = await connection
+    .sobject("ApexLog")
+    .findOne({ LogUserId: userId }, ["Id"], { sort: { StartTime: -1 } });
+
+  if (!logRecord) {
     throw new Error(`Could not retrieve log from anonymous execution.`);
   }
 
-  const logId = logResult.records[0].Id;
+  const logId = logRecord.Id;
   const logBody = await connection.request(`/sobjects/ApexLog/${logId}/Body/`);
 
   return {

--- a/tests/executeAnonymous.test.ts
+++ b/tests/executeAnonymous.test.ts
@@ -3,10 +3,6 @@
  */
 
 import { jest, describe, it, expect, beforeEach } from "@jest/globals";
-import {
-  executeAnonymous,
-  ExecuteAnonymousArgs,
-} from "../src/tools/executeAnonymous";
 
 jest.mock("../src/salesforce/users", () => ({
   getUserIdByUsername: jest.fn(),
@@ -20,6 +16,15 @@ jest.mock("../src/salesforce/traceFlags", () => ({
   ensureTraceFlag: jest.fn(),
 }));
 
+const mockConnect = jest.fn() as jest.MockedFunction<() => Promise<any>>;
+jest.mock("../src/salesforce/connection", () => ({
+  connect: mockConnect,
+}));
+
+import {
+  executeAnonymous,
+  ExecuteAnonymousArgs,
+} from "../src/tools/executeAnonymous";
 import { getUserIdByUsername } from "../src/salesforce/users";
 import { getOrCreateDebugLevelId } from "../src/salesforce/debugLevels";
 import { ensureTraceFlag } from "../src/salesforce/traceFlags";
@@ -63,6 +68,8 @@ describe("Execute Anonymous", () => {
       },
     };
 
+    mockConnect.mockResolvedValue(mockConnection);
+
     (
       getUserIdByUsername as jest.MockedFunction<typeof getUserIdByUsername>
     ).mockResolvedValue(testUserId);
@@ -90,7 +97,7 @@ describe("Execute Anonymous", () => {
       mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
-      const result = await executeAnonymous(mockConnection, args);
+      const result = await executeAnonymous(args);
 
       expect(getUserIdByUsername).toHaveBeenCalledWith(
         mockConnection,
@@ -126,7 +133,7 @@ describe("Execute Anonymous", () => {
       mockGetUsername.mockReturnValue(null);
       const args: ExecuteAnonymousArgs = { apex: testApexCode };
 
-      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+      await expect(executeAnonymous(args)).rejects.toThrow(
         "Could not determine username from connection",
       );
 
@@ -147,7 +154,7 @@ describe("Execute Anonymous", () => {
         compileProblem: "Unexpected token 'Invalid'",
       });
 
-      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+      await expect(executeAnonymous(args)).rejects.toThrow(
         "Apex could not be compiled at line 1, column 5: Unexpected token 'Invalid'",
       );
 
@@ -160,7 +167,7 @@ describe("Execute Anonymous", () => {
 
       mockExecuteAnonymous.mockResolvedValue(null);
 
-      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+      await expect(executeAnonymous(args)).rejects.toThrow(
         "Cannot read properties of null",
       );
 
@@ -180,7 +187,7 @@ describe("Execute Anonymous", () => {
 
       mockFindOne.mockResolvedValue(null);
 
-      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+      await expect(executeAnonymous(args)).rejects.toThrow(
         "Could not retrieve log from anonymous execution",
       );
 
@@ -200,7 +207,7 @@ describe("Execute Anonymous", () => {
       mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
-      await executeAnonymous(mockConnection, args);
+      await executeAnonymous(args);
 
       expect(mockFindOne).toHaveBeenCalledWith(
         expect.any(Object),
@@ -227,7 +234,7 @@ describe("Execute Anonymous", () => {
       mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
-      const result = await executeAnonymous(mockConnection, args);
+      const result = await executeAnonymous(args);
 
       expect(mockExecuteAnonymous).toHaveBeenCalledWith(multiLineApex);
       expect(result.content[0].text).toBe(testLogBody);
@@ -241,9 +248,7 @@ describe("Execute Anonymous", () => {
         getUserIdByUsername as jest.MockedFunction<typeof getUserIdByUsername>;
       mockGetUserIdByUsername.mockRejectedValue(userError);
 
-      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
-        "User not found",
-      );
+      await expect(executeAnonymous(args)).rejects.toThrow("User not found");
 
       expect(getOrCreateDebugLevelId).not.toHaveBeenCalled();
       expect(ensureTraceFlag).not.toHaveBeenCalled();
@@ -260,7 +265,7 @@ describe("Execute Anonymous", () => {
         >;
       mockGetOrCreateDebugLevelId.mockRejectedValue(debugLevelError);
 
-      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+      await expect(executeAnonymous(args)).rejects.toThrow(
         "Failed to create debug level",
       );
 
@@ -277,7 +282,7 @@ describe("Execute Anonymous", () => {
       >;
       mockEnsureTraceFlag.mockRejectedValue(traceFlagError);
 
-      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+      await expect(executeAnonymous(args)).rejects.toThrow(
         "Failed to create trace flag",
       );
 
@@ -290,9 +295,7 @@ describe("Execute Anonymous", () => {
 
       mockExecuteAnonymous.mockRejectedValue(executeError);
 
-      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
-        "Tooling API error",
-      );
+      await expect(executeAnonymous(args)).rejects.toThrow("Tooling API error");
 
       expect(mockSobject).not.toHaveBeenCalled();
       expect(mockRequest).not.toHaveBeenCalled();
@@ -311,9 +314,7 @@ describe("Execute Anonymous", () => {
 
       mockFindOne.mockRejectedValue(queryError);
 
-      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
-        "Query failed",
-      );
+      await expect(executeAnonymous(args)).rejects.toThrow("Query failed");
 
       expect(mockRequest).not.toHaveBeenCalled();
     });
@@ -332,7 +333,7 @@ describe("Execute Anonymous", () => {
       mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockRejectedValue(requestError);
 
-      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+      await expect(executeAnonymous(args)).rejects.toThrow(
         "Failed to fetch log body",
       );
     });
@@ -356,7 +357,7 @@ describe("Execute Anonymous", () => {
       mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
-      await executeAnonymous(mockConnection, args);
+      await executeAnonymous(args);
 
       expect(mockFindOne).toHaveBeenCalledWith(
         { LogUserId: customUserId },
@@ -380,7 +381,7 @@ describe("Execute Anonymous", () => {
       mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
-      const result = await executeAnonymous(mockConnection, args);
+      const result = await executeAnonymous(args);
 
       expect(mockExecuteAnonymous).toHaveBeenCalledWith(soqlApex);
       expect(result.content[0].text).toBe(testLogBody);
@@ -400,10 +401,28 @@ describe("Execute Anonymous", () => {
       mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
-      const result = await executeAnonymous(mockConnection, args);
+      const result = await executeAnonymous(args);
 
       expect(mockExecuteAnonymous).toHaveBeenCalledWith(dmlApex);
       expect(result.content[0].text).toBe(testLogBody);
+    });
+
+    it("should throw error when connect() fails (no default org)", async () => {
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+      const connectError = new Error(
+        "No default org configured. Please set a default org using 'sf config set target-org <username>'.",
+      );
+
+      mockConnect.mockRejectedValue(connectError);
+
+      await expect(executeAnonymous(args)).rejects.toThrow(
+        "No default org configured",
+      );
+
+      expect(getUserIdByUsername).not.toHaveBeenCalled();
+      expect(getOrCreateDebugLevelId).not.toHaveBeenCalled();
+      expect(ensureTraceFlag).not.toHaveBeenCalled();
+      expect(mockExecuteAnonymous).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/executeAnonymous.test.ts
+++ b/tests/executeAnonymous.test.ts
@@ -2,13 +2,7 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import {
-  jest,
-  describe,
-  it,
-  expect,
-  beforeEach,
-} from "@jest/globals";
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
 import {
   executeAnonymous,
   ExecuteAnonymousArgs,
@@ -40,17 +34,20 @@ describe("Execute Anonymous", () => {
   let mockConnection: any;
   let mockTooling: any;
   let mockExecuteAnonymous: any;
-  let mockQuery: any;
   let mockRequest: any;
   let mockGetUsername: any;
+  let mockSobject: any;
+  let mockFindOne: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
 
     mockExecuteAnonymous = jest.fn();
-    mockQuery = jest.fn();
     mockRequest = jest.fn();
     mockGetUsername = jest.fn().mockReturnValue("test@example.com");
+
+    mockFindOne = jest.fn();
+    mockSobject = jest.fn().mockReturnValue({ findOne: mockFindOne });
 
     mockTooling = {
       executeAnonymous: mockExecuteAnonymous,
@@ -58,7 +55,7 @@ describe("Execute Anonymous", () => {
 
     mockConnection = {
       tooling: mockTooling,
-      query: mockQuery,
+      sobject: mockSobject,
       request: mockRequest,
       getUsername: mockGetUsername,
       userInfo: {
@@ -90,33 +87,30 @@ describe("Execute Anonymous", () => {
         column: -1,
       });
 
-      mockQuery.mockResolvedValue({
-        records: [{ Id: testLogId }],
-      });
-
+      mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
       const result = await executeAnonymous(mockConnection, args);
 
       expect(getUserIdByUsername).toHaveBeenCalledWith(
         mockConnection,
-        "test@example.com"
+        "test@example.com",
       );
       expect(getOrCreateDebugLevelId).toHaveBeenCalledWith(mockConnection);
       expect(ensureTraceFlag).toHaveBeenCalledWith(
         mockConnection,
         testUserId,
-        testDebugLevelId
+        testDebugLevelId,
       );
       expect(mockExecuteAnonymous).toHaveBeenCalledWith(testApexCode);
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining("SELECT Id FROM ApexLog")
-      );
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining(`WHERE LogUserId = '${testUserId}'`)
+      expect(mockSobject).toHaveBeenCalledWith("ApexLog");
+      expect(mockFindOne).toHaveBeenCalledWith(
+        { LogUserId: testUserId },
+        ["Id"],
+        { sort: { StartTime: -1 } },
       );
       expect(mockRequest).toHaveBeenCalledWith(
-        `/sobjects/ApexLog/${testLogId}/Body/`
+        `/sobjects/ApexLog/${testLogId}/Body/`,
       );
       expect(result).toEqual({
         content: [
@@ -133,7 +127,7 @@ describe("Execute Anonymous", () => {
       const args: ExecuteAnonymousArgs = { apex: testApexCode };
 
       await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
-        "Could not determine username from connection"
+        "Could not determine username from connection",
       );
 
       expect(getUserIdByUsername).not.toHaveBeenCalled();
@@ -154,10 +148,10 @@ describe("Execute Anonymous", () => {
       });
 
       await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
-        "Apex could not be compiled at line 1, column 5: Unexpected token 'Invalid'"
+        "Apex could not be compiled at line 1, column 5: Unexpected token 'Invalid'",
       );
 
-      expect(mockQuery).not.toHaveBeenCalled();
+      expect(mockSobject).not.toHaveBeenCalled();
       expect(mockRequest).not.toHaveBeenCalled();
     });
 
@@ -167,10 +161,10 @@ describe("Execute Anonymous", () => {
       mockExecuteAnonymous.mockResolvedValue(null);
 
       await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
-        "Cannot read properties of null"
+        "Cannot read properties of null",
       );
 
-      expect(mockQuery).not.toHaveBeenCalled();
+      expect(mockSobject).not.toHaveBeenCalled();
       expect(mockRequest).not.toHaveBeenCalled();
     });
 
@@ -184,31 +178,10 @@ describe("Execute Anonymous", () => {
         column: -1,
       });
 
-      mockQuery.mockResolvedValue({
-        records: [],
-      });
+      mockFindOne.mockResolvedValue(null);
 
       await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
-        "Could not retrieve log from anonymous execution"
-      );
-
-      expect(mockRequest).not.toHaveBeenCalled();
-    });
-
-    it("should throw error when logResult is null", async () => {
-      const args: ExecuteAnonymousArgs = { apex: testApexCode };
-
-      mockExecuteAnonymous.mockResolvedValue({
-        compiled: true,
-        success: true,
-        line: -1,
-        column: -1,
-      });
-
-      mockQuery.mockResolvedValue(null);
-
-      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
-        "Could not retrieve log from anonymous execution"
+        "Could not retrieve log from anonymous execution",
       );
 
       expect(mockRequest).not.toHaveBeenCalled();
@@ -224,17 +197,16 @@ describe("Execute Anonymous", () => {
         column: -1,
       });
 
-      mockQuery.mockResolvedValue({
-        records: [{ Id: testLogId }],
-      });
-
+      mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
       await executeAnonymous(mockConnection, args);
 
-      const queryCall = mockQuery.mock.calls[0][0];
-      expect(queryCall).toContain("ORDER BY StartTime DESC");
-      expect(queryCall).toContain("LIMIT 1");
+      expect(mockFindOne).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Array),
+        { sort: { StartTime: -1 } },
+      );
     });
 
     it("should handle multi-line Apex code", async () => {
@@ -252,10 +224,7 @@ describe("Execute Anonymous", () => {
         column: -1,
       });
 
-      mockQuery.mockResolvedValue({
-        records: [{ Id: testLogId }],
-      });
-
+      mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
       const result = await executeAnonymous(mockConnection, args);
@@ -273,7 +242,7 @@ describe("Execute Anonymous", () => {
       mockGetUserIdByUsername.mockRejectedValue(userError);
 
       await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
-        "User not found"
+        "User not found",
       );
 
       expect(getOrCreateDebugLevelId).not.toHaveBeenCalled();
@@ -292,7 +261,7 @@ describe("Execute Anonymous", () => {
       mockGetOrCreateDebugLevelId.mockRejectedValue(debugLevelError);
 
       await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
-        "Failed to create debug level"
+        "Failed to create debug level",
       );
 
       expect(ensureTraceFlag).not.toHaveBeenCalled();
@@ -309,7 +278,7 @@ describe("Execute Anonymous", () => {
       mockEnsureTraceFlag.mockRejectedValue(traceFlagError);
 
       await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
-        "Failed to create trace flag"
+        "Failed to create trace flag",
       );
 
       expect(mockExecuteAnonymous).not.toHaveBeenCalled();
@@ -322,14 +291,14 @@ describe("Execute Anonymous", () => {
       mockExecuteAnonymous.mockRejectedValue(executeError);
 
       await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
-        "Tooling API error"
+        "Tooling API error",
       );
 
-      expect(mockQuery).not.toHaveBeenCalled();
+      expect(mockSobject).not.toHaveBeenCalled();
       expect(mockRequest).not.toHaveBeenCalled();
     });
 
-    it("should handle errors from query", async () => {
+    it("should handle errors from findOne query", async () => {
       const args: ExecuteAnonymousArgs = { apex: testApexCode };
       const queryError = new Error("Query failed");
 
@@ -340,10 +309,10 @@ describe("Execute Anonymous", () => {
         column: -1,
       });
 
-      mockQuery.mockRejectedValue(queryError);
+      mockFindOne.mockRejectedValue(queryError);
 
       await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
-        "Query failed"
+        "Query failed",
       );
 
       expect(mockRequest).not.toHaveBeenCalled();
@@ -360,14 +329,11 @@ describe("Execute Anonymous", () => {
         column: -1,
       });
 
-      mockQuery.mockResolvedValue({
-        records: [{ Id: testLogId }],
-      });
-
+      mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockRejectedValue(requestError);
 
       await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
-        "Failed to fetch log body"
+        "Failed to fetch log body",
       );
     });
 
@@ -387,16 +353,15 @@ describe("Execute Anonymous", () => {
         column: -1,
       });
 
-      mockQuery.mockResolvedValue({
-        records: [{ Id: testLogId }],
-      });
-
+      mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
       await executeAnonymous(mockConnection, args);
 
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining(`WHERE LogUserId = '${customUserId}'`)
+      expect(mockFindOne).toHaveBeenCalledWith(
+        { LogUserId: customUserId },
+        ["Id"],
+        expect.any(Object),
       );
     });
 
@@ -412,10 +377,7 @@ describe("Execute Anonymous", () => {
         column: -1,
       });
 
-      mockQuery.mockResolvedValue({
-        records: [{ Id: testLogId }],
-      });
-
+      mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
       const result = await executeAnonymous(mockConnection, args);
@@ -435,10 +397,7 @@ describe("Execute Anonymous", () => {
         column: -1,
       });
 
-      mockQuery.mockResolvedValue({
-        records: [{ Id: testLogId }],
-      });
-
+      mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
       const result = await executeAnonymous(mockConnection, args);
@@ -450,18 +409,17 @@ describe("Execute Anonymous", () => {
 
   describe("executeAnonymousTool", () => {
     it("should have correct tool definition", async () => {
-      const { executeAnonymousTool } = await import(
-        "../src/tools/executeAnonymous"
-      );
+      const { executeAnonymousTool } =
+        await import("../src/tools/executeAnonymous");
 
       expect(executeAnonymousTool.name).toBe("execute_anonymous");
       expect(executeAnonymousTool.description).toContain(
-        "Execute a snippet of anonymous Apex"
+        "Execute a snippet of anonymous Apex",
       );
       expect(executeAnonymousTool.inputSchema.type).toBe("object");
       expect(executeAnonymousTool.inputSchema.properties.apex).toBeDefined();
       expect(executeAnonymousTool.inputSchema.properties.apex.type).toBe(
-        "string"
+        "string",
       );
       expect(executeAnonymousTool.inputSchema.required).toContain("apex");
     });

--- a/tests/executeAnonymous.test.ts
+++ b/tests/executeAnonymous.test.ts
@@ -8,7 +8,6 @@ import {
   it,
   expect,
   beforeEach,
-  afterEach,
 } from "@jest/globals";
 import {
   executeAnonymous,
@@ -43,17 +42,15 @@ describe("Execute Anonymous", () => {
   let mockExecuteAnonymous: any;
   let mockQuery: any;
   let mockRequest: any;
-  let originalEnv: NodeJS.ProcessEnv;
+  let mockGetUsername: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    originalEnv = { ...process.env };
-    process.env.ORG_USERNAME = "test@example.com";
-
     mockExecuteAnonymous = jest.fn();
     mockQuery = jest.fn();
     mockRequest = jest.fn();
+    mockGetUsername = jest.fn().mockReturnValue("test@example.com");
 
     mockTooling = {
       executeAnonymous: mockExecuteAnonymous,
@@ -63,6 +60,7 @@ describe("Execute Anonymous", () => {
       tooling: mockTooling,
       query: mockQuery,
       request: mockRequest,
+      getUsername: mockGetUsername,
       userInfo: {
         id: testUserId,
       },
@@ -79,10 +77,6 @@ describe("Execute Anonymous", () => {
     (
       ensureTraceFlag as jest.MockedFunction<typeof ensureTraceFlag>
     ).mockResolvedValue();
-  });
-
-  afterEach(() => {
-    process.env = originalEnv;
   });
 
   describe("executeAnonymous", () => {
@@ -134,12 +128,12 @@ describe("Execute Anonymous", () => {
       });
     });
 
-    it("should throw error when ORG_USERNAME is not set", async () => {
-      delete process.env.ORG_USERNAME;
+    it("should throw error when connection username cannot be determined", async () => {
+      mockGetUsername.mockReturnValue(null);
       const args: ExecuteAnonymousArgs = { apex: testApexCode };
 
       await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
-        "Please set a valid ORG_USERNAME environment variable in your .env file"
+        "Could not determine username from connection"
       );
 
       expect(getUserIdByUsername).not.toHaveBeenCalled();

--- a/tests/executeAnonymous.test.ts
+++ b/tests/executeAnonymous.test.ts
@@ -1,0 +1,475 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import {
+  executeAnonymous,
+  ExecuteAnonymousArgs,
+} from "../src/tools/executeAnonymous";
+
+jest.mock("../src/salesforce/users", () => ({
+  getUserIdByUsername: jest.fn(),
+}));
+
+jest.mock("../src/salesforce/debugLevels", () => ({
+  getOrCreateDebugLevelId: jest.fn(),
+}));
+
+jest.mock("../src/salesforce/traceFlags", () => ({
+  ensureTraceFlag: jest.fn(),
+}));
+
+import { getUserIdByUsername } from "../src/salesforce/users";
+import { getOrCreateDebugLevelId } from "../src/salesforce/debugLevels";
+import { ensureTraceFlag } from "../src/salesforce/traceFlags";
+
+describe("Execute Anonymous", () => {
+  const testUserId = "005000000000001";
+  const testDebugLevelId = "07L000000000001";
+  const testLogId = "07L000000000002";
+  const testLogBody = "APEX DEBUG LOG CONTENT HERE";
+  const testApexCode = "System.debug('Hello World');";
+
+  let mockConnection: any;
+  let mockTooling: any;
+  let mockExecuteAnonymous: any;
+  let mockQuery: any;
+  let mockRequest: any;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    originalEnv = { ...process.env };
+    process.env.ORG_USERNAME = "test@example.com";
+
+    mockExecuteAnonymous = jest.fn();
+    mockQuery = jest.fn();
+    mockRequest = jest.fn();
+
+    mockTooling = {
+      executeAnonymous: mockExecuteAnonymous,
+    };
+
+    mockConnection = {
+      tooling: mockTooling,
+      query: mockQuery,
+      request: mockRequest,
+      userInfo: {
+        id: testUserId,
+      },
+    };
+
+    (
+      getUserIdByUsername as jest.MockedFunction<typeof getUserIdByUsername>
+    ).mockResolvedValue(testUserId);
+    (
+      getOrCreateDebugLevelId as jest.MockedFunction<
+        typeof getOrCreateDebugLevelId
+      >
+    ).mockResolvedValue(testDebugLevelId);
+    (
+      ensureTraceFlag as jest.MockedFunction<typeof ensureTraceFlag>
+    ).mockResolvedValue();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("executeAnonymous", () => {
+    it("should successfully execute Apex and return log", async () => {
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+
+      mockExecuteAnonymous.mockResolvedValue({
+        compiled: true,
+        success: true,
+        line: -1,
+        column: -1,
+      });
+
+      mockQuery.mockResolvedValue({
+        records: [{ Id: testLogId }],
+      });
+
+      mockRequest.mockResolvedValue(testLogBody);
+
+      const result = await executeAnonymous(mockConnection, args);
+
+      expect(getUserIdByUsername).toHaveBeenCalledWith(
+        mockConnection,
+        "test@example.com"
+      );
+      expect(getOrCreateDebugLevelId).toHaveBeenCalledWith(mockConnection);
+      expect(ensureTraceFlag).toHaveBeenCalledWith(
+        mockConnection,
+        testUserId,
+        testDebugLevelId
+      );
+      expect(mockExecuteAnonymous).toHaveBeenCalledWith(testApexCode);
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("SELECT Id FROM ApexLog")
+      );
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining(`WHERE LogUserId = '${testUserId}'`)
+      );
+      expect(mockRequest).toHaveBeenCalledWith(
+        `/sobjects/ApexLog/${testLogId}/Body/`
+      );
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: testLogBody,
+          },
+        ],
+      });
+    });
+
+    it("should throw error when ORG_USERNAME is not set", async () => {
+      delete process.env.ORG_USERNAME;
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+
+      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+        "Please set a valid ORG_USERNAME environment variable in your .env file"
+      );
+
+      expect(getUserIdByUsername).not.toHaveBeenCalled();
+      expect(getOrCreateDebugLevelId).not.toHaveBeenCalled();
+      expect(ensureTraceFlag).not.toHaveBeenCalled();
+      expect(mockExecuteAnonymous).not.toHaveBeenCalled();
+    });
+
+    it("should throw error when Apex compilation fails", async () => {
+      const args: ExecuteAnonymousArgs = { apex: "Invalid Apex;" };
+
+      mockExecuteAnonymous.mockResolvedValue({
+        compiled: false,
+        success: false,
+        line: 1,
+        column: 5,
+        compileProblem: "Unexpected token 'Invalid'",
+      });
+
+      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+        "Apex could not be compiled at line 1, column 5: Unexpected token 'Invalid'"
+      );
+
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(mockRequest).not.toHaveBeenCalled();
+    });
+
+    it("should throw error when apexResult is null", async () => {
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+
+      mockExecuteAnonymous.mockResolvedValue(null);
+
+      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+        "Cannot read properties of null"
+      );
+
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(mockRequest).not.toHaveBeenCalled();
+    });
+
+    it("should throw error when no log is found", async () => {
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+
+      mockExecuteAnonymous.mockResolvedValue({
+        compiled: true,
+        success: true,
+        line: -1,
+        column: -1,
+      });
+
+      mockQuery.mockResolvedValue({
+        records: [],
+      });
+
+      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+        "Could not retrieve log from anonymous execution"
+      );
+
+      expect(mockRequest).not.toHaveBeenCalled();
+    });
+
+    it("should throw error when logResult is null", async () => {
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+
+      mockExecuteAnonymous.mockResolvedValue({
+        compiled: true,
+        success: true,
+        line: -1,
+        column: -1,
+      });
+
+      mockQuery.mockResolvedValue(null);
+
+      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+        "Could not retrieve log from anonymous execution"
+      );
+
+      expect(mockRequest).not.toHaveBeenCalled();
+    });
+
+    it("should query for most recent log by StartTime", async () => {
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+
+      mockExecuteAnonymous.mockResolvedValue({
+        compiled: true,
+        success: true,
+        line: -1,
+        column: -1,
+      });
+
+      mockQuery.mockResolvedValue({
+        records: [{ Id: testLogId }],
+      });
+
+      mockRequest.mockResolvedValue(testLogBody);
+
+      await executeAnonymous(mockConnection, args);
+
+      const queryCall = mockQuery.mock.calls[0][0];
+      expect(queryCall).toContain("ORDER BY StartTime DESC");
+      expect(queryCall).toContain("LIMIT 1");
+    });
+
+    it("should handle multi-line Apex code", async () => {
+      const multiLineApex = `
+        Integer x = 10;
+        Integer y = 20;
+        System.debug('Sum: ' + (x + y));
+      `;
+      const args: ExecuteAnonymousArgs = { apex: multiLineApex };
+
+      mockExecuteAnonymous.mockResolvedValue({
+        compiled: true,
+        success: true,
+        line: -1,
+        column: -1,
+      });
+
+      mockQuery.mockResolvedValue({
+        records: [{ Id: testLogId }],
+      });
+
+      mockRequest.mockResolvedValue(testLogBody);
+
+      const result = await executeAnonymous(mockConnection, args);
+
+      expect(mockExecuteAnonymous).toHaveBeenCalledWith(multiLineApex);
+      expect(result.content[0].text).toBe(testLogBody);
+    });
+
+    it("should propagate errors from getUserIdByUsername", async () => {
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+      const userError = new Error("User not found");
+
+      const mockGetUserIdByUsername =
+        getUserIdByUsername as jest.MockedFunction<typeof getUserIdByUsername>;
+      mockGetUserIdByUsername.mockRejectedValue(userError);
+
+      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+        "User not found"
+      );
+
+      expect(getOrCreateDebugLevelId).not.toHaveBeenCalled();
+      expect(ensureTraceFlag).not.toHaveBeenCalled();
+      expect(mockExecuteAnonymous).not.toHaveBeenCalled();
+    });
+
+    it("should propagate errors from getOrCreateDebugLevelId", async () => {
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+      const debugLevelError = new Error("Failed to create debug level");
+
+      const mockGetOrCreateDebugLevelId =
+        getOrCreateDebugLevelId as jest.MockedFunction<
+          typeof getOrCreateDebugLevelId
+        >;
+      mockGetOrCreateDebugLevelId.mockRejectedValue(debugLevelError);
+
+      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+        "Failed to create debug level"
+      );
+
+      expect(ensureTraceFlag).not.toHaveBeenCalled();
+      expect(mockExecuteAnonymous).not.toHaveBeenCalled();
+    });
+
+    it("should propagate errors from ensureTraceFlag", async () => {
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+      const traceFlagError = new Error("Failed to create trace flag");
+
+      const mockEnsureTraceFlag = ensureTraceFlag as jest.MockedFunction<
+        typeof ensureTraceFlag
+      >;
+      mockEnsureTraceFlag.mockRejectedValue(traceFlagError);
+
+      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+        "Failed to create trace flag"
+      );
+
+      expect(mockExecuteAnonymous).not.toHaveBeenCalled();
+    });
+
+    it("should handle errors from tooling.executeAnonymous", async () => {
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+      const executeError = new Error("Tooling API error");
+
+      mockExecuteAnonymous.mockRejectedValue(executeError);
+
+      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+        "Tooling API error"
+      );
+
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(mockRequest).not.toHaveBeenCalled();
+    });
+
+    it("should handle errors from query", async () => {
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+      const queryError = new Error("Query failed");
+
+      mockExecuteAnonymous.mockResolvedValue({
+        compiled: true,
+        success: true,
+        line: -1,
+        column: -1,
+      });
+
+      mockQuery.mockRejectedValue(queryError);
+
+      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+        "Query failed"
+      );
+
+      expect(mockRequest).not.toHaveBeenCalled();
+    });
+
+    it("should handle errors from request", async () => {
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+      const requestError = new Error("Failed to fetch log body");
+
+      mockExecuteAnonymous.mockResolvedValue({
+        compiled: true,
+        success: true,
+        line: -1,
+        column: -1,
+      });
+
+      mockQuery.mockResolvedValue({
+        records: [{ Id: testLogId }],
+      });
+
+      mockRequest.mockRejectedValue(requestError);
+
+      await expect(executeAnonymous(mockConnection, args)).rejects.toThrow(
+        "Failed to fetch log body"
+      );
+    });
+
+    it("should use getUserIdByUsername for log query", async () => {
+      const customUserId = "005CUSTOMUSERID";
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+
+      // Mock getUserIdByUsername to return custom user ID
+      (
+        getUserIdByUsername as jest.MockedFunction<typeof getUserIdByUsername>
+      ).mockResolvedValue(customUserId);
+
+      mockExecuteAnonymous.mockResolvedValue({
+        compiled: true,
+        success: true,
+        line: -1,
+        column: -1,
+      });
+
+      mockQuery.mockResolvedValue({
+        records: [{ Id: testLogId }],
+      });
+
+      mockRequest.mockResolvedValue(testLogBody);
+
+      await executeAnonymous(mockConnection, args);
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining(`WHERE LogUserId = '${customUserId}'`)
+      );
+    });
+
+    it("should handle SOQL queries in Apex", async () => {
+      const soqlApex =
+        "List<Account> accounts = [SELECT Id FROM Account LIMIT 10];";
+      const args: ExecuteAnonymousArgs = { apex: soqlApex };
+
+      mockExecuteAnonymous.mockResolvedValue({
+        compiled: true,
+        success: true,
+        line: -1,
+        column: -1,
+      });
+
+      mockQuery.mockResolvedValue({
+        records: [{ Id: testLogId }],
+      });
+
+      mockRequest.mockResolvedValue(testLogBody);
+
+      const result = await executeAnonymous(mockConnection, args);
+
+      expect(mockExecuteAnonymous).toHaveBeenCalledWith(soqlApex);
+      expect(result.content[0].text).toBe(testLogBody);
+    });
+
+    it("should handle DML operations in Apex", async () => {
+      const dmlApex = "Account acc = new Account(Name='Test'); insert acc;";
+      const args: ExecuteAnonymousArgs = { apex: dmlApex };
+
+      mockExecuteAnonymous.mockResolvedValue({
+        compiled: true,
+        success: true,
+        line: -1,
+        column: -1,
+      });
+
+      mockQuery.mockResolvedValue({
+        records: [{ Id: testLogId }],
+      });
+
+      mockRequest.mockResolvedValue(testLogBody);
+
+      const result = await executeAnonymous(mockConnection, args);
+
+      expect(mockExecuteAnonymous).toHaveBeenCalledWith(dmlApex);
+      expect(result.content[0].text).toBe(testLogBody);
+    });
+  });
+
+  describe("executeAnonymousTool", () => {
+    it("should have correct tool definition", async () => {
+      const { executeAnonymousTool } = await import(
+        "../src/tools/executeAnonymous"
+      );
+
+      expect(executeAnonymousTool.name).toBe("execute_anonymous");
+      expect(executeAnonymousTool.description).toContain(
+        "Execute a snippet of anonymous Apex"
+      );
+      expect(executeAnonymousTool.inputSchema.type).toBe("object");
+      expect(executeAnonymousTool.inputSchema.properties.apex).toBeDefined();
+      expect(executeAnonymousTool.inputSchema.properties.apex.type).toBe(
+        "string"
+      );
+      expect(executeAnonymousTool.inputSchema.required).toContain("apex");
+    });
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -20,6 +20,22 @@ import {
 // Mock the MCP SDK components
 jest.mock("@modelcontextprotocol/sdk/server/index.js");
 jest.mock("@modelcontextprotocol/sdk/server/stdio.js");
+
+const mockConnection = {
+  query: jest.fn(),
+  tooling: {
+    query: jest.fn(),
+    executeAnonymous: jest.fn(),
+  },
+} as any;
+
+const mockConnect = jest.fn() as jest.MockedFunction<any>;
+mockConnect.mockResolvedValue(mockConnection);
+
+jest.mock("../src/salesforce/connection", () => ({
+  connect: mockConnect,
+}));
+
 import { LanaServer } from "../src/index";
 
 // Mock the tool modules
@@ -86,6 +102,24 @@ jest.mock("../src/tools/findPerformanceBottlenecks", () => ({
   },
 }));
 
+jest.mock("../src/tools/executeAnonymous", () => ({
+  executeAnonymous: jest.fn(),
+  executeAnonymousTool: {
+    name: "execute_anonymous",
+    description: "Execute a snippet of anonymous Apex and retrieve the resulting log",
+    inputSchema: {
+      type: "object",
+      properties: {
+        apex: {
+          type: "string",
+          description: "The anonymous Apex to be executed",
+        },
+      },
+      required: ["apex"],
+    },
+  },
+}));
+
 // Import the tools after mocking
 import {
   analyzeLogPerformance,
@@ -96,6 +130,10 @@ import {
   findPerformanceBottlenecks,
   findPerformanceBottlenecksTool,
 } from "../src/tools/findPerformanceBottlenecks";
+import {
+  executeAnonymous,
+  executeAnonymousTool,
+} from "../src/tools/executeAnonymous";
 
 // Mock process methods
 const mockExit = jest.spyOn(process, "exit").mockImplementation((() => {
@@ -159,8 +197,20 @@ describe("LanaServer", () => {
     ],
   };
 
+  const mockExecuteAnonymousResult = {
+    content: [
+      {
+        type: "text",
+        text: "APEX DEBUG LOG CONTENT",
+      },
+    ],
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
+
+    // Set required environment variable for connection
+    process.env.ORG_USERNAME = "test@example.com";
 
     // Setup server mock
     mockSetRequestHandler = jest.fn();
@@ -196,6 +246,9 @@ describe("LanaServer", () => {
         typeof findPerformanceBottlenecks
       >
     ).mockResolvedValue(mockBottleneckResult);
+    (
+      executeAnonymous as jest.MockedFunction<typeof executeAnonymous>
+    ).mockResolvedValue(mockExecuteAnonymousResult);
 
     // Clear the module cache and re-import
     jest.resetModules();
@@ -284,6 +337,7 @@ describe("LanaServer", () => {
           analyzeLogPerformanceTool,
           getLogSummaryTool,
           findPerformanceBottlenecksTool,
+          executeAnonymousTool,
         ],
       });
     });
@@ -504,7 +558,7 @@ describe("LanaServer", () => {
 
       // Test tool listing
       const toolsResult = await listToolsHandler({} as any, {} as any);
-      expect(toolsResult.tools).toHaveLength(3);
+      expect(toolsResult.tools).toHaveLength(4);
       expect(toolsResult.tools[0].name).toBe("analyze_apex_log_performance");
 
       // Test tool execution

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -21,22 +21,6 @@ import {
 jest.mock("@modelcontextprotocol/sdk/server/index.js");
 jest.mock("@modelcontextprotocol/sdk/server/stdio.js");
 
-// Mock the connection
-const mockConnection = {
-  query: jest.fn(),
-  tooling: {
-    query: jest.fn(),
-    executeAnonymous: jest.fn(),
-  },
-} as any;
-
-const mockConnect = jest.fn() as jest.MockedFunction<any>;
-mockConnect.mockResolvedValue(mockConnection);
-
-jest.mock("../src/salesforce/connection", () => ({
-  connect: mockConnect,
-}));
-
 import { LanaServer } from "../src/index";
 
 // Mock the tool modules
@@ -107,7 +91,8 @@ jest.mock("../src/tools/executeAnonymous", () => ({
   executeAnonymous: jest.fn(),
   executeAnonymousTool: {
     name: "execute_anonymous",
-    description: "Execute a snippet of anonymous Apex and retrieve the resulting log",
+    description:
+      "Execute a snippet of anonymous Apex and retrieve the resulting log",
     inputSchema: {
       type: "object",
       properties: {
@@ -226,7 +211,7 @@ describe("LanaServer", () => {
     mockTransport = {} as jest.Mocked<StdioServerTransport>;
 
     (Server as jest.MockedClass<typeof Server>).mockImplementation(
-      () => mockServer
+      () => mockServer,
     );
     (
       StdioServerTransport as jest.MockedClass<typeof StdioServerTransport>
@@ -269,7 +254,7 @@ describe("LanaServer", () => {
           capabilities: {
             tools: {},
           },
-        }
+        },
       );
     });
 
@@ -294,7 +279,7 @@ describe("LanaServer", () => {
 
       expect(mockProcessOn).toHaveBeenCalledWith(
         "SIGINT",
-        expect.any(Function)
+        expect.any(Function),
       );
     });
   });
@@ -305,7 +290,7 @@ describe("LanaServer", () => {
 
       expect(mockSetRequestHandler).toHaveBeenCalledWith(
         ListToolsRequestSchema,
-        expect.any(Function)
+        expect.any(Function),
       );
     });
 
@@ -314,7 +299,7 @@ describe("LanaServer", () => {
 
       expect(mockSetRequestHandler).toHaveBeenCalledWith(
         CallToolRequestSchema,
-        expect.any(Function)
+        expect.any(Function),
       );
     });
 
@@ -323,7 +308,7 @@ describe("LanaServer", () => {
 
       // Get the ListToolsRequest handler
       const listToolsCall = mockSetRequestHandler.mock.calls.find(
-        (call: any) => call[0] === ListToolsRequestSchema
+        (call: any) => call[0] === ListToolsRequestSchema,
       );
       expect(listToolsCall).toBeDefined();
 
@@ -349,7 +334,7 @@ describe("LanaServer", () => {
 
       // Get the CallToolRequest handler
       const callToolCall = mockSetRequestHandler.mock.calls.find(
-        (call: any) => call[0] === CallToolRequestSchema
+        (call: any) => call[0] === CallToolRequestSchema,
       );
       expect(callToolCall).toBeDefined();
       callToolHandler = callToolCall![1];
@@ -502,7 +487,7 @@ describe("LanaServer", () => {
       expect(StdioServerTransport).toHaveBeenCalled();
       expect(mockConnect).toHaveBeenCalledWith(mockTransport);
       expect(mockConsoleError).toHaveBeenCalledWith(
-        "LANA MCP Server running on stdio"
+        "LANA MCP Server running on stdio",
       );
     });
 
@@ -520,7 +505,7 @@ describe("LanaServer", () => {
       // Find the SIGINT handler
       const processOnCalls = jest.spyOn(process, "on").mock.calls;
       const sigintCall = processOnCalls.find(
-        (call: any) => call[0] === "SIGINT"
+        (call: any) => call[0] === "SIGINT",
       );
       expect(sigintCall).toBeDefined();
 
@@ -545,10 +530,10 @@ describe("LanaServer", () => {
 
       // Get handlers
       const listToolsCall = mockSetRequestHandler.mock.calls.find(
-        (call: any) => call[0] === ListToolsRequestSchema
+        (call: any) => call[0] === ListToolsRequestSchema,
       );
       const callToolCall = mockSetRequestHandler.mock.calls.find(
-        (call: any) => call[0] === CallToolRequestSchema
+        (call: any) => call[0] === CallToolRequestSchema,
       );
 
       const listToolsHandler = listToolsCall![1];
@@ -584,7 +569,7 @@ describe("LanaServer", () => {
       new LanaServer();
 
       const callToolCall = mockSetRequestHandler.mock.calls.find(
-        (call: any) => call[0] === CallToolRequestSchema
+        (call: any) => call[0] === CallToolRequestSchema,
       );
       const callToolHandler = callToolCall![1];
 
@@ -613,7 +598,7 @@ describe("LanaServer", () => {
       new LanaServer();
 
       const callToolCall = mockSetRequestHandler.mock.calls.find(
-        (call: any) => call[0] === CallToolRequestSchema
+        (call: any) => call[0] === CallToolRequestSchema,
       );
       const callToolHandler = callToolCall![1];
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -21,6 +21,7 @@ import {
 jest.mock("@modelcontextprotocol/sdk/server/index.js");
 jest.mock("@modelcontextprotocol/sdk/server/stdio.js");
 
+// Mock the connection
 const mockConnection = {
   query: jest.fn(),
   tooling: {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -210,9 +210,6 @@ describe("LanaServer", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    // Set required environment variable for connection
-    process.env.ORG_USERNAME = "test@example.com";
-
     // Setup server mock
     mockSetRequestHandler = jest.fn();
     mockConnect = jest.fn();

--- a/tests/salesforce/connection.test.ts
+++ b/tests/salesforce/connection.test.ts
@@ -8,7 +8,6 @@ import {
   it,
   expect,
   beforeEach,
-  afterEach,
 } from "@jest/globals";
 
 const mockConnectionInstance = {
@@ -25,6 +24,12 @@ const mockAuthInfo = {
 
 const mockConnectionCreate = jest.fn() as jest.MockedFunction<any>;
 
+const mockConfigAggregator = {
+  getPropertyValue: jest.fn(),
+} as any;
+
+const mockConfigAggregatorCreate = jest.fn() as jest.MockedFunction<any>;
+
 jest.mock("@salesforce/core", () => ({
   Connection: {
     create: mockConnectionCreate,
@@ -32,42 +37,32 @@ jest.mock("@salesforce/core", () => ({
   AuthInfo: {
     create: mockAuthInfo.create,
   },
+  ConfigAggregator: {
+    create: mockConfigAggregatorCreate,
+  },
 }));
-
-jest.mock("dotenv", () => {
-  const mockConfig = jest.fn();
-  return {
-    default: mockConfig,
-    config: mockConfig,
-  };
-});
 
 import { connect } from "../../src/salesforce/connection";
 
 describe("Salesforce Connection", () => {
   const testUsername = "test@example.com";
-  const missingUsernameError =
-    "Please set a valid ORG_USERNAME environment variable in your .env file";
-
-  let originalEnv: NodeJS.ProcessEnv;
+  const noDefaultOrgError =
+    "No default org configured. Please set a default org using 'sf config set target-org <username>'.";
 
   beforeEach(() => {
     jest.clearAllMocks();
-    originalEnv = { ...process.env };
     mockAuthInfo.create.mockResolvedValue({ username: testUsername });
     mockConnectionCreate.mockResolvedValue(mockConnectionInstance);
-  });
-
-  afterEach(() => {
-    process.env = originalEnv;
+    mockConfigAggregatorCreate.mockResolvedValue(mockConfigAggregator);
+    mockConfigAggregator.getPropertyValue.mockReturnValue(testUsername);
   });
 
   describe("connect", () => {
-    it("should successfully connect with valid username", async () => {
-      process.env.ORG_USERNAME = testUsername;
-
+    it("should successfully connect with default org", async () => {
       const result = await connect();
 
+      expect(mockConfigAggregatorCreate).toHaveBeenCalled();
+      expect(mockConfigAggregator.getPropertyValue).toHaveBeenCalledWith("target-org");
       expect(mockAuthInfo.create).toHaveBeenCalledWith({
         username: testUsername,
       });
@@ -75,14 +70,13 @@ describe("Salesforce Connection", () => {
       expect(result).toBe(mockConnectionInstance);
     });
 
-    it("should throw error when ORG_USERNAME is missing", async () => {
-      delete process.env.ORG_USERNAME;
+    it("should throw error when no default org is configured", async () => {
+      mockConfigAggregator.getPropertyValue.mockReturnValue(undefined);
 
-      await expect(connect()).rejects.toThrow(missingUsernameError);
+      await expect(connect()).rejects.toThrow(noDefaultOrgError);
     });
 
     it("should propagate errors from AuthInfo.create", async () => {
-      process.env.ORG_USERNAME = testUsername;
       const authError = new Error("Org not found");
       mockAuthInfo.create.mockRejectedValue(authError);
 

--- a/tests/salesforce/traceFlags.test.ts
+++ b/tests/salesforce/traceFlags.test.ts
@@ -9,25 +9,23 @@ import { ensureTraceFlag } from "../../src/salesforce/traceFlags";
 describe("Trace Flags", () => {
   let mockConnection: jest.Mocked<Connection>;
   let mockTooling: any;
-  let mockQuery: any;
   let mockSobject: any;
   let mockCreate: any;
+  let mockFindOne: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockQuery = jest.fn();
     mockCreate = jest.fn();
-    mockSobject = jest.fn();
+    mockFindOne = jest.fn();
+    mockSobject = jest.fn().mockReturnValue({
+      create: mockCreate,
+      findOne: mockFindOne,
+    });
 
     mockTooling = {
-      query: mockQuery,
       sobject: mockSobject,
     };
-
-    mockSobject.mockReturnValue({
-      create: mockCreate,
-    });
 
     mockConnection = {
       tooling: mockTooling,
@@ -60,31 +58,24 @@ describe("Trace Flags", () => {
         ExpirationDate: tomorrow,
       };
 
-      mockQuery.mockResolvedValue({
-        records: [existingTraceFlag],
-      });
+      mockFindOne.mockResolvedValue(existingTraceFlag);
 
       await ensureTraceFlag(mockConnection, tracedEntityId, debugLevelId);
 
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining("SELECT Id, TracedEntityId, DebugLevelId, StartDate, ExpirationDate")
-      );
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining("FROM TraceFlag")
-      );
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining(`WHERE TracedEntityId = '${tracedEntityId}'`)
-      );
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining(`AND LogType = '${userDebug}'`)
+      expect(mockSobject).toHaveBeenCalledWith("TraceFlag");
+      expect(mockFindOne).toHaveBeenCalledWith(
+        {
+          TracedEntityId: tracedEntityId,
+          ExpirationDate: { $gt: now },
+          LogType: userDebug,
+        },
+        ["Id", "TracedEntityId", "DebugLevelId", "StartDate", "ExpirationDate"],
       );
       expect(mockCreate).not.toHaveBeenCalled();
     });
 
     it("should create new trace flag when none exists", async () => {
-      mockQuery.mockResolvedValue({
-        records: [],
-      });
+      mockFindOne.mockResolvedValue(null);
 
       mockCreate.mockResolvedValue({
         success: true,
@@ -93,7 +84,6 @@ describe("Trace Flags", () => {
 
       await ensureTraceFlag(mockConnection, tracedEntityId, debugLevelId);
 
-      expect(mockQuery).toHaveBeenCalled();
       expect(mockSobject).toHaveBeenCalledWith("TraceFlag");
       expect(mockCreate).toHaveBeenCalledWith({
         TracedEntityId: tracedEntityId,
@@ -105,9 +95,7 @@ describe("Trace Flags", () => {
     });
 
     it("should set expiration date 24 hours from now", async () => {
-      mockQuery.mockResolvedValue({
-        records: [],
-      });
+      mockFindOne.mockResolvedValue(null);
 
       mockCreate.mockResolvedValue({
         success: true,
@@ -120,14 +108,12 @@ describe("Trace Flags", () => {
         expect.objectContaining({
           StartDate: now,
           ExpirationDate: tomorrow,
-        })
+        }),
       );
     });
 
     it("should include errors in error message when creation fails", async () => {
-      mockQuery.mockResolvedValue({
-        records: [],
-      });
+      mockFindOne.mockResolvedValue(null);
 
       mockCreate.mockResolvedValue({
         success: false,
@@ -146,30 +132,26 @@ describe("Trace Flags", () => {
 
     it("should handle query errors gracefully", async () => {
       const queryError = new Error("Query failed");
-      mockQuery.mockRejectedValue(queryError);
+      mockFindOne.mockRejectedValue(queryError);
 
       await expect(
-        ensureTraceFlag(mockConnection, tracedEntityId, debugLevelId)
+        ensureTraceFlag(mockConnection, tracedEntityId, debugLevelId),
       ).rejects.toThrow("Query failed");
     });
 
     it("should handle creation errors gracefully", async () => {
-      mockQuery.mockResolvedValue({
-        records: [],
-      });
+      mockFindOne.mockResolvedValue(null);
 
       const createError = new Error("Network error");
       mockCreate.mockRejectedValue(createError);
 
       await expect(
-        ensureTraceFlag(mockConnection, tracedEntityId, debugLevelId)
+        ensureTraceFlag(mockConnection, tracedEntityId, debugLevelId),
       ).rejects.toThrow("Network error");
     });
 
     it("should query for active trace flags only (ExpirationDate > now)", async () => {
-      mockQuery.mockResolvedValue({
-        records: [],
-      });
+      mockFindOne.mockResolvedValue(null);
 
       mockCreate.mockResolvedValue({
         success: true,
@@ -178,31 +160,16 @@ describe("Trace Flags", () => {
 
       await ensureTraceFlag(mockConnection, tracedEntityId, debugLevelId);
 
-      const queryCall = mockQuery.mock.calls[0][0];
-      expect(queryCall).toContain(`ExpirationDate > ${now}`);
-    });
-
-    it("should query with LIMIT 1 for efficiency", async () => {
-      mockQuery.mockResolvedValue({
-        records: [],
-      });
-
-      mockCreate.mockResolvedValue({
-        success: true,
-        id: traceFlagId,
-      });
-
-      await ensureTraceFlag(mockConnection, tracedEntityId, debugLevelId);
-
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining("LIMIT 1")
+      expect(mockFindOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ExpirationDate: { $gt: now },
+        }),
+        expect.any(Array),
       );
     });
 
     it("should only query for USER_DEBUG log type", async () => {
-      mockQuery.mockResolvedValue({
-        records: [],
-      });
+      mockFindOne.mockResolvedValue(null);
 
       mockCreate.mockResolvedValue({
         success: true,
@@ -211,15 +178,16 @@ describe("Trace Flags", () => {
 
       await ensureTraceFlag(mockConnection, tracedEntityId, debugLevelId);
 
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining(`AND LogType = '${userDebug}'`)
+      expect(mockFindOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          LogType: userDebug,
+        }),
+        expect.any(Array),
       );
     });
 
     it("should create trace flag with USER_DEBUG log type", async () => {
-      mockQuery.mockResolvedValue({
-        records: [],
-      });
+      mockFindOne.mockResolvedValue(null);
 
       mockCreate.mockResolvedValue({
         success: true,
@@ -231,7 +199,7 @@ describe("Trace Flags", () => {
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
           LogType: userDebug,
-        })
+        }),
       );
     });
 
@@ -239,9 +207,7 @@ describe("Trace Flags", () => {
       const customTracedEntityId = "customEntity";
       const customDebugLevelId = "customDebug";
 
-      mockQuery.mockResolvedValue({
-        records: [],
-      });
+      mockFindOne.mockResolvedValue(null);
 
       mockCreate.mockResolvedValue({
         success: true,
@@ -251,35 +217,34 @@ describe("Trace Flags", () => {
       await ensureTraceFlag(
         mockConnection,
         customTracedEntityId,
-        customDebugLevelId
+        customDebugLevelId,
       );
 
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining(`WHERE TracedEntityId = '${customTracedEntityId}'`)
+      expect(mockFindOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          TracedEntityId: customTracedEntityId,
+        }),
+        expect.any(Array),
       );
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
           TracedEntityId: customTracedEntityId,
           DebugLevelId: customDebugLevelId,
-        })
+        }),
       );
     });
 
     it("should not throw error when active trace flag exists", async () => {
-      mockQuery.mockResolvedValue({
-        records: [
-          {
-            Id: traceFlagId,
-            TracedEntityId: tracedEntityId,
-            DebugLevelId: debugLevelId,
-            StartDate: now,
-            ExpirationDate: tomorrow,
-          },
-        ],
+      mockFindOne.mockResolvedValue({
+        Id: traceFlagId,
+        TracedEntityId: tracedEntityId,
+        DebugLevelId: debugLevelId,
+        StartDate: now,
+        ExpirationDate: tomorrow,
       });
 
       await expect(
-        ensureTraceFlag(mockConnection, tracedEntityId, debugLevelId)
+        ensureTraceFlag(mockConnection, tracedEntityId, debugLevelId),
       ).resolves.not.toThrow();
     });
   });


### PR DESCRIPTION
Adds a tool to execute a snippet of anonymous Apex on a Salesforce org. This tool will return the corresponding debug log. 

In order to make this work, we read the default org from the Salesforce CLI. Then, whenever it receives a request for Apex execution, it validates that a trace flag exists in the org to allow the debug log to be read.

The tool will return an error in the event of a compilation error, as no log will be created in this case, but otherwise it will return the full log, including error messages.

Addresses #4.