### PR TITLE
chore: speed up CI and harden publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  verify_files:
-    name: Verify Files
+  ci:
+    name: Lint, Test & Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -25,21 +23,7 @@ jobs:
         run: HUSKY=0 pnpm install
       - name: Lint Files
         run: pnpm run lint
-
-  tests:
-    name: Run Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-      - name: Install Packages
-        run: HUSKY=0 pnpm install
+      - name: Build
+        run: pnpm run build
       - name: Tests
         run: pnpm run test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -23,8 +21,14 @@ jobs:
       - name: Dependencies
         run: HUSKY=0 pnpm install
 
+      - name: Lint Files
+        run: pnpm run lint
+
       - name: Build
         run: pnpm run build
+
+      - name: Tests
+        run: pnpm run test
 
       - name: Configure NPM
         run: |
@@ -36,7 +40,7 @@ jobs:
           NPM_KEY: ${{ secrets.ARTIFACTORY_MTLS_KEY_BASE64 }}
 
       - name: Publish
-        run: npm publish --registry ${{ secrets.REGISTRY_URL }}
+        run: pnpm publish --registry ${{ secrets.REGISTRY_URL }} --no-git-checks
         env:
           REGISTRY_BASE_URL: ${{ secrets.REGISTRY_BASE_URL }}
           REGISTRY_AUTH: ${{ secrets.REGISTRY_AUTH }}

--- a/package.json
+++ b/package.json
@@ -79,5 +79,6 @@
   },
   "engines": {
     "node": ">=18.0.0"
-  }
+  },
+  "packageManager": "pnpm@10.30.2"
 }


### PR DESCRIPTION
## Summary

- **Merge CI jobs** — Combine `verify_files` and `tests` into a single `ci` job, eliminating duplicate runner provisioning and dependency installation (~30-60s saved per run)
- **Add build step to CI** — Run `pnpm run build` in CI to catch TypeScript compilation errors before merge
- **Pin pnpm version** — Add `packageManager` field to `package.json` (`pnpm@10.30.2`) so `pnpm/action-setup` auto-detects the version, improving cache reliability
- **Add lint/test to publish workflow** — Run lint, build, and test before publishing to prevent broken releases
- **Use `pnpm publish`** — Replace `npm publish` with `pnpm publish --no-git-checks` for consistency with the pnpm toolchain

## Test plan

- [ ] CI workflow runs successfully with the merged job (lint, build, test all pass)
- [ ] Verify `pnpm/action-setup` picks up the version from `packageManager` field (no `version:` needed in workflow)
- [ ] Publish workflow includes lint/test steps before build/publish