### PR TITLE
feat: add configurable debug levels to execute_anonymous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Performance Analysis** (`analyze_apex_log_performance`) - Feed in a debug log and instantly see which methods are the slowest. See execution times, SOQL/DML counts.
 - **Log Summaries** (`get_apex_log_summary`) - Get a debug log summary. Total execution time, method count, governor limit usage.
 - **Bottleneck Detection** (`find_performance_bottlenecks`) - Detects CPU, database and method performance issues by type so you know exactly what to focus on.
-- **Anonymous Apex Execution** (`execute_anonymous`) - Run Apex against any Salesforce org and get the debug log back for analysis. Specify a target org by alias or username, or use the project default.
+- **Anonymous Apex Execution** (`execute_anonymous`) - Run Apex against any Salesforce org and get the debug log back for analysis. Specify a target org by alias or username, or use the project default. Includes configurable debug levels via the `debugLevel` parameter — set all categories at once (e.g. `"FINEST"`), reset to defaults, or override specific categories like apexCode, database, and nba.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,17 +9,17 @@ This is the LANA MCP Server - a Model Context Protocol (MCP) server for Apex Log
 ## Development Commands
 
 ```bash
-# Install dependencies (use npm, not pnpm despite README mention)
-npm install
+# Install dependencies
+pnpm install
 
 # Build the TypeScript project
-npm run build
+pnpm run build
 
 # Development with watch mode
-npm run dev
+pnpm run dev
 
 # Run the server standalone
-npm start
+pnpm start
 ```
 
 ## Architecture
@@ -46,6 +46,7 @@ npm start
 ### MCP Integration
 
 This server is designed to integrate with the LANA VS Code extension:
+
 - Registered automatically by the extension
 - Communicates via MCP protocol over stdio
 - Provides structured JSON responses for AI analysis
@@ -77,4 +78,4 @@ The server provides four main capabilities:
 4. **Execute Anonymous**: Executes anonymous Apex code snippets and retrieves the resulting debug log
 
 Log analysis tools (1-3) accept absolute file paths to `.log` files and return structured JSON for AI processing.
-Anonymous execution (4) accepts multi-line strings containing Apex and returns the entire contents of the log.
+Anonymous execution (4) accepts multi-line strings containing Apex and returns the entire contents of the log. It supports an optional `debugLevel` parameter to configure trace flag log levels per category or set all categories at once.

