### PR TITLE
refactor: rename LANA MCP Server to Apex Log MCP Server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is the LANA MCP Server - a Model Context Protocol (MCP) server for Apex Log Analysis. It provides AI agents with tools to analyze Salesforce Apex debug logs for performance bottlenecks and optimization opportunities.
+This is the Apex Log MCP Server - a Model Context Protocol (MCP) server for Apex Log Analysis. It provides AI agents with tools to analyze Salesforce Apex debug logs for performance bottlenecks and optimization opportunities.
 
 ## Development Commands
 
@@ -26,7 +26,7 @@ npm start
 
 ### Core Components
 
-- **src/index.ts**: Main MCP server implementation (`LanaServer` class)
+- **src/index.ts**: Main MCP server implementation (`ApexLogServer` class)
   - Implements 4 MCP tools: `analyze_apex_log_performance`, `get_apex_log_summary`, `find_performance_bottlenecks`, `execute_anonymous`
   - Uses stdio transport for communication
   - Handles file validation, log parsing, analysis, and anonymous Apex execution
@@ -45,7 +45,8 @@ npm start
 
 ### MCP Integration
 
-This server is designed to integrate with the LANA VS Code extension:
+This server is designed to integrate with the Apex Log Analyzer VS Code extension:
+
 - Registered automatically by the extension
 - Communicates via MCP protocol over stdio
 - Provides structured JSON responses for AI analysis

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# 🤝 Contributing to LANA MCP Server
+# 🤝 Contributing to Apex Log MCP Server
 
 🎉🥳 Thank you for contributing! 🥳🎉
 
