### PR TITLE
feat: add target org support for execute anonymous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2025-11-20
+## [Unreleased] - xxxx-xx-x
 
 ### Added
 
 - **Performance Analysis** (`analyze_apex_log_performance`) - Feed in a debug log and instantly see which methods are the slowest. See execution times, SOQL/DML counts.
 - **Log Summaries** (`get_apex_log_summary`) - Get a debug log summary. Total execution time, method count, governor limit usage.
 - **Bottleneck Detection** (`find_performance_bottlenecks`) - Detects CPU, database and method performance issues by type so you know exactly what to focus on.
-- **Anonymous Apex Execution** (`execute_anonymous`) - Write Apex, run it, and get the debug log back for analysis.
+- **Anonymous Apex Execution** (`execute_anonymous`) - Run Apex against any Salesforce org and get the debug log back for analysis. Specify a target org by alias or username, or use the project default.

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,16 @@ class LanaServer {
     });
   }
 
+  private async getProjectPath(): Promise<string | undefined> {
+    try {
+      const { roots } = await this.server.listRoots();
+      const rootUri = roots[0]?.uri;
+      return rootUri ? new URL(rootUri).pathname : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
   private setupToolHandlers(): void {
     this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
       tools: [
@@ -73,6 +83,7 @@ class LanaServer {
 
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;
+      const projectPath = await this.getProjectPath();
 
       try {
         switch (name) {
@@ -87,9 +98,10 @@ class LanaServer {
               args as unknown as BottleneckArgs,
             );
           case "execute_anonymous":
-            return await executeAnonymous(
-              args as unknown as ExecuteAnonymousArgs,
-            );
+            return await executeAnonymous({
+              ...(args as unknown as ExecuteAnonymousArgs),
+              projectPath,
+            });
           default:
             throw new Error(`Unknown tool: ${name}`);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,10 +58,12 @@ class LanaServer {
     this.server.onerror = (error) => {
       console.error("[MCP Error]", error);
     };
-    process.on("SIGINT", async () => {
+
+    const shutdown = async () => {
       this.server.close();
       process.exit(0);
-    });
+    };
+    process.once("SIGINT", shutdown);
   }
 
   private setupToolHandlers(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,11 @@ import {
 import {
   executeAnonymous,
   executeAnonymousTool,
-  ExecuteAnonymousArgs,
 } from "./tools/executeAnonymous.js";
+
+function parseArgs<T>(args: Record<string, unknown> | undefined): T {
+  return (args ?? {}) as T;
+}
 
 class LanaServer {
   private server: Server;
@@ -61,16 +64,6 @@ class LanaServer {
     });
   }
 
-  private async getProjectPath(): Promise<string | undefined> {
-    try {
-      const { roots } = await this.server.listRoots();
-      const rootUri = roots[0]?.uri;
-      return rootUri ? new URL(rootUri).pathname : undefined;
-    } catch {
-      return undefined;
-    }
-  }
-
   private setupToolHandlers(): void {
     this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
       tools: [
@@ -83,25 +76,22 @@ class LanaServer {
 
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;
-      const projectPath = await this.getProjectPath();
 
       try {
         switch (name) {
           case "analyze_apex_log_performance":
-            return await analyzeLogPerformance(
-              args as unknown as AnalyzeLogArgs,
-            );
+            return await analyzeLogPerformance(parseArgs<AnalyzeLogArgs>(args));
           case "get_apex_log_summary":
-            return await getLogSummary(args as unknown as LogSummaryArgs);
+            return await getLogSummary(parseArgs<LogSummaryArgs>(args));
           case "find_performance_bottlenecks":
             return await findPerformanceBottlenecks(
-              args as unknown as BottleneckArgs,
+              parseArgs<BottleneckArgs>(args),
             );
           case "execute_anonymous":
-            return await executeAnonymous({
-              ...(args as unknown as ExecuteAnonymousArgs),
-              projectPath,
-            });
+            return await executeAnonymous(
+              this.server,
+              parseArgs<{ apex: string; targetOrg?: string }>(args),
+            );
           default:
             throw new Error(`Unknown tool: ${name}`);
         }

--- a/src/salesforce/connection.ts
+++ b/src/salesforce/connection.ts
@@ -1,18 +1,30 @@
-import { Connection, AuthInfo, ConfigAggregator } from "@salesforce/core";
+import {
+  Connection,
+  ConfigAggregator,
+  OrgConfigProperties,
+  Org,
+} from "@salesforce/core";
 
-export async function connect(): Promise<Connection> {
-  // Get default org from SF CLI configuration
-  const aggregator = await ConfigAggregator.create();
-  const defaultOrg = aggregator.getPropertyValue("target-org") as string | undefined;
+export async function connect(
+  projectPath?: string,
+  targetOrg?: string,
+): Promise<Connection> {
+  const aliasOrUsername = targetOrg ?? (await resolveDefaultOrg(projectPath));
+  const org = await Org.create({ aliasOrUsername });
+  return org.getConnection();
+}
+
+async function resolveDefaultOrg(projectPath?: string): Promise<string> {
+  const aggregator = await ConfigAggregator.create({ projectPath });
+  const defaultOrg = aggregator.getPropertyValue<string>(
+    OrgConfigProperties.TARGET_ORG,
+  );
 
   if (!defaultOrg) {
     throw new Error(
-      "No default org configured. Please set a default org using 'sf config set target-org <username>'."
+      "No default org configured. Please set a default org using 'sf config set target-org <username>' (use --global if not in a Salesforce DX project).",
     );
   }
 
-  const authInfo = await AuthInfo.create({ username: defaultOrg });
-  const connection = await Connection.create({ authInfo });
-
-  return connection;
+  return defaultOrg;
 }

--- a/src/salesforce/traceFlags.ts
+++ b/src/salesforce/traceFlags.ts
@@ -3,6 +3,10 @@ import { Connection } from "@salesforce/core";
 const TRACE_FLAG_SOBJECT = "TraceFlag";
 const USER_DEBUG = "USER_DEBUG";
 
+function toDateTimeLiteral(date: Date): { toString(): string } {
+  return { toString: () => date.toISOString() };
+}
+
 type TraceFlag = {
   Id: string;
   TracedEntityId: string;
@@ -22,6 +26,9 @@ export async function ensureTraceFlag(
   );
 
   if (existingTraceFlag) {
+    if (existingTraceFlag.DebugLevelId !== debugLevelId) {
+      await updateTraceFlag(connection, existingTraceFlag.Id, debugLevelId);
+    }
     return;
   }
 
@@ -42,15 +49,30 @@ async function findActiveTraceFlag(
   connection: Connection,
   tracedEntityId: string,
 ): Promise<TraceFlag | null> {
-  const now = new Date().toISOString();
   return await connection.tooling.sobject(TRACE_FLAG_SOBJECT).findOne(
     {
       TracedEntityId: tracedEntityId,
-      ExpirationDate: { $gt: now },
+      ExpirationDate: { $gt: toDateTimeLiteral(new Date()) },
       LogType: USER_DEBUG,
     },
     ["Id", "TracedEntityId", "DebugLevelId", "StartDate", "ExpirationDate"],
   );
+}
+
+async function updateTraceFlag(
+  connection: Connection,
+  traceFlagId: string,
+  debugLevelId: string,
+): Promise<void> {
+  const result = await connection.tooling
+    .sobject(TRACE_FLAG_SOBJECT)
+    .update({ Id: traceFlagId, DebugLevelId: debugLevelId });
+
+  if (!result.success) {
+    throw new Error(
+      `Failed to update TraceFlag: ${JSON.stringify(result.errors)}`,
+    );
+  }
 }
 
 async function createTraceFlag(

--- a/src/salesforce/users.ts
+++ b/src/salesforce/users.ts
@@ -2,11 +2,11 @@ import { Connection } from "@salesforce/core";
 
 export async function getUserIdByUsername(
   connection: Connection,
-  username: string
+  username: string,
 ): Promise<string> {
   const sanitisedUsername = username.replace(/'/g, "\\'");
   const result = await connection.query(
-    `SELECT Id FROM User WHERE Username = '${sanitisedUsername}'`
+    `SELECT Id FROM User WHERE Username = '${sanitisedUsername}'`,
   );
 
   if (result.records.length === 0) {

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -1,3 +1,4 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { Connection } from "@salesforce/core";
 import { getUserIdByUsername } from "../salesforce/users.js";
 import { getOrCreateDebugLevelId } from "../salesforce/debugLevels.js";
@@ -7,7 +8,6 @@ import { connect } from "../salesforce/connection.js";
 export interface ExecuteAnonymousArgs {
   apex: string;
   targetOrg?: string;
-  projectPath?: string;
 }
 
 type ApexLogRecord = {
@@ -35,8 +35,22 @@ export const executeAnonymousTool = {
   },
 };
 
-export async function executeAnonymous(args: ExecuteAnonymousArgs) {
-  const { apex, projectPath, targetOrg } = args;
+async function getProjectPath(server: Server): Promise<string | undefined> {
+  try {
+    const { roots } = await server.listRoots();
+    const rootUri = roots[0]?.uri;
+    return rootUri ? new URL(rootUri).pathname : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function executeAnonymous(
+  server: Server,
+  args: ExecuteAnonymousArgs,
+) {
+  const { apex, targetOrg } = args;
+  const projectPath = await getProjectPath(server);
 
   const connection = await connect(projectPath, targetOrg);
 

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -6,6 +6,8 @@ import { connect } from "../salesforce/connection.js";
 
 export interface ExecuteAnonymousArgs {
   apex: string;
+  targetOrg?: string;
+  projectPath?: string;
 }
 
 type ApexLogRecord = {
@@ -23,15 +25,20 @@ export const executeAnonymousTool = {
         type: "string",
         description: "The anonymous Apex to be executed",
       },
+      targetOrg: {
+        type: "string",
+        description:
+          "Alias or username of the target Salesforce org. Uses the project default if not specified.",
+      },
     },
     required: ["apex"],
   },
 };
 
 export async function executeAnonymous(args: ExecuteAnonymousArgs) {
-  const { apex } = args;
+  const { apex, projectPath, targetOrg } = args;
 
-  const connection = await connect();
+  const connection = await connect(projectPath, targetOrg);
 
   const username = connection.getUsername();
   if (!username) {

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -17,7 +17,7 @@ type ApexLogRecord = {
 export const executeAnonymousTool = {
   name: "execute_anonymous",
   description:
-    "Execute a snippet of anonymous Apex and retrieve the resulting log",
+    "Execute a snippet of anonymous Apex against any Salesforce org and retrieve the resulting debug log",
   inputSchema: {
     type: "object",
     properties: {

--- a/tests/executeAnonymous.test.ts
+++ b/tests/executeAnonymous.test.ts
@@ -21,6 +21,9 @@ jest.mock("../src/salesforce/connection", () => ({
   connect: mockConnect,
 }));
 
+jest.mock("@modelcontextprotocol/sdk/server/index.js");
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import {
   executeAnonymous,
   ExecuteAnonymousArgs,
@@ -36,6 +39,7 @@ describe("Execute Anonymous", () => {
   const testLogBody = "APEX DEBUG LOG CONTENT HERE";
   const testApexCode = "System.debug('Hello World');";
 
+  let mockServer: Server;
   let mockConnection: any;
   let mockTooling: any;
   let mockExecuteAnonymous: any;
@@ -46,6 +50,10 @@ describe("Execute Anonymous", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockServer = {
+      listRoots: jest.fn<any>().mockResolvedValue({ roots: [] }),
+    } as unknown as Server;
 
     mockExecuteAnonymous = jest.fn();
     mockRequest = jest.fn();
@@ -97,7 +105,7 @@ describe("Execute Anonymous", () => {
       mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
-      const result = await executeAnonymous(args);
+      const result = await executeAnonymous(mockServer, args);
 
       expect(getUserIdByUsername).toHaveBeenCalledWith(
         mockConnection,
@@ -133,7 +141,7 @@ describe("Execute Anonymous", () => {
       mockGetUsername.mockReturnValue(null);
       const args: ExecuteAnonymousArgs = { apex: testApexCode };
 
-      await expect(executeAnonymous(args)).rejects.toThrow(
+      await expect(executeAnonymous(mockServer, args)).rejects.toThrow(
         "Could not determine username from connection",
       );
 
@@ -154,7 +162,7 @@ describe("Execute Anonymous", () => {
         compileProblem: "Unexpected token 'Invalid'",
       });
 
-      await expect(executeAnonymous(args)).rejects.toThrow(
+      await expect(executeAnonymous(mockServer, args)).rejects.toThrow(
         "Apex could not be compiled at line 1, column 5: Unexpected token 'Invalid'",
       );
 
@@ -167,7 +175,7 @@ describe("Execute Anonymous", () => {
 
       mockExecuteAnonymous.mockResolvedValue(null);
 
-      await expect(executeAnonymous(args)).rejects.toThrow(
+      await expect(executeAnonymous(mockServer, args)).rejects.toThrow(
         "Cannot read properties of null",
       );
 
@@ -187,7 +195,7 @@ describe("Execute Anonymous", () => {
 
       mockFindOne.mockResolvedValue(null);
 
-      await expect(executeAnonymous(args)).rejects.toThrow(
+      await expect(executeAnonymous(mockServer, args)).rejects.toThrow(
         "Could not retrieve log from anonymous execution",
       );
 
@@ -207,7 +215,7 @@ describe("Execute Anonymous", () => {
       mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
-      await executeAnonymous(args);
+      await executeAnonymous(mockServer, args);
 
       expect(mockFindOne).toHaveBeenCalledWith(
         expect.any(Object),
@@ -234,7 +242,7 @@ describe("Execute Anonymous", () => {
       mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
-      const result = await executeAnonymous(args);
+      const result = await executeAnonymous(mockServer, args);
 
       expect(mockExecuteAnonymous).toHaveBeenCalledWith(multiLineApex);
       expect(result.content[0].text).toBe(testLogBody);
@@ -248,7 +256,9 @@ describe("Execute Anonymous", () => {
         getUserIdByUsername as jest.MockedFunction<typeof getUserIdByUsername>;
       mockGetUserIdByUsername.mockRejectedValue(userError);
 
-      await expect(executeAnonymous(args)).rejects.toThrow("User not found");
+      await expect(executeAnonymous(mockServer, args)).rejects.toThrow(
+        "User not found",
+      );
 
       expect(getOrCreateDebugLevelId).not.toHaveBeenCalled();
       expect(ensureTraceFlag).not.toHaveBeenCalled();
@@ -265,7 +275,7 @@ describe("Execute Anonymous", () => {
         >;
       mockGetOrCreateDebugLevelId.mockRejectedValue(debugLevelError);
 
-      await expect(executeAnonymous(args)).rejects.toThrow(
+      await expect(executeAnonymous(mockServer, args)).rejects.toThrow(
         "Failed to create debug level",
       );
 
@@ -282,7 +292,7 @@ describe("Execute Anonymous", () => {
       >;
       mockEnsureTraceFlag.mockRejectedValue(traceFlagError);
 
-      await expect(executeAnonymous(args)).rejects.toThrow(
+      await expect(executeAnonymous(mockServer, args)).rejects.toThrow(
         "Failed to create trace flag",
       );
 
@@ -295,7 +305,9 @@ describe("Execute Anonymous", () => {
 
       mockExecuteAnonymous.mockRejectedValue(executeError);
 
-      await expect(executeAnonymous(args)).rejects.toThrow("Tooling API error");
+      await expect(executeAnonymous(mockServer, args)).rejects.toThrow(
+        "Tooling API error",
+      );
 
       expect(mockSobject).not.toHaveBeenCalled();
       expect(mockRequest).not.toHaveBeenCalled();
@@ -314,7 +326,9 @@ describe("Execute Anonymous", () => {
 
       mockFindOne.mockRejectedValue(queryError);
 
-      await expect(executeAnonymous(args)).rejects.toThrow("Query failed");
+      await expect(executeAnonymous(mockServer, args)).rejects.toThrow(
+        "Query failed",
+      );
 
       expect(mockRequest).not.toHaveBeenCalled();
     });
@@ -333,7 +347,7 @@ describe("Execute Anonymous", () => {
       mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockRejectedValue(requestError);
 
-      await expect(executeAnonymous(args)).rejects.toThrow(
+      await expect(executeAnonymous(mockServer, args)).rejects.toThrow(
         "Failed to fetch log body",
       );
     });
@@ -357,7 +371,7 @@ describe("Execute Anonymous", () => {
       mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
-      await executeAnonymous(args);
+      await executeAnonymous(mockServer, args);
 
       expect(mockFindOne).toHaveBeenCalledWith(
         { LogUserId: customUserId },
@@ -381,7 +395,7 @@ describe("Execute Anonymous", () => {
       mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
-      const result = await executeAnonymous(args);
+      const result = await executeAnonymous(mockServer, args);
 
       expect(mockExecuteAnonymous).toHaveBeenCalledWith(soqlApex);
       expect(result.content[0].text).toBe(testLogBody);
@@ -401,7 +415,7 @@ describe("Execute Anonymous", () => {
       mockFindOne.mockResolvedValue({ Id: testLogId });
       mockRequest.mockResolvedValue(testLogBody);
 
-      const result = await executeAnonymous(args);
+      const result = await executeAnonymous(mockServer, args);
 
       expect(mockExecuteAnonymous).toHaveBeenCalledWith(dmlApex);
       expect(result.content[0].text).toBe(testLogBody);
@@ -415,7 +429,7 @@ describe("Execute Anonymous", () => {
 
       mockConnect.mockRejectedValue(connectError);
 
-      await expect(executeAnonymous(args)).rejects.toThrow(
+      await expect(executeAnonymous(mockServer, args)).rejects.toThrow(
         "No default org configured",
       );
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -239,6 +239,7 @@ describe("LanaServer", () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    process.removeAllListeners("SIGINT");
   });
 
   describe("Server Initialization", () => {
@@ -273,11 +274,11 @@ describe("LanaServer", () => {
     });
 
     it("should setup SIGINT handler", async () => {
-      const mockProcessOn = jest.spyOn(process, "on");
+      const mockProcessOnce = jest.spyOn(process, "once");
 
       new LanaServer();
 
-      expect(mockProcessOn).toHaveBeenCalledWith(
+      expect(mockProcessOnce).toHaveBeenCalledWith(
         "SIGINT",
         expect.any(Function),
       );
@@ -503,8 +504,8 @@ describe("LanaServer", () => {
       new LanaServer();
 
       // Find the SIGINT handler
-      const processOnCalls = jest.spyOn(process, "on").mock.calls;
-      const sigintCall = processOnCalls.find(
+      const processOnceCalls = jest.spyOn(process, "once").mock.calls;
+      const sigintCall = processOnceCalls.find(
         (call: any) => call[0] === "SIGINT",
       );
       expect(sigintCall).toBeDefined();

--- a/tests/salesforce/connection.test.ts
+++ b/tests/salesforce/connection.test.ts
@@ -2,13 +2,7 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import {
-  jest,
-  describe,
-  it,
-  expect,
-  beforeEach,
-} from "@jest/globals";
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
 
 const mockConnectionInstance = {
   query: jest.fn(),
@@ -18,11 +12,11 @@ const mockConnectionInstance = {
   },
 } as any;
 
-const mockAuthInfo = {
-  create: jest.fn(),
+const mockOrgInstance = {
+  getConnection: jest.fn().mockReturnValue(mockConnectionInstance),
 } as any;
 
-const mockConnectionCreate = jest.fn() as jest.MockedFunction<any>;
+const mockOrgCreate = jest.fn() as jest.MockedFunction<any>;
 
 const mockConfigAggregator = {
   getPropertyValue: jest.fn(),
@@ -31,14 +25,14 @@ const mockConfigAggregator = {
 const mockConfigAggregatorCreate = jest.fn() as jest.MockedFunction<any>;
 
 jest.mock("@salesforce/core", () => ({
-  Connection: {
-    create: mockConnectionCreate,
-  },
-  AuthInfo: {
-    create: mockAuthInfo.create,
+  Org: {
+    create: mockOrgCreate,
   },
   ConfigAggregator: {
     create: mockConfigAggregatorCreate,
+  },
+  OrgConfigProperties: {
+    TARGET_ORG: "target-org",
   },
 }));
 
@@ -47,12 +41,11 @@ import { connect } from "../../src/salesforce/connection";
 describe("Salesforce Connection", () => {
   const testUsername = "test@example.com";
   const noDefaultOrgError =
-    "No default org configured. Please set a default org using 'sf config set target-org <username>'.";
+    "No default org configured. Please set a default org using 'sf config set target-org <username>'";
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockAuthInfo.create.mockResolvedValue({ username: testUsername });
-    mockConnectionCreate.mockResolvedValue(mockConnectionInstance);
+    mockOrgCreate.mockResolvedValue(mockOrgInstance);
     mockConfigAggregatorCreate.mockResolvedValue(mockConfigAggregator);
     mockConfigAggregator.getPropertyValue.mockReturnValue(testUsername);
   });
@@ -62,11 +55,12 @@ describe("Salesforce Connection", () => {
       const result = await connect();
 
       expect(mockConfigAggregatorCreate).toHaveBeenCalled();
-      expect(mockConfigAggregator.getPropertyValue).toHaveBeenCalledWith("target-org");
-      expect(mockAuthInfo.create).toHaveBeenCalledWith({
-        username: testUsername,
+      expect(mockConfigAggregator.getPropertyValue).toHaveBeenCalledWith(
+        "target-org",
+      );
+      expect(mockOrgCreate).toHaveBeenCalledWith({
+        aliasOrUsername: testUsername,
       });
-      expect(mockConnectionCreate).toHaveBeenCalled();
       expect(result).toBe(mockConnectionInstance);
     });
 
@@ -76,9 +70,20 @@ describe("Salesforce Connection", () => {
       await expect(connect()).rejects.toThrow(noDefaultOrgError);
     });
 
-    it("should propagate errors from AuthInfo.create", async () => {
-      const authError = new Error("Org not found");
-      mockAuthInfo.create.mockRejectedValue(authError);
+    it("should use targetOrg when provided", async () => {
+      const targetOrg = "my-scratch-org";
+      const result = await connect(undefined, targetOrg);
+
+      expect(mockConfigAggregatorCreate).not.toHaveBeenCalled();
+      expect(mockOrgCreate).toHaveBeenCalledWith({
+        aliasOrUsername: targetOrg,
+      });
+      expect(result).toBe(mockConnectionInstance);
+    });
+
+    it("should propagate errors from Org.create", async () => {
+      const orgError = new Error("Org not found");
+      mockOrgCreate.mockRejectedValue(orgError);
 
       await expect(connect()).rejects.toThrow("Org not found");
     });

--- a/tests/salesforce/traceFlags.test.ts
+++ b/tests/salesforce/traceFlags.test.ts
@@ -66,7 +66,11 @@ describe("Trace Flags", () => {
       expect(mockFindOne).toHaveBeenCalledWith(
         {
           TracedEntityId: tracedEntityId,
-          ExpirationDate: { $gt: now },
+          ExpirationDate: {
+            $gt: expect.objectContaining({
+              toString: expect.any(Function),
+            }),
+          },
           LogType: userDebug,
         },
         ["Id", "TracedEntityId", "DebugLevelId", "StartDate", "ExpirationDate"],
@@ -162,7 +166,11 @@ describe("Trace Flags", () => {
 
       expect(mockFindOne).toHaveBeenCalledWith(
         expect.objectContaining({
-          ExpirationDate: { $gt: now },
+          ExpirationDate: {
+            $gt: expect.objectContaining({
+              toString: expect.any(Function),
+            }),
+          },
         }),
         expect.any(Array),
       );


### PR DESCRIPTION
## Summary
- Add `targetOrg` parameter to `execute_anonymous` tool, allowing execution against any authorized Salesforce org (not just the default)
- Refactor `executeAnonymous` to resolve `projectPath` internally via `Server.listRoots()` instead of receiving it from the call site
- Replace unsafe `as unknown as` casts with a type-safe `parseArgs` helper in `index.ts`

Closes #18

## Test plan
- [X] `npm run build` compiles without errors
- [X] `npm test` passes all tests
- [X] Verify `execute_anonymous` works with default org (no `targetOrg`)
- [X] Verify `execute_anonymous` works with explicit `targetOrg` alias/username