--- a/README.md
+++ b/README.md
@@ -88,14 +88,24 @@ Detects and categorizes performance issues by type (CPU, database, or method pat
 
 Executes anonymous Apex code and retrieves the resulting debug log for analysis.
 
-| Parameter | Type   | Required | Description                    |
-| --------- | ------ | -------- | ------------------------------ |
-| `apex`    | string | Yes      | Anonymous Apex code to execute |
+| Parameter    | Type             | Required | Description                                                                                                                                                                                                                                      |
+| ------------ | ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `apex`       | string           | Yes      | Anonymous Apex code to execute                                                                                                                                                                                                                   |
+| `targetOrg`  | string           | No       | Alias or username of the target Salesforce org. Uses the project default if not specified.                                                                                                                                                       |
+| `debugLevel` | string \| object | No       | Controls the trace flag debug levels. Use `"default"` to reset all categories to defaults, a log level string (e.g. `"FINEST"`) to set all categories to that level, or an object to override specific categories. Omit to keep existing config. |
+
+**Supported `debugLevel` categories** (when using an object):
+
+`apexCode`, `apexProfiling`, `callout`, `database`, `nba`, `system`, `validation`, `visualforce`, `wave`, `workflow`
+
+Each accepts a log level: `NONE`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `FINE`, `FINER`, `FINEST`
 
 **Example prompts:**
 
 - "Execute this Apex and show me the log: `System.debug('Hello');`"
 - "Run a query for all Accounts and analyze the performance"
+- "Execute this Apex with all debug levels set to FINEST"
+- "Run this Apex with database logging set to FINEST"
 
 **Note:** Requires a default Salesforce org configured via Salesforce CLI.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
 import {
   executeAnonymous,
   executeAnonymousTool,
+  ExecuteAnonymousArgs,
 } from "./tools/executeAnonymous.js";
 
 function parseArgs<T>(args: Record<string, unknown> | undefined): T {
@@ -92,7 +93,7 @@ class LanaServer {
           case "execute_anonymous":
             return await executeAnonymous(
               this.server,
-              parseArgs<{ apex: string; targetOrg?: string }>(args),
+              parseArgs<ExecuteAnonymousArgs>(args),
             );
           default:
             throw new Error(`Unknown tool: ${name}`);

--- a/src/salesforce/debugLevels.ts
+++ b/src/salesforce/debugLevels.ts
@@ -1,53 +1,176 @@
 import { Connection } from "@salesforce/core";
 
 const DEBUG_LEVEL_SOBJECT = "DebugLevel";
-const DEVELOPER_NAME_FIELD = "DeveloperName";
 const MCP_DEBUG_LEVEL_NAME = "LANA_MCP_Debug_Level";
 
-export async function getOrCreateDebugLevelId(
-  connection: Connection
-): Promise<string> {
-  const existingDebugLevelId = await findDebugLevelId(connection);
+export type LogLevel =
+  | "NONE"
+  | "ERROR"
+  | "WARN"
+  | "INFO"
+  | "DEBUG"
+  | "FINE"
+  | "FINER"
+  | "FINEST";
 
-  if (existingDebugLevelId) {
-    return existingDebugLevelId;
-  }
+export type TraceConfig = {
+  apexCode?: LogLevel;
+  apexProfiling?: LogLevel;
+  callout?: LogLevel;
+  database?: LogLevel;
+  nba?: LogLevel;
+  system?: LogLevel;
+  validation?: LogLevel;
+  visualforce?: LogLevel;
+  wave?: LogLevel;
+  workflow?: LogLevel;
+};
 
-  return await createDebugLevel(connection);
+const DEFAULT_TRACE_CONFIG: Required<TraceConfig> = {
+  apexCode: "FINE",
+  apexProfiling: "FINE",
+  callout: "DEBUG",
+  database: "FINEST",
+  nba: "INFO",
+  system: "DEBUG",
+  validation: "DEBUG",
+  visualforce: "FINE",
+  wave: "INFO",
+  workflow: "FINE",
+};
+
+export type DebugLevelInput = "default" | LogLevel | TraceConfig;
+
+const LOG_LEVELS: readonly string[] = [
+  "NONE",
+  "ERROR",
+  "WARN",
+  "INFO",
+  "DEBUG",
+  "FINE",
+  "FINER",
+  "FINEST",
+];
+
+function isLogLevel(value: DebugLevelInput): value is LogLevel {
+  return typeof value === "string" && LOG_LEVELS.includes(value);
 }
 
-async function findDebugLevelId(connection: Connection): Promise<string | null> {
+function resolveLevels(debugLevel: DebugLevelInput): Record<string, string> {
+  if (debugLevel === "default") return resolveAllDefaults();
+  if (isLogLevel(debugLevel)) return allCategoriesAt(debugLevel);
+  return toSObjectFields(debugLevel);
+}
+
+function allCategoriesAt(level: LogLevel) {
+  return toSObjectFields({
+    apexCode: level,
+    apexProfiling: level,
+    callout: level,
+    database: level,
+    nba: level,
+    system: level,
+    validation: level,
+    visualforce: level,
+    wave: level,
+    workflow: level,
+  });
+}
+
+type DebugLevelRecord = {
+  Id: string;
+};
+
+function toSObjectFields(config: TraceConfig) {
+  const entries: Record<string, string> = {};
+  if (config.apexCode !== undefined) entries.ApexCode = config.apexCode;
+  if (config.apexProfiling !== undefined)
+    entries.ApexProfiling = config.apexProfiling;
+  if (config.callout !== undefined) entries.Callout = config.callout;
+  if (config.database !== undefined) entries.Database = config.database;
+  if (config.nba !== undefined) entries.Nba = config.nba;
+  if (config.system !== undefined) entries.System = config.system;
+  if (config.validation !== undefined) entries.Validation = config.validation;
+  if (config.visualforce !== undefined)
+    entries.Visualforce = config.visualforce;
+  if (config.wave !== undefined) entries.Wave = config.wave;
+  if (config.workflow !== undefined) entries.Workflow = config.workflow;
+  return entries;
+}
+
+function resolveAllDefaults() {
+  return toSObjectFields(DEFAULT_TRACE_CONFIG);
+}
+
+export async function getOrCreateDebugLevelId(
+  connection: Connection,
+  debugLevel?: DebugLevelInput,
+): Promise<string> {
+  const existing = await findDebugLevel(connection);
+
+  if (existing) {
+    if (debugLevel !== undefined) {
+      const levels = resolveLevels(debugLevel);
+      await updateDebugLevel(connection, existing.Id, levels);
+    }
+    return existing.Id;
+  }
+
+  const levels =
+    debugLevel === undefined || debugLevel === "default"
+      ? resolveAllDefaults()
+      : isLogLevel(debugLevel)
+        ? allCategoriesAt(debugLevel)
+        : { ...resolveAllDefaults(), ...toSObjectFields(debugLevel) };
+  return await createDebugLevel(connection, levels);
+}
+
+async function findDebugLevel(
+  connection: Connection,
+): Promise<DebugLevelRecord | null> {
   const result = await connection.tooling.query(
-    `SELECT Id, ${DEVELOPER_NAME_FIELD}, ApexCode, ApexProfiling, Database
+    `SELECT Id
      FROM ${DEBUG_LEVEL_SOBJECT}
-     WHERE ApexCode = 'FINEST'
-     AND ApexProfiling = 'FINEST'
-     AND Database = 'FINEST'
-     LIMIT 1`
+     WHERE DeveloperName = '${MCP_DEBUG_LEVEL_NAME}'
+     LIMIT 1`,
   );
 
   if (result.records.length === 0) {
     return null;
   }
 
-  const debugLevelId = result.records[0].Id;
-  return debugLevelId || null;
+  const record = result.records[0] as DebugLevelRecord;
+  if (!record.Id) {
+    return null;
+  }
+
+  return record;
+}
+
+async function updateDebugLevel(
+  connection: Connection,
+  id: string,
+  levels: Record<string, string>,
+): Promise<void> {
+  const result = await connection.tooling
+    .sobject(DEBUG_LEVEL_SOBJECT)
+    .update({ Id: id, ...levels });
+
+  if (!result.success) {
+    throw new Error(
+      `Failed to update DebugLevel: ${JSON.stringify(result.errors)}`,
+    );
+  }
 }
 
 async function createDebugLevel(
-  connection: Connection
+  connection: Connection,
+  levels: Record<string, string>,
 ): Promise<string> {
   const result = await connection.tooling.sobject(DEBUG_LEVEL_SOBJECT).create({
     DeveloperName: MCP_DEBUG_LEVEL_NAME,
     MasterLabel: MCP_DEBUG_LEVEL_NAME,
-    ApexCode: "FINEST",
-    ApexProfiling: "FINEST",
-    Callout: "FINEST",
-    Database: "FINEST",
-    System: "DEBUG",
-    Validation: "INFO",
-    Visualforce: "INFO",
-    Workflow: "INFO",
+    ...levels,
   });
 
   if (!result.success || !result.id) {

--- a/src/salesforce/debugLevels.ts
+++ b/src/salesforce/debugLevels.ts
@@ -1,7 +1,7 @@
 import { Connection } from "@salesforce/core";
 
 const DEBUG_LEVEL_SOBJECT = "DebugLevel";
-const MCP_DEBUG_LEVEL_NAME = "LANA_MCP_Debug_Level";
+const DEBUG_LEVEL_NAME = "Apex_Log_MCP_Debug_Level";
 
 export type LogLevel =
   | "NONE"
@@ -131,7 +131,7 @@ async function findDebugLevel(
   const result = await connection.tooling.query(
     `SELECT Id
      FROM ${DEBUG_LEVEL_SOBJECT}
-     WHERE DeveloperName = '${MCP_DEBUG_LEVEL_NAME}'
+     WHERE DeveloperName = '${DEBUG_LEVEL_NAME}'
      LIMIT 1`,
   );
 
@@ -168,8 +168,8 @@ async function createDebugLevel(
   levels: Record<string, string>,
 ): Promise<string> {
   const result = await connection.tooling.sobject(DEBUG_LEVEL_SOBJECT).create({
-    DeveloperName: MCP_DEBUG_LEVEL_NAME,
-    MasterLabel: MCP_DEBUG_LEVEL_NAME,
+    DeveloperName: DEBUG_LEVEL_NAME,
+    MasterLabel: DEBUG_LEVEL_NAME,
     ...levels,
   });
 

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -1,18 +1,37 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { Connection } from "@salesforce/core";
 import { getUserIdByUsername } from "../salesforce/users.js";
-import { getOrCreateDebugLevelId } from "../salesforce/debugLevels.js";
+import {
+  getOrCreateDebugLevelId,
+  DebugLevelInput,
+} from "../salesforce/debugLevels.js";
 import { ensureTraceFlag } from "../salesforce/traceFlags.js";
 import { connect } from "../salesforce/connection.js";
 
 export interface ExecuteAnonymousArgs {
   apex: string;
   targetOrg?: string;
+  debugLevel?: DebugLevelInput;
 }
 
 type ApexLogRecord = {
   Id: string;
 };
+
+const LOG_LEVEL_ENUM = [
+  "NONE",
+  "ERROR",
+  "WARN",
+  "INFO",
+  "DEBUG",
+  "FINE",
+  "FINER",
+  "FINEST",
+];
+
+function logLevelProperty(description: string) {
+  return { type: "string", enum: LOG_LEVEL_ENUM, description };
+}
 
 export const executeAnonymousTool = {
   name: "execute_anonymous",
@@ -29,6 +48,48 @@ export const executeAnonymousTool = {
         type: "string",
         description:
           "Alias or username of the target Salesforce org. Uses the project default if not specified.",
+      },
+      debugLevel: {
+        description:
+          'Optional debug level configuration. Use "default" to reset all categories to defaults. Use a log level string (e.g. "FINEST") to set all categories to that level. Use an object to override specific categories. Omit entirely to keep the existing configuration.',
+        oneOf: [
+          {
+            type: "string",
+            enum: ["default", ...LOG_LEVEL_ENUM],
+            description:
+              'Use "default" to reset to defaults, or a log level (e.g. "FINEST") to set all categories to that level.',
+          },
+          {
+            type: "object",
+            description:
+              "Override specific log categories. Only specified categories are updated; others remain unchanged.",
+            properties: {
+              apexCode: logLevelProperty("Apex code log level (default: FINE)"),
+              apexProfiling: logLevelProperty(
+                "Apex profiling log level (default: FINE)",
+              ),
+              callout: logLevelProperty("Callout log level (default: DEBUG)"),
+              database: logLevelProperty(
+                "Database log level (default: FINEST)",
+              ),
+              nba: logLevelProperty(
+                "NBA (Next Best Action) log level (default: INFO)",
+              ),
+              system: logLevelProperty("System log level (default: DEBUG)"),
+              validation: logLevelProperty(
+                "Validation log level (default: DEBUG)",
+              ),
+              visualforce: logLevelProperty(
+                "Visualforce log level (default: FINE)",
+              ),
+              wave: logLevelProperty(
+                "Wave/Analytics log level (default: INFO)",
+              ),
+              workflow: logLevelProperty("Workflow log level (default: FINE)"),
+            },
+            additionalProperties: false,
+          },
+        ],
       },
     },
     required: ["apex"],
@@ -49,7 +110,7 @@ export async function executeAnonymous(
   server: Server,
   args: ExecuteAnonymousArgs,
 ) {
-  const { apex, targetOrg } = args;
+  const { apex, targetOrg, debugLevel } = args;
   const projectPath = await getProjectPath(server);
 
   const connection = await connect(projectPath, targetOrg);
@@ -60,7 +121,7 @@ export async function executeAnonymous(
   }
 
   const userId = await getUserIdByUsername(connection, username);
-  await validateTraceFlag(connection, userId);
+  await validateTraceFlag(connection, userId, debugLevel);
 
   const apexResult = await connection.tooling.executeAnonymous(apex);
 
@@ -97,7 +158,11 @@ export async function executeAnonymous(
   };
 }
 
-async function validateTraceFlag(connection: Connection, userId: string) {
-  const debugLevelId = await getOrCreateDebugLevelId(connection);
+async function validateTraceFlag(
+  connection: Connection,
+  userId: string,
+  debugLevel?: DebugLevelInput,
+) {
+  const debugLevelId = await getOrCreateDebugLevelId(connection, debugLevel);
   await ensureTraceFlag(connection, userId, debugLevelId);
 }

--- a/tests/executeAnonymous.test.ts
+++ b/tests/executeAnonymous.test.ts
@@ -111,7 +111,10 @@ describe("Execute Anonymous", () => {
         mockConnection,
         "test@example.com",
       );
-      expect(getOrCreateDebugLevelId).toHaveBeenCalledWith(mockConnection);
+      expect(getOrCreateDebugLevelId).toHaveBeenCalledWith(
+        mockConnection,
+        undefined,
+      );
       expect(ensureTraceFlag).toHaveBeenCalledWith(
         mockConnection,
         testUserId,

--- a/tests/salesforce/debugLevels.test.ts
+++ b/tests/salesforce/debugLevels.test.ts
@@ -8,18 +8,20 @@ import { getOrCreateDebugLevelId } from "../../src/salesforce/debugLevels";
 
 describe("Debug Levels", () => {
   const testId = "000000000000000000";
-  
+
   let mockConnection: jest.Mocked<Connection>;
   let mockTooling: any;
   let mockQuery: any;
   let mockSobject: any;
   let mockCreate: any;
+  let mockUpdate: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
 
     mockQuery = jest.fn();
     mockCreate = jest.fn();
+    mockUpdate = jest.fn();
     mockSobject = jest.fn();
 
     mockTooling = {
@@ -29,6 +31,7 @@ describe("Debug Levels", () => {
 
     mockSobject.mockReturnValue({
       create: mockCreate,
+      update: mockUpdate,
     });
 
     mockConnection = {
@@ -36,213 +39,224 @@ describe("Debug Levels", () => {
     } as any;
   });
 
+  const allDefaults = {
+    ApexCode: "FINE",
+    ApexProfiling: "FINE",
+    Callout: "DEBUG",
+    Database: "FINEST",
+    Nba: "INFO",
+    System: "DEBUG",
+    Validation: "DEBUG",
+    Visualforce: "FINE",
+    Wave: "INFO",
+    Workflow: "FINE",
+  };
+
   describe("getOrCreateDebugLevelId", () => {
-    it("should return existing debug level ID when one exists", async () => {
-      mockQuery.mockResolvedValue({
-        records: [
-          {
-            Id: testId,
-            DeveloperName: "ExistingDebugLevel",
-            ApexCode: "FINEST",
-            ApexProfiling: "FINEST",
-            Database: "FINEST",
-          },
-        ],
+    describe("when no debug level exists", () => {
+      beforeEach(() => {
+        mockQuery.mockResolvedValue({ records: [] });
+        mockCreate.mockResolvedValue({ success: true, id: testId });
       });
 
-      const result = await getOrCreateDebugLevelId(mockConnection);
+      it("should create with all defaults when debugLevel is undefined", async () => {
+        const result = await getOrCreateDebugLevelId(mockConnection);
 
-      expect(result).toBe(testId);
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "SELECT Id, DeveloperName, ApexCode, ApexProfiling, Database"
-        )
-      );
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining("FROM DebugLevel")
-      );
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining("WHERE ApexCode = 'FINEST'")
-      );
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining("AND ApexProfiling = 'FINEST'")
-      );
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining("AND Database = 'FINEST'")
-      );
-      expect(mockCreate).not.toHaveBeenCalled();
+        expect(result).toBe(testId);
+        expect(mockCreate).toHaveBeenCalledWith({
+          DeveloperName: "LANA_MCP_Debug_Level",
+          MasterLabel: "LANA_MCP_Debug_Level",
+          ...allDefaults,
+        });
+      });
+
+      it('should create with all defaults when debugLevel is "default"', async () => {
+        const result = await getOrCreateDebugLevelId(mockConnection, "default");
+
+        expect(result).toBe(testId);
+        expect(mockCreate).toHaveBeenCalledWith({
+          DeveloperName: "LANA_MCP_Debug_Level",
+          MasterLabel: "LANA_MCP_Debug_Level",
+          ...allDefaults,
+        });
+      });
+
+      it("should create with defaults merged with overrides", async () => {
+        const result = await getOrCreateDebugLevelId(mockConnection, {
+          apexCode: "FINEST",
+          nba: "FINEST",
+        });
+
+        expect(result).toBe(testId);
+        expect(mockCreate).toHaveBeenCalledWith({
+          DeveloperName: "LANA_MCP_Debug_Level",
+          MasterLabel: "LANA_MCP_Debug_Level",
+          ...allDefaults,
+          ApexCode: "FINEST",
+          Nba: "FINEST",
+        });
+      });
+
+      it("should create with all categories at specified level when debugLevel is a log level string", async () => {
+        const result = await getOrCreateDebugLevelId(mockConnection, "FINEST");
+
+        expect(result).toBe(testId);
+        const createArg = mockCreate.mock.calls[0][0];
+        expect(createArg.ApexCode).toBe("FINEST");
+        expect(createArg.ApexProfiling).toBe("FINEST");
+        expect(createArg.Callout).toBe("FINEST");
+        expect(createArg.Database).toBe("FINEST");
+        expect(createArg.Nba).toBe("FINEST");
+        expect(createArg.System).toBe("FINEST");
+        expect(createArg.Validation).toBe("FINEST");
+        expect(createArg.Visualforce).toBe("FINEST");
+        expect(createArg.Wave).toBe("FINEST");
+        expect(createArg.Workflow).toBe("FINEST");
+      });
+
+      it("should create when existing record has null Id", async () => {
+        mockQuery.mockResolvedValue({ records: [{ Id: null }] });
+
+        const result = await getOrCreateDebugLevelId(mockConnection);
+
+        expect(result).toBe(testId);
+        expect(mockCreate).toHaveBeenCalled();
+      });
     });
 
-    it("should create new debug level when none exists", async () => {
-      mockQuery.mockResolvedValue({
-        records: [],
+    describe("when debug level already exists", () => {
+      beforeEach(() => {
+        mockQuery.mockResolvedValue({ records: [{ Id: testId }] });
+        mockUpdate.mockResolvedValue({ success: true });
       });
 
-      mockCreate.mockResolvedValue({
-        success: true,
-        id: testId,
+      it("should not update when debugLevel is undefined", async () => {
+        const result = await getOrCreateDebugLevelId(mockConnection);
+
+        expect(result).toBe(testId);
+        expect(mockUpdate).not.toHaveBeenCalled();
+        expect(mockCreate).not.toHaveBeenCalled();
       });
 
-      const result = await getOrCreateDebugLevelId(mockConnection);
+      it('should update all categories to defaults when debugLevel is "default"', async () => {
+        const result = await getOrCreateDebugLevelId(mockConnection, "default");
 
-      expect(result).toBe(testId);
-      expect(mockQuery).toHaveBeenCalled();
-      expect(mockSobject).toHaveBeenCalledWith("DebugLevel");
-      expect(mockCreate).toHaveBeenCalledWith({
-        DeveloperName: "LANA_MCP_Debug_Level",
-        MasterLabel: "LANA_MCP_Debug_Level",
-        ApexCode: "FINEST",
-        ApexProfiling: "FINEST",
-        Callout: "FINEST",
-        Database: "FINEST",
-        System: "DEBUG",
-        Validation: "INFO",
-        Visualforce: "INFO",
-        Workflow: "INFO",
+        expect(result).toBe(testId);
+        expect(mockUpdate).toHaveBeenCalledWith({
+          Id: testId,
+          ...allDefaults,
+        });
+      });
+
+      it("should only update specified categories", async () => {
+        const result = await getOrCreateDebugLevelId(mockConnection, {
+          apexCode: "FINEST",
+        });
+
+        expect(result).toBe(testId);
+        expect(mockUpdate).toHaveBeenCalledWith({
+          Id: testId,
+          ApexCode: "FINEST",
+        });
+      });
+
+      it("should update all categories to specified level when debugLevel is a log level string", async () => {
+        const result = await getOrCreateDebugLevelId(mockConnection, "FINEST");
+
+        expect(result).toBe(testId);
+        const updateArg = mockUpdate.mock.calls[0][0];
+        expect(updateArg.ApexCode).toBe("FINEST");
+        expect(updateArg.ApexProfiling).toBe("FINEST");
+        expect(updateArg.Callout).toBe("FINEST");
+        expect(updateArg.Database).toBe("FINEST");
+        expect(updateArg.Nba).toBe("FINEST");
+        expect(updateArg.System).toBe("FINEST");
+        expect(updateArg.Validation).toBe("FINEST");
+        expect(updateArg.Visualforce).toBe("FINEST");
+        expect(updateArg.Wave).toBe("FINEST");
+        expect(updateArg.Workflow).toBe("FINEST");
+      });
+
+      it("should update multiple specified categories", async () => {
+        const result = await getOrCreateDebugLevelId(mockConnection, {
+          apexCode: "FINEST",
+          database: "NONE",
+          nba: "FINE",
+        });
+
+        expect(result).toBe(testId);
+        expect(mockUpdate).toHaveBeenCalledWith({
+          Id: testId,
+          ApexCode: "FINEST",
+          Database: "NONE",
+          Nba: "FINE",
+        });
       });
     });
 
-    it("should handle case when existing debug level ID is null", async () => {
-      mockQuery.mockResolvedValue({
-        records: [
-          {
-            Id: null,
-            DeveloperName: "SomeDebugLevel",
-          },
-        ],
+    describe("query behavior", () => {
+      it("should query by DeveloperName with LIMIT 1", async () => {
+        mockQuery.mockResolvedValue({ records: [{ Id: testId }] });
+        mockUpdate.mockResolvedValue({ success: true });
+
+        await getOrCreateDebugLevelId(mockConnection);
+
+        const query = mockQuery.mock.calls[0][0] as string;
+        expect(query).toContain("WHERE DeveloperName = 'LANA_MCP_Debug_Level'");
+        expect(query).toContain("LIMIT 1");
       });
-
-      mockCreate.mockResolvedValue({
-        success: true,
-        id: testId,
-      });
-
-      const result = await getOrCreateDebugLevelId(mockConnection);
-
-      expect(result).toBe(testId);
-      expect(mockCreate).toHaveBeenCalled();
     });
 
-    it("should throw error when debug level creation fails", async () => {
-      mockQuery.mockResolvedValue({
-        records: [],
+    describe("error handling", () => {
+      it("should throw error when creation fails", async () => {
+        mockQuery.mockResolvedValue({ records: [] });
+        mockCreate.mockResolvedValue({
+          success: false,
+          errors: ["Creation failed"],
+        });
+
+        await expect(getOrCreateDebugLevelId(mockConnection)).rejects.toThrow(
+          "Failed to create DebugLevel",
+        );
       });
 
-      mockCreate.mockResolvedValue({
-        success: false,
-        errors: ["Creation failed"],
+      it("should throw error when creation returns no ID", async () => {
+        mockQuery.mockResolvedValue({ records: [] });
+        mockCreate.mockResolvedValue({ success: true, id: null });
+
+        await expect(getOrCreateDebugLevelId(mockConnection)).rejects.toThrow(
+          "Failed to create DebugLevel",
+        );
       });
 
-      await expect(getOrCreateDebugLevelId(mockConnection)).rejects.toThrow(
-        "Failed to create DebugLevel"
-      );
-    });
+      it("should throw error when update fails", async () => {
+        mockQuery.mockResolvedValue({ records: [{ Id: testId }] });
+        mockUpdate.mockResolvedValue({
+          success: false,
+          errors: ["Update failed"],
+        });
 
-    it("should throw error when debug level creation returns no ID", async () => {
-      mockQuery.mockResolvedValue({
-        records: [],
+        await expect(
+          getOrCreateDebugLevelId(mockConnection, "default"),
+        ).rejects.toThrow("Failed to update DebugLevel");
       });
 
-      mockCreate.mockResolvedValue({
-        success: true,
-        id: null,
+      it("should propagate query errors", async () => {
+        mockQuery.mockRejectedValue(new Error("Query failed"));
+
+        await expect(getOrCreateDebugLevelId(mockConnection)).rejects.toThrow(
+          "Query failed",
+        );
       });
 
-      await expect(getOrCreateDebugLevelId(mockConnection)).rejects.toThrow(
-        "Failed to create DebugLevel"
-      );
-    });
+      it("should propagate creation errors", async () => {
+        mockQuery.mockResolvedValue({ records: [] });
+        mockCreate.mockRejectedValue(new Error("Creation failed"));
 
-    it("should handle query errors gracefully", async () => {
-      const queryError = new Error("Query failed");
-      mockQuery.mockRejectedValue(queryError);
-
-      await expect(getOrCreateDebugLevelId(mockConnection)).rejects.toThrow(
-        "Query failed"
-      );
-    });
-
-    it("should handle creation errors gracefully", async () => {
-      mockQuery.mockResolvedValue({
-        records: [],
+        await expect(getOrCreateDebugLevelId(mockConnection)).rejects.toThrow(
+          "Creation failed",
+        );
       });
-
-      const createError = new Error("Creation failed");
-      mockCreate.mockRejectedValue(createError);
-
-      await expect(getOrCreateDebugLevelId(mockConnection)).rejects.toThrow(
-        "Creation failed"
-      );
-    });
-
-    it("should query with LIMIT 1 for efficiency", async () => {
-      mockQuery.mockResolvedValue({
-        records: [
-          {
-            Id: testId,
-            DeveloperName: "Test",
-            ApexCode: "FINEST",
-            ApexProfiling: "FINEST",
-            Database: "FINEST",
-          },
-        ],
-      });
-
-      await getOrCreateDebugLevelId(mockConnection);
-
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining("LIMIT 1")
-      );
-    });
-
-    it("should find debug level with all required log levels set to FINEST", async () => {
-      mockQuery.mockResolvedValue({
-        records: [
-          {
-            Id: testId,
-            DeveloperName: "LANA_MCP_Debug_Level",
-            ApexCode: "FINEST",
-            ApexProfiling: "FINEST",
-            Database: "FINEST",
-          },
-        ],
-      });
-
-      const result = await getOrCreateDebugLevelId(mockConnection);
-
-      expect(result).toBe(testId);
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringMatching(/ApexCode = 'FINEST'/)
-      );
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringMatching(/ApexProfiling = 'FINEST'/)
-      );
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringMatching(/Database = 'FINEST'/)
-      );
-    });
-
-    it("should create debug level with correct log levels", async () => {
-      mockQuery.mockResolvedValue({
-        records: [],
-      });
-
-      mockCreate.mockResolvedValue({
-        success: true,
-        id: testId,
-      });
-
-      await getOrCreateDebugLevelId(mockConnection);
-
-      const createCall = mockCreate.mock.calls[0][0];
-      expect(createCall.ApexCode).toBe("FINEST");
-      expect(createCall.ApexProfiling).toBe("FINEST");
-      expect(createCall.Callout).toBe("FINEST");
-      expect(createCall.Database).toBe("FINEST");
-      expect(createCall.System).toBe("DEBUG");
-      expect(createCall.Validation).toBe("INFO");
-      expect(createCall.Visualforce).toBe("INFO");
-      expect(createCall.Workflow).toBe("INFO");
     });
   });
 });

--- a/tests/salesforce/debugLevels.test.ts
+++ b/tests/salesforce/debugLevels.test.ts
@@ -64,8 +64,8 @@ describe("Debug Levels", () => {
 
         expect(result).toBe(testId);
         expect(mockCreate).toHaveBeenCalledWith({
-          DeveloperName: "LANA_MCP_Debug_Level",
-          MasterLabel: "LANA_MCP_Debug_Level",
+          DeveloperName: "Apex_Log_MCP_Debug_Level",
+          MasterLabel: "Apex_Log_MCP_Debug_Level",
           ...allDefaults,
         });
       });
@@ -75,8 +75,8 @@ describe("Debug Levels", () => {
 
         expect(result).toBe(testId);
         expect(mockCreate).toHaveBeenCalledWith({
-          DeveloperName: "LANA_MCP_Debug_Level",
-          MasterLabel: "LANA_MCP_Debug_Level",
+          DeveloperName: "Apex_Log_MCP_Debug_Level",
+          MasterLabel: "Apex_Log_MCP_Debug_Level",
           ...allDefaults,
         });
       });
@@ -89,8 +89,8 @@ describe("Debug Levels", () => {
 
         expect(result).toBe(testId);
         expect(mockCreate).toHaveBeenCalledWith({
-          DeveloperName: "LANA_MCP_Debug_Level",
-          MasterLabel: "LANA_MCP_Debug_Level",
+          DeveloperName: "Apex_Log_MCP_Debug_Level",
+          MasterLabel: "Apex_Log_MCP_Debug_Level",
           ...allDefaults,
           ApexCode: "FINEST",
           Nba: "FINEST",
@@ -202,7 +202,9 @@ describe("Debug Levels", () => {
         await getOrCreateDebugLevelId(mockConnection);
 
         const query = mockQuery.mock.calls[0][0] as string;
-        expect(query).toContain("WHERE DeveloperName = 'LANA_MCP_Debug_Level'");
+        expect(query).toContain(
+          "WHERE DeveloperName = 'Apex_Log_MCP_Debug_Level'",
+        );
         expect(query).toContain("LIMIT 1");
       });
     });


### PR DESCRIPTION
## Summary

- Add a `debugLevel` parameter to `execute_anonymous` allowing full control over Salesforce trace flag log levels
- All 10 DebugLevel categories are configurable: apexCode, apexProfiling, callout, database, nba, system, validation, visualforce, wave, workflow
- Three input modes for flexibility:
  - **Omit** — keep existing config untouched
  - **Log level string** (e.g. `"FINEST"`) — set all categories to that level
  - **`"default"`** — reset all categories to defaults
  - **Object** (e.g. `{ apexCode: "FINEST" }`) — override only specified categories, leave others unchanged
- Rework `debugLevels.ts` to find-by-name + upsert pattern (query by `DeveloperName`, update if exists, create if not)
- Rename debug level from `LANA_MCP_Debug_Level` to `Apex_Log_MCP_Debug_Level`
- Update CLAUDE.md to use `pnpm` instead of `npm`

## Test plan

- [x] All new and existing `debugLevels.test.ts` tests pass (15 tests covering create/update/error paths and all input modes)
- [x] All `executeAnonymous.test.ts` tests pass (19 tests)
- [x] TypeScript build passes cleanly
- [x] Manual test: call `execute_anonymous` without `debugLevel` — verify existing trace flag is not modified
- [x] Manual test: call with `debugLevel: "FINEST"` — verify all categories set to FINEST in the org
- [x] Manual test: call with `debugLevel: { database: "NONE" }` — verify only database is changed
- [x] Manual test: call with `debugLevel: "default"` — verify all categories reset to defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)