-We truly appreciate your help in making LANA MCP Server better. Whether you're fixing a bug, adding a feature, or improving documentation, your contributions are invaluable to us!
+We truly appreciate your help in making Apex Log MCP Server better. Whether you're fixing a bug, adding a feature, or improving documentation, your contributions are invaluable to us!
 
 Before you dive in, please make sure to review our [code of conduct](https://github.com/certinia/debug-log-analyzer-mcp/blob/main/CODE_OF_CONDUCT.md) to ensure a welcoming environment for everyone.
 
@@ -56,4 +56,4 @@ Please verify the following before opening a PR:
 
 If you get stuck at any point, feel free to open an issue or reach out to us in the discussions tab. We’re here to help and we want to make your contribution experience as smooth as possible. 🤗
 
-Thank you again for contributing to **LANA MCP Server**! Your input helps make this tool even better for Salesforce developers. 🙌
+Thank you again for contributing to **Apex Log MCP Server**! Your input helps make this tool even better for Salesforce developers. 🙌

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,6 +1,6 @@
-# 🛠️ Developing the LANA MCP Server
+# 🛠️ Developing the Apex Log MCP Server
 
-Welcome to the development guide for the **LANA MCP Server**. This document will walk you through the steps required to get started with the development environment, run the server locally, and contribute to the project.
+Welcome to the development guide for the **Apex Log MCP Server**. This document will walk you through the steps required to get started with the development environment, run the server locally, and contribute to the project.
 
 - The source code is written in [TypeScript](https://www.typescriptlang.org/).
 - The tools directory contains the source code for the functionality available on the server.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# 🛠️ LANA MCP Server
+# 🛠️ Apex Log MCP Server
 
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue)](https://www.typescriptlang.org/)
 
-Supercharge Salesforce Apex debugging with AI-powered log analysis. LANA MCP Server gives AI assistants like Claude and Copilot the ability to identify performance bottlenecks, slow methods, and optimization opportunities in your debug logs - insights that would take hours to find manually.
+Supercharge Salesforce Apex debugging with AI-powered log analysis. Apex Log MCP Server gives AI assistants like Claude and Copilot the ability to identify performance bottlenecks, slow methods, and optimization opportunities in your debug logs - insights that would take hours to find manually.
 
 [Features](#-features "Go to Features") |
 [Usage](#-usage "Go to usage guidelines") |
@@ -20,7 +20,7 @@ Supercharge Salesforce Apex debugging with AI-powered log analysis. LANA MCP Ser
 - **analyze_apex_log_performance** - Identify the slowest methods in your Apex execution with detailed timing metrics
 - **get_apex_log_summary** - Get high-level statistics on execution time, method counts, and governor limits
 - **find_performance_bottlenecks** - Find CPU, database, and method performance issues categorized by type
-- **execute_anonymous** - Run Apex code and immediately analyze the resulting debug log
+- **execute_anonymous** - Run Apex code against any Salesforce org and immediately analyze the resulting debug log
 
 ## 💡 Usage
 
@@ -86,18 +86,20 @@ Detects and categorizes performance issues by type (CPU, database, or method pat
 
 ### execute_anonymous
 
-Executes anonymous Apex code and retrieves the resulting debug log for analysis.
+Executes anonymous Apex code against any Salesforce org and retrieves the resulting debug log for analysis.
 
-| Parameter | Type   | Required | Description                    |
-| --------- | ------ | -------- | ------------------------------ |
-| `apex`    | string | Yes      | Anonymous Apex code to execute |
+| Parameter   | Type   | Required | Description                                                                                |
+| ----------- | ------ | -------- | ------------------------------------------------------------------------------------------ |
+| `apex`      | string | Yes      | Anonymous Apex code to execute                                                             |
+| `targetOrg` | string | No       | Alias or username of the target Salesforce org. Uses the project default if not specified. |
 
 **Example prompts:**
 
 - "Execute this Apex and show me the log: `System.debug('Hello');`"
 - "Run a query for all Accounts and analyze the performance"
+- "Run this Apex against my QA org"
 
-**Note:** Requires a default Salesforce org configured via Salesforce CLI.
+**Note:** Requires Salesforce CLI. Uses the project's default org unless `targetOrg` is specified.
 
 ## Configuration
 
@@ -106,9 +108,9 @@ Add to your `claude_desktop_config.json` or `mcp.json`:
 ```json
 {
   "mcpServers": {
-    "lana-mcp": {
+    "apex-log-mcp": {
       "command": "npx",
-      "args": ["@certinia/lana-mcp"]
+      "args": ["@certinia/apex-log-mcp"]
     }
   }
 }
@@ -134,7 +136,7 @@ We welcome contributions! Please see our [Contributing Guide](https://github.com
 ### 🏗️ Architecture
 
 - Built with TypeScript and the MCP SDK
-- Uses the same `ApexLogParser` as the main LANA extension
+- Uses the same `ApexLogParser` as the Apex Log Analyzer VS Code extension
 - Runs as a standalone Node.js process
 - Communicates via stdio transport
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@certinia/lana-mcp",
-  "version": "0.2.0",
-  "description": "Apex debug log analyzer MCP tools for Salesforce.",
+  "name": "@certinia/apex-log-mcp",
+  "version": "0.1.0",
+  "description": "MCP server for analyzing Salesforce Apex debug logs.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "lana-mcp-server": "dist/index.js"
+    "apex-log-mcp": "dist/index.js"
   },
   "files": [
     "dist/**/*.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,13 +34,13 @@ function parseArgs<T>(args: Record<string, unknown> | undefined): T {
   return (args ?? {}) as T;
 }
 
-class LanaServer {
+class ApexLogServer {
   private server: Server;
 
   constructor() {
     this.server = new Server(
       {
-        name: "lana-mcp-server",
+        name: "apex-log-mcp",
         version: "1.0.0",
       },
       {
@@ -117,12 +117,12 @@ class LanaServer {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
 
-    console.error("LANA MCP Server running on stdio");
+    console.error("Apex Log MCP Server running on stdio");
   }
 }
 
-const server = new LanaServer();
+const server = new ApexLogServer();
 
 server.run().catch(console.error);
 
-export { LanaServer };
+export { ApexLogServer };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -21,7 +21,7 @@ import {
 jest.mock("@modelcontextprotocol/sdk/server/index.js");
 jest.mock("@modelcontextprotocol/sdk/server/stdio.js");
 
-import { LanaServer } from "../src/index";
+import { ApexLogServer } from "../src/index";
 
 // Mock the tool modules
 jest.mock("../src/tools/analyzeLogPerformance", () => ({
@@ -131,7 +131,7 @@ const mockConsoleError = jest
   .spyOn(console, "error")
   .mockImplementation(() => {});
 
-describe("LanaServer", () => {
+describe("ApexLogServer", () => {
   let mockServer: jest.Mocked<Server>;
   let mockTransport: jest.Mocked<StdioServerTransport>;
   let mockSetRequestHandler: jest.MockedFunction<
@@ -244,11 +244,11 @@ describe("LanaServer", () => {
 
   describe("Server Initialization", () => {
     it("should create server with correct configuration", async () => {
-      new LanaServer();
+      new ApexLogServer();
 
       expect(Server).toHaveBeenCalledWith(
         {
-          name: "lana-mcp-server",
+          name: "apex-log-mcp",
           version: "1.0.0",
         },
         {
@@ -260,7 +260,7 @@ describe("LanaServer", () => {
     });
 
     it("should setup error handling", async () => {
-      new LanaServer();
+      new ApexLogServer();
 
       expect(mockServer.onerror).toBeDefined();
 
@@ -276,7 +276,7 @@ describe("LanaServer", () => {
     it("should setup SIGINT handler", async () => {
       const mockProcessOnce = jest.spyOn(process, "once");
 
-      new LanaServer();
+      new ApexLogServer();
 
       expect(mockProcessOnce).toHaveBeenCalledWith(
         "SIGINT",
@@ -287,7 +287,7 @@ describe("LanaServer", () => {
 
   describe("Tool Registration", () => {
     it("should register ListToolsRequest handler", async () => {
-      new LanaServer();
+      new ApexLogServer();
 
       expect(mockSetRequestHandler).toHaveBeenCalledWith(
         ListToolsRequestSchema,
@@ -296,7 +296,7 @@ describe("LanaServer", () => {
     });
 
     it("should register CallToolRequest handler", async () => {
-      new LanaServer();
+      new ApexLogServer();
 
       expect(mockSetRequestHandler).toHaveBeenCalledWith(
         CallToolRequestSchema,
@@ -305,7 +305,7 @@ describe("LanaServer", () => {
     });
 
     it("should return correct tools list when ListToolsRequest is called", async () => {
-      new LanaServer();
+      new ApexLogServer();
 
       // Get the ListToolsRequest handler
       const listToolsCall = mockSetRequestHandler.mock.calls.find(
@@ -331,7 +331,7 @@ describe("LanaServer", () => {
     let callToolHandler: (request: any, extra: any) => Promise<any>;
 
     beforeEach(async () => {
-      new LanaServer();
+      new ApexLogServer();
 
       // Get the CallToolRequest handler
       const callToolCall = mockSetRequestHandler.mock.calls.find(
@@ -482,18 +482,18 @@ describe("LanaServer", () => {
 
   describe("Server Lifecycle", () => {
     it("should start server correctly", async () => {
-      const lanaServer = new LanaServer();
+      const lanaServer = new ApexLogServer();
       await lanaServer.run();
 
       expect(StdioServerTransport).toHaveBeenCalled();
       expect(mockConnect).toHaveBeenCalledWith(mockTransport);
       expect(mockConsoleError).toHaveBeenCalledWith(
-        "LANA MCP Server running on stdio",
+        "Apex Log MCP Server running on stdio",
       );
     });
 
     it("should connect to stdio transport", async () => {
-      const lanaServer = new LanaServer();
+      const lanaServer = new ApexLogServer();
       await lanaServer.run();
 
       expect(StdioServerTransport).toHaveBeenCalled();
@@ -501,7 +501,7 @@ describe("LanaServer", () => {
     });
 
     it("should handle SIGINT and close server", async () => {
-      new LanaServer();
+      new ApexLogServer();
 
       // Find the SIGINT handler
       const processOnceCalls = jest.spyOn(process, "once").mock.calls;
@@ -527,7 +527,7 @@ describe("LanaServer", () => {
 
   describe("Integration Tests", () => {
     it("should handle complete workflow for analyze_apex_log_performance", async () => {
-      new LanaServer();
+      new ApexLogServer();
 
       // Get handlers
       const listToolsCall = mockSetRequestHandler.mock.calls.find(
@@ -567,7 +567,7 @@ describe("LanaServer", () => {
     });
 
     it("should handle edge cases with malformed requests", async () => {
-      new LanaServer();
+      new ApexLogServer();
 
       const callToolCall = mockSetRequestHandler.mock.calls.find(
         (call: any) => call[0] === CallToolRequestSchema,
@@ -596,7 +596,7 @@ describe("LanaServer", () => {
 
   describe("Type Safety", () => {
     it("should handle typed arguments correctly", async () => {
-      new LanaServer();
+      new ApexLogServer();
 
       const callToolCall = mockSetRequestHandler.mock.calls.find(
         (call: any) => call[0] === CallToolRequestSchema,


### PR DESCRIPTION
## Summary
- Renames all references from "LANA MCP Server" to "Apex Log MCP Server" across documentation and codebase
- Updates package name, server class name, and test references to reflect the new project identity
- Affects README, CLAUDE.md, CONTRIBUTING.md, DEVELOPING.md, package.json, src/index.ts, and tests

## Test plan
- [x] Verify all documentation references updated consistently
- [x] Verify server class and package name updated
- [x] Verify tests reference the new name
