### PR TITLE
build: replace ts-jest with @swc/jest for faster test execution

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,18 @@
 export default {
-  preset: "ts-jest",
   testEnvironment: "node",
   roots: ["<rootDir>/src", "<rootDir>/tests"],
   testMatch: ["**/*.test.ts"],
   transform: {
-    "^.+\\.ts$": "ts-jest",
+    "^.+\\.ts$": [
+      "@swc/jest",
+      {
+        jsc: {
+          parser: { syntax: "typescript", decorators: true },
+          target: "es2022",
+        },
+        module: { type: "commonjs" },
+      },
+    ],
   },
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
-    "@jest/globals": "^30.2.0",
+    "@swc/core": "^1.15.18",
+    "@swc/jest": "^0.2.39",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.16.3",
     "@typescript-eslint/eslint-plugin": "^8.44.0",
@@ -72,8 +73,6 @@
     "eslint": "^9.39.1",
     "eslint-plugin-headers": "^1.3.3",
     "jest": "^30.1.3",
-    "ts-jest": "^29.4.4",
-    "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.44.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,9 +21,12 @@ importers:
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.1
-      '@jest/globals':
-        specifier: ^30.2.0
-        version: 30.2.0
+      '@swc/core':
+        specifier: ^1.15.18
+        version: 1.15.18
+      '@swc/jest':
+        specifier: ^0.2.39
+        version: 0.2.39(@swc/core@1.15.18)
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -44,13 +47,7 @@ importers:
         version: 1.3.3(eslint@9.39.1)
       jest:
         specifier: ^30.1.3
-        version: 30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@types/node@22.19.0)(typescript@5.9.3))
-      ts-jest:
-        specifier: ^29.4.4
-        version: 29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@types/node@22.19.0)(typescript@5.9.3)))(typescript@5.9.3)
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.0)(typescript@5.9.3)
+        version: 30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.0)(typescript@5.9.3))
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -323,6 +320,10 @@ packages:
       node-notifier:
         optional: true
 
+  '@jest/create-cache-key-function@30.2.0':
+    resolution: {integrity: sha512-44F4l4Enf+MirJN8X/NhdGkl71k5rBYiwdVlo4HxOwbu0sHV8QKrGEedb1VUU4K3W7fBKE0HGfbn7eZm0Ti3zg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   '@jest/diff-sequences@30.0.1':
     resolution: {integrity: sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -515,6 +516,91 @@ packages:
   '@sinonjs/fake-timers@13.0.5':
     resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
 
+  '@swc/core-darwin-arm64@1.15.18':
+    resolution: {integrity: sha512-+mIv7uBuSaywN3C9LNuWaX1jJJ3SKfiJuE6Lr3bd+/1Iv8oMU7oLBjYMluX1UrEPzwN2qCdY6Io0yVicABoCwQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.18':
+    resolution: {integrity: sha512-wZle0eaQhnzxWX5V/2kEOI6Z9vl/lTFEC6V4EWcn+5pDjhemCpQv9e/TDJ0GIoiClX8EDWRvuZwh+Z3dhL1NAg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.18':
+    resolution: {integrity: sha512-ao61HGXVqrJFHAcPtF4/DegmwEkVCo4HApnotLU8ognfmU8x589z7+tcf3hU+qBiU1WOXV5fQX6W9Nzs6hjxDw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.18':
+    resolution: {integrity: sha512-3xnctOBLIq3kj8PxOCgPrGjBLP/kNOddr6f5gukYt/1IZxsITQaU9TDyjeX6jG+FiCIHjCuWuffsyQDL5Ew1bg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-arm64-musl@1.15.18':
+    resolution: {integrity: sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@swc/core-linux-x64-gnu@1.15.18':
+    resolution: {integrity: sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-musl@1.15.18':
+    resolution: {integrity: sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@swc/core-win32-arm64-msvc@1.15.18':
+    resolution: {integrity: sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.18':
+    resolution: {integrity: sha512-yVuTrZ0RccD5+PEkpcLOBAuPbYBXS6rslENvIXfvJGXSdX5QGi1ehC4BjAMl5FkKLiam4kJECUI0l7Hq7T1vwg==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.18':
+    resolution: {integrity: sha512-7NRmE4hmUQNCbYU3Hn9Tz57mK9Qq4c97ZS+YlamlK6qG9Fb5g/BB3gPDe0iLlJkns/sYv2VWSkm8c3NmbEGjbg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.18':
+    resolution: {integrity: sha512-z87aF9GphWp//fnkRsqvtY+inMVPgYW3zSlXH1kJFvRT5H/wiAn+G32qW5l3oEk63KSF1x3Ov0BfHCObAmT8RA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/jest@0.2.39':
+    resolution: {integrity: sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA==}
+    engines: {npm: '>= 7.0.0'}
+    peerDependencies:
+      '@swc/core': '*'
+
+  '@swc/types@0.1.25':
+    resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
+
   '@toon-format/toon@1.0.0':
     resolution: {integrity: sha512-2gIk8LaqrzpurNDaDWZ72kucAGcBbxJxUnp+4ZP+Pny/QVNdMVf97yzSDTI3ed2q8ypjj8T271P6iE3bRmQBNw==}
 
@@ -676,41 +762,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -876,10 +970,6 @@ packages:
     resolution: {integrity: sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  bs-logger@0.2.6:
-    resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
-    engines: {node: '>= 6'}
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
@@ -1384,11 +1474,6 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
-    engines: {node: '>=0.4.7'}
-    hasBin: true
-
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1719,6 +1804,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   jsonwebtoken@9.0.2:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
     engines: {node: '>=12', npm: '>=6'}
@@ -1774,9 +1862,6 @@ packages:
 
   lodash.isstring@4.0.1:
     resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
-
-  lodash.memoize@4.1.2:
-    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -1880,9 +1965,6 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
-
-  neo-async@2.6.2:
-    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
@@ -2361,33 +2443,6 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
-  ts-jest@29.4.5:
-    resolution: {integrity: sha512-HO3GyiWn2qvTQA4kTgjDcXiMwYQt68a1Y8+JuLRVpdIzm+UOLSHgl/XqR4c6nzJkq5rOkjc02O2I7P7l/Yof0Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/transform': ^29.0.0 || ^30.0.0
-      '@jest/types': ^29.0.0 || ^30.0.0
-      babel-jest: ^29.0.0 || ^30.0.0
-      esbuild: '*'
-      jest: ^29.0.0 || ^30.0.0
-      jest-util: ^29.0.0 || ^30.0.0
-      typescript: '>=4.3 <6'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/transform':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-      jest-util:
-        optional: true
-
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
@@ -2424,10 +2479,6 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
-  type-fest@4.41.0:
-    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
-    engines: {node: '>=16'}
-
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
@@ -2442,11 +2493,6 @@ packages:
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
-    hasBin: true
-
-  uglify-js@3.19.3:
-    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
-    engines: {node: '>=0.8.0'}
     hasBin: true
 
   undici-types@6.21.0:
@@ -2513,9 +2559,6 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
-
-  wordwrap@1.0.0:
-    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -2768,6 +2811,7 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+    optional: true
 
   '@emnapi/core@1.7.0':
     dependencies:
@@ -2874,7 +2918,7 @@ snapshots:
       jest-util: 30.2.0
       slash: 3.0.0
 
-  '@jest/core@30.2.0(ts-node@10.9.2(@types/node@22.19.0)(typescript@5.9.3))':
+  '@jest/core@30.2.0(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.0)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.2.0
       '@jest/pattern': 30.0.1
@@ -2889,7 +2933,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@types/node@22.19.0)(typescript@5.9.3))
+      jest-config: 30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.0)(typescript@5.9.3))
       jest-haste-map: 30.2.0
       jest-message-util: 30.2.0
       jest-regex-util: 30.0.1
@@ -2909,6 +2953,10 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+
+  '@jest/create-cache-key-function@30.2.0':
+    dependencies:
+      '@jest/types': 30.2.0
 
   '@jest/diff-sequences@30.0.1': {}
 
@@ -3067,6 +3115,7 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+    optional: true
 
   '@jsforce/jsforce-node@3.10.8':
     dependencies:
@@ -3213,15 +3262,78 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@swc/core-darwin-arm64@1.15.18':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.18':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.18':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.18':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.18':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.18':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.18':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.18':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.18':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.18':
+    optional: true
+
+  '@swc/core@1.15.18':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.25
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.18
+      '@swc/core-darwin-x64': 1.15.18
+      '@swc/core-linux-arm-gnueabihf': 1.15.18
+      '@swc/core-linux-arm64-gnu': 1.15.18
+      '@swc/core-linux-arm64-musl': 1.15.18
+      '@swc/core-linux-x64-gnu': 1.15.18
+      '@swc/core-linux-x64-musl': 1.15.18
+      '@swc/core-win32-arm64-msvc': 1.15.18
+      '@swc/core-win32-ia32-msvc': 1.15.18
+      '@swc/core-win32-x64-msvc': 1.15.18
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/jest@0.2.39(@swc/core@1.15.18)':
+    dependencies:
+      '@jest/create-cache-key-function': 30.2.0
+      '@swc/core': 1.15.18
+      '@swc/counter': 0.1.3
+      jsonc-parser: 3.3.1
+
+  '@swc/types@0.1.25':
+    dependencies:
+      '@swc/counter': 0.1.3
+
   '@toon-format/toon@1.0.0': {}
 
-  '@tsconfig/node10@1.0.11': {}
+  '@tsconfig/node10@1.0.11':
+    optional: true
 
-  '@tsconfig/node12@1.0.11': {}
+  '@tsconfig/node12@1.0.11':
+    optional: true
 
-  '@tsconfig/node14@1.0.3': {}
+  '@tsconfig/node14@1.0.3':
+    optional: true
 
-  '@tsconfig/node16@1.0.4': {}
+  '@tsconfig/node16@1.0.4':
+    optional: true
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -3450,6 +3562,7 @@ snapshots:
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.15.0
+    optional: true
 
   acorn@8.15.0: {}
 
@@ -3498,7 +3611,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  arg@4.1.3: {}
+  arg@4.1.3:
+    optional: true
 
   argparse@1.0.10:
     dependencies:
@@ -3606,10 +3720,6 @@ snapshots:
       electron-to-chromium: 1.5.249
       node-releases: 2.0.27
       update-browserslist-db: 1.1.4(browserslist@4.27.0)
-
-  bs-logger@0.2.6:
-    dependencies:
-      fast-json-stable-stringify: 2.1.0
 
   bser@2.1.1:
     dependencies:
@@ -3728,7 +3838,8 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  create-require@1.1.1: {}
+  create-require@1.1.1:
+    optional: true
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3762,7 +3873,8 @@ snapshots:
 
   detect-newline@3.1.0: {}
 
-  diff@4.0.2: {}
+  diff@4.0.2:
+    optional: true
 
   dot-case@3.0.4:
     dependencies:
@@ -4140,15 +4252,6 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  handlebars@4.7.8:
-    dependencies:
-      minimist: 1.2.8
-      neo-async: 2.6.2
-      source-map: 0.6.1
-      wordwrap: 1.0.0
-    optionalDependencies:
-      uglify-js: 3.19.3
-
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -4319,15 +4422,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@types/node@22.19.0)(typescript@5.9.3)):
+  jest-cli@30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.0)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@22.19.0)(typescript@5.9.3))
+      '@jest/core': 30.2.0(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.0)(typescript@5.9.3))
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@types/node@22.19.0)(typescript@5.9.3))
+      jest-config: 30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.0)(typescript@5.9.3))
       jest-util: 30.2.0
       jest-validate: 30.2.0
       yargs: 17.7.2
@@ -4338,7 +4441,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@types/node@22.19.0)(typescript@5.9.3)):
+  jest-config@30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.5
       '@jest/get-type': 30.1.0
@@ -4366,7 +4469,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.0
-      ts-node: 10.9.2(@types/node@22.19.0)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.15.18)(@types/node@22.19.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -4586,12 +4689,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@types/node@22.19.0)(typescript@5.9.3)):
+  jest@30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.0)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@22.19.0)(typescript@5.9.3))
+      '@jest/core': 30.2.0(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.0)(typescript@5.9.3))
       '@jest/types': 30.2.0
       import-local: 3.2.0
-      jest-cli: 30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@types/node@22.19.0)(typescript@5.9.3))
+      jest-cli: 30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.0)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -4633,6 +4736,8 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
 
   jsonwebtoken@9.0.2:
     dependencies:
@@ -4702,8 +4807,6 @@ snapshots:
 
   lodash.isstring@4.0.1: {}
 
-  lodash.memoize@4.1.2: {}
-
   lodash.merge@4.6.2: {}
 
   lodash.once@4.1.1: {}
@@ -4722,7 +4825,8 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
-  make-error@1.3.6: {}
+  make-error@1.3.6:
+    optional: true
 
   makeerror@1.0.12:
     dependencies:
@@ -4790,8 +4894,6 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
-
-  neo-async@2.6.2: {}
 
   no-case@3.0.4:
     dependencies:
@@ -5279,27 +5381,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@types/node@22.19.0)(typescript@5.9.3)))(typescript@5.9.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
-      jest: 30.2.0(@types/node@22.19.0)(ts-node@10.9.2(@types/node@22.19.0)(typescript@5.9.3))
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.3
-      type-fest: 4.41.0
-      typescript: 5.9.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.28.5
-      '@jest/transform': 30.2.0
-      '@jest/types': 30.2.0
-      babel-jest: 30.2.0(@babel/core@7.28.5)
-      jest-util: 30.2.0
-
-  ts-node@10.9.2(@types/node@22.19.0)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.0)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -5316,6 +5398,9 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.18
+    optional: true
 
   ts-retry-promise@0.8.1: {}
 
@@ -5332,8 +5417,6 @@ snapshots:
   type-detect@4.0.8: {}
 
   type-fest@0.21.3: {}
-
-  type-fest@4.41.0: {}
 
   type-is@2.0.1:
     dependencies:
@@ -5353,9 +5436,6 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
-
-  uglify-js@3.19.3:
-    optional: true
 
   undici-types@6.21.0: {}
 
@@ -5405,7 +5485,8 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  v8-compile-cache-lib@3.0.1: {}
+  v8-compile-cache-lib@3.0.1:
+    optional: true
 
   v8-to-istanbul@9.3.0:
     dependencies:
@@ -5439,8 +5520,6 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
-
-  wordwrap@1.0.0: {}
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -5486,7 +5565,8 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yn@3.1.1: {}
+  yn@3.1.1:
+    optional: true
 
   yocto-queue@0.1.0: {}
 

--- a/tests/analyzeLogPerformance.test.ts
+++ b/tests/analyzeLogPerformance.test.ts
@@ -2,7 +2,6 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { jest } from "@jest/globals";
 import { promises as fs } from "fs";
 import {
   analyzeLogPerformance,
@@ -37,22 +36,22 @@ describe("analyzeLogPerformance", () => {
   describe("Tool Configuration", () => {
     it("should have correct tool configuration", () => {
       expect(analyzeLogPerformanceTool.name).toBe(
-        "analyze_apex_log_performance"
+        "analyze_apex_log_performance",
       );
       expect(analyzeLogPerformanceTool.description).toContain(
-        "Analyze an Apex debug log file"
+        "Analyze an Apex debug log file",
       );
       expect(analyzeLogPerformanceTool.inputSchema.required).toEqual([
         "logFilePath",
       ]);
       expect(
-        analyzeLogPerformanceTool.inputSchema.properties.logFilePath.type
+        analyzeLogPerformanceTool.inputSchema.properties.logFilePath.type,
       ).toBe("string");
       expect(
-        analyzeLogPerformanceTool.inputSchema.properties.topMethods.default
+        analyzeLogPerformanceTool.inputSchema.properties.topMethods.default,
       ).toBe(10);
       expect(
-        analyzeLogPerformanceTool.inputSchema.properties.minDuration.default
+        analyzeLogPerformanceTool.inputSchema.properties.minDuration.default,
       ).toBe(0);
     });
   });
@@ -63,7 +62,7 @@ describe("analyzeLogPerformance", () => {
       mockedFs.access.mockRejectedValue(new Error("File not found"));
 
       await expect(analyzeLogPerformance(args)).rejects.toThrow(
-        "Log file not found: /nonexistent/file.log"
+        "Log file not found: /nonexistent/file.log",
       );
 
       expect(mockedFs.access).toHaveBeenCalledWith("/nonexistent/file.log");
@@ -83,7 +82,7 @@ describe("analyzeLogPerformance", () => {
       expect(mockedFs.access).toHaveBeenCalledWith("/valid/file.log");
       expect(mockedFs.readFile).toHaveBeenCalledWith(
         "/valid/file.log",
-        "utf-8"
+        "utf-8",
       );
       expect(mockedParse).toHaveBeenCalledWith(mockLogContent);
       expect(result.content).toHaveLength(1);
@@ -142,8 +141,8 @@ describe("analyzeLogPerformance", () => {
       expect(parsedResult.slowestMethods).toHaveLength(2);
       expect(
         parsedResult.slowestMethods.every(
-          (method) => method.duration >= 300000000
-        )
+          (method) => method.duration >= 300000000,
+        ),
       ).toBe(true);
     });
 
@@ -184,7 +183,7 @@ describe("analyzeLogPerformance", () => {
 
       expect(methods).toHaveLength(2);
       expect(methods.every((method) => method.duration >= 300000000)).toBe(
-        true
+        true,
       );
     });
 
@@ -253,7 +252,7 @@ describe("analyzeLogPerformance", () => {
       const parsedResult = toonDecode(result);
 
       expect(parsedResult.summary).toBe(
-        "No methods found matching the criteria."
+        "No methods found matching the criteria.",
       );
       expect(parsedResult.totalMethods).toBe(0);
     });
@@ -271,7 +270,7 @@ describe("analyzeLogPerformance", () => {
 
       const soqlRecommendation = parsedResult.recommendations.find(
         (rec) =>
-          rec.includes("SOQL queries") && rec.includes("reducing query count")
+          rec.includes("SOQL queries") && rec.includes("reducing query count"),
       );
       expect(soqlRecommendation).toBeDefined();
     });
@@ -286,7 +285,7 @@ describe("analyzeLogPerformance", () => {
       const parsedResult = toonDecode(result);
 
       const dmlRecommendation = parsedResult.recommendations.find(
-        (rec) => rec.includes("DML operations") && rec.includes("bulkifying")
+        (rec) => rec.includes("DML operations") && rec.includes("bulkifying"),
       );
       expect(dmlRecommendation).toBeDefined();
     });
@@ -301,7 +300,7 @@ describe("analyzeLogPerformance", () => {
       const parsedResult = toonDecode(result);
 
       const rowsRecommendation = parsedResult.recommendations.find(
-        (rec) => rec.includes("SOQL rows") && rec.includes("WHERE clauses")
+        (rec) => rec.includes("SOQL rows") && rec.includes("WHERE clauses"),
       );
       expect(rowsRecommendation).toBeDefined();
     });
@@ -318,7 +317,7 @@ describe("analyzeLogPerformance", () => {
       const percentageRecommendation = parsedResult.recommendations.find(
         (rec) =>
           rec.includes("% self execution time") &&
-          rec.includes("can be optimized")
+          rec.includes("can be optimized"),
       );
       expect(percentageRecommendation).toBeDefined();
     });
@@ -333,7 +332,7 @@ describe("analyzeLogPerformance", () => {
       const parsedResult = toonDecode(result);
 
       expect(parsedResult.recommendations).toContain(
-        "Performance looks good! No obvious bottlenecks detected in the analyzed methods."
+        "Performance looks good! No obvious bottlenecks detected in the analyzed methods.",
       );
     });
 
@@ -355,11 +354,11 @@ describe("analyzeLogPerformance", () => {
           rec.includes("Method1") ||
           rec.includes("Method2") ||
           rec.includes("Method3") ||
-          rec.includes("Method4")
+          rec.includes("Method4"),
       );
 
       const mentionsMethod4 = methodMentions.some((rec) =>
-        rec.includes("Method4")
+        rec.includes("Method4"),
       );
       expect(mentionsMethod4).toBe(false);
     });
@@ -378,7 +377,7 @@ describe("analyzeLogPerformance", () => {
       expect(parsedResult.totalMethods).toBe(0);
       expect(parsedResult.slowestMethods).toHaveLength(0);
       expect(parsedResult.summary).toBe(
-        "No methods found matching the criteria."
+        "No methods found matching the criteria.",
       );
     });
 
@@ -408,7 +407,7 @@ describe("analyzeLogPerformance", () => {
       });
 
       await expect(analyzeLogPerformance(args)).rejects.toThrow(
-        "Parsing failed"
+        "Parsing failed",
       );
     });
 
@@ -419,7 +418,7 @@ describe("analyzeLogPerformance", () => {
       mockedFs.readFile.mockRejectedValue(new Error("Permission denied"));
 
       await expect(analyzeLogPerformance(args)).rejects.toThrow(
-        "Permission denied"
+        "Permission denied",
       );
     });
   });
@@ -445,7 +444,7 @@ describe("analyzeLogPerformance", () => {
       expect(typeof method.soqlRows).toBe("number");
       expect(typeof method.selfPercentage).toBe("number");
       expect(["number", "string", "object"]).toContain(
-        typeof method.lineNumber
+        typeof method.lineNumber,
       );
     });
 
@@ -468,9 +467,7 @@ describe("analyzeLogPerformance", () => {
 
   // Helper function for decoding TOON-formatted data
   function toonDecode(result: any): LogAnalysisResult {
-    return decode(
-      result.content[0].text
-    ) as unknown as LogAnalysisResult;
+    return decode(result.content[0].text) as unknown as LogAnalysisResult;
   }
 
   // Helper functions for creating mock data
@@ -489,7 +486,7 @@ describe("analyzeLogPerformance", () => {
     dmlCount: number = 0,
     soqlCount: number = 0,
     dmlRows: number = 0,
-    soqlRows: number = 0
+    soqlRows: number = 0,
   ): any {
     return {
       type: "METHOD_ENTRY",
@@ -515,7 +512,7 @@ describe("analyzeLogPerformance", () => {
       5,
       10,
       100,
-      1000
+      1000,
     );
     const mediumMethod = createMockLogLine(
       "MediumMethod",
@@ -526,7 +523,7 @@ describe("analyzeLogPerformance", () => {
       2,
       3,
       50,
-      200
+      200,
     );
     const fastMethod = createMockLogLine(
       "FastMethod",
@@ -537,7 +534,7 @@ describe("analyzeLogPerformance", () => {
       1,
       1,
       10,
-      50
+      50,
     );
 
     return {
@@ -560,14 +557,14 @@ describe("analyzeLogPerformance", () => {
       500000000,
       500000000,
       "default",
-      1
+      1,
     );
     const customMethod = createMockLogLine(
       "CustomMethod",
       400000000,
       400000000,
       "CustomNamespace",
-      2
+      2,
     );
 
     return {
@@ -639,7 +636,7 @@ describe("analyzeLogPerformance", () => {
       2,
       8,
       50,
-      500
+      500,
     );
 
     return {
@@ -666,7 +663,7 @@ describe("analyzeLogPerformance", () => {
       6,
       2,
       100,
-      50
+      50,
     );
 
     return {
@@ -693,7 +690,7 @@ describe("analyzeLogPerformance", () => {
       1,
       2,
       10,
-      1500
+      1500,
     );
 
     return {
@@ -720,7 +717,7 @@ describe("analyzeLogPerformance", () => {
       1,
       1,
       10,
-      50
+      50,
     );
 
     return {
@@ -747,7 +744,7 @@ describe("analyzeLogPerformance", () => {
       1,
       2,
       50,
-      100
+      100,
     );
 
     return {
@@ -774,7 +771,7 @@ describe("analyzeLogPerformance", () => {
       8,
       8,
       100,
-      1200
+      1200,
     );
     const method2 = createMockLogLine(
       "Method2",
@@ -785,7 +782,7 @@ describe("analyzeLogPerformance", () => {
       6,
       6,
       80,
-      1000
+      1000,
     );
     const method3 = createMockLogLine(
       "Method3",
@@ -796,7 +793,7 @@ describe("analyzeLogPerformance", () => {
       4,
       4,
       60,
-      800
+      800,
     );
     const method4 = createMockLogLine(
       "Method4",
@@ -807,7 +804,7 @@ describe("analyzeLogPerformance", () => {
       8,
       8,
       100,
-      1200
+      1200,
     ); // Should not appear in recommendations
 
     return {

--- a/tests/executeAnonymous.test.ts
+++ b/tests/executeAnonymous.test.ts
@@ -2,8 +2,6 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { jest, describe, it, expect, beforeEach } from "@jest/globals";
-
 jest.mock("../src/salesforce/users", () => ({
   getUserIdByUsername: jest.fn(),
 }));
@@ -16,9 +14,8 @@ jest.mock("../src/salesforce/traceFlags", () => ({
   ensureTraceFlag: jest.fn(),
 }));
 
-const mockConnect = jest.fn() as jest.MockedFunction<() => Promise<any>>;
 jest.mock("../src/salesforce/connection", () => ({
-  connect: mockConnect,
+  connect: jest.fn(),
 }));
 
 jest.mock("@modelcontextprotocol/sdk/server/index.js");
@@ -31,6 +28,9 @@ import {
 import { getUserIdByUsername } from "../src/salesforce/users";
 import { getOrCreateDebugLevelId } from "../src/salesforce/debugLevels";
 import { ensureTraceFlag } from "../src/salesforce/traceFlags";
+import { connect } from "../src/salesforce/connection";
+
+const mockConnect = connect as jest.MockedFunction<typeof connect>;
 
 describe("Execute Anonymous", () => {
   const testUserId = "005000000000001";
@@ -52,7 +52,7 @@ describe("Execute Anonymous", () => {
     jest.clearAllMocks();
 
     mockServer = {
-      listRoots: jest.fn<any>().mockResolvedValue({ roots: [] }),
+      listRoots: jest.fn().mockResolvedValue({ roots: [] }),
     } as unknown as Server;
 
     mockExecuteAnonymous = jest.fn();

--- a/tests/findPerformanceBottlenecks.test.ts
+++ b/tests/findPerformanceBottlenecks.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { promises as fs } from "fs";
-import { jest } from "@jest/globals";
+
 import {
   findPerformanceBottlenecks,
   BottleneckArgs,
@@ -37,7 +37,7 @@ const mockExtractMethods = extractMethods as jest.MockedFunction<
 
 // Helper function to create mock governor limits
 function createMockGovernorLimits(
-  overrides: Partial<Limits> = {}
+  overrides: Partial<Limits> = {},
 ): GovernorLimits {
   const defaultLimits: Limits = {
     soqlQueries: { used: 0, limit: 100 },
@@ -150,7 +150,7 @@ describe("findPerformanceBottlenecks", () => {
       mockFs.access.mockRejectedValue(new Error("File not found"));
 
       await expect(findPerformanceBottlenecks(args)).rejects.toThrow(
-        "Log file not found: /nonexistent/file.log"
+        "Log file not found: /nonexistent/file.log",
       );
 
       expect(mockFs.access).toHaveBeenCalledWith("/nonexistent/file.log");
@@ -163,7 +163,7 @@ describe("findPerformanceBottlenecks", () => {
       mockFs.readFile.mockRejectedValue(new Error("Permission denied"));
 
       await expect(findPerformanceBottlenecks(args)).rejects.toThrow(
-        "Permission denied"
+        "Permission denied",
       );
 
       expect(mockFs.access).toHaveBeenCalledWith(mockLogFilePath);
@@ -178,7 +178,7 @@ describe("findPerformanceBottlenecks", () => {
       });
 
       await expect(findPerformanceBottlenecks(args)).rejects.toThrow(
-        "Invalid log format"
+        "Invalid log format",
       );
 
       expect(mockFs.access).toHaveBeenCalledWith(mockLogFilePath);
@@ -251,10 +251,10 @@ describe("findPerformanceBottlenecks", () => {
 
       // Verify governor limit warnings
       expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "cpuTime: 85.0% of limit used (8500/10000)"
+        "cpuTime: 85.0% of limit used (8500/10000)",
       );
       expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "soqlQueries: 90.0% of limit used (90/100)"
+        "soqlQueries: 90.0% of limit used (90/100)",
       );
     });
 
@@ -522,19 +522,19 @@ describe("findPerformanceBottlenecks", () => {
       const parsedResult = toonDecode(result);
 
       expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "cpuTime: 85.0% of limit used (8500/10000)"
+        "cpuTime: 85.0% of limit used (8500/10000)",
       );
       expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "soqlQueries: 90.0% of limit used (90/100)"
+        "soqlQueries: 90.0% of limit used (90/100)",
       );
       expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "dmlStatements: 90.0% of limit used (135/150)"
+        "dmlStatements: 90.0% of limit used (135/150)",
       );
       expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "queryRows: 90.0% of limit used (45000/50000)"
+        "queryRows: 90.0% of limit used (45000/50000)",
       );
       expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "heapSize: 85.0% of limit used (5100000/6000000)"
+        "heapSize: 85.0% of limit used (5100000/6000000)",
       );
     });
 
@@ -630,7 +630,7 @@ describe("findPerformanceBottlenecks", () => {
 
       // Should generate warning for just over 80%
       expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "cpuTime: 80.0% of limit used (8001/10000)"
+        "cpuTime: 80.0% of limit used (8001/10000)",
       );
     });
   });
@@ -689,7 +689,7 @@ describe("findPerformanceBottlenecks", () => {
 
       // Should identify all bottleneck types
       expect(parsedResult.cpuBottlenecks!.warning).toBe(
-        "High CPU usage detected - consider optimizing algorithms"
+        "High CPU usage detected - consider optimizing algorithms",
       );
       expect(parsedResult.cpuBottlenecks!.cpuUsagePercentage).toBe(95);
 
@@ -697,7 +697,7 @@ describe("findPerformanceBottlenecks", () => {
       expect(databaseBottlenecks.soqlQueries.percentage).toBe(95);
       expect(databaseBottlenecks.dmlStatements.percentage).toBeCloseTo(
         93.33,
-        1
+        1,
       );
       expect(databaseBottlenecks.queryRows.percentage).toBe(96);
 
@@ -708,10 +708,10 @@ describe("findPerformanceBottlenecks", () => {
       // Multiple governor limit warnings
       expect(governorLimitWarnings.warnings.length).toBeGreaterThan(3);
       expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "cpuTime: 95.0% of limit used (9500/10000)"
+        "cpuTime: 95.0% of limit used (9500/10000)",
       );
       expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "soqlQueries: 95.0% of limit used (95/100)"
+        "soqlQueries: 95.0% of limit used (95/100)",
       );
     });
 

--- a/tests/getLogSummary.test.ts
+++ b/tests/getLogSummary.test.ts
@@ -4,7 +4,7 @@
 
 import { promises as fs } from "fs";
 import path from "path";
-import { jest } from "@jest/globals";
+
 import { getLogSummary, LogSummaryArgs } from "../src/tools/getLogSummary";
 import {
   parse,
@@ -41,7 +41,7 @@ const mockParse = parse as jest.MockedFunction<typeof parse>;
 const createMockLogLine = (
   type: string,
   subCategory?: string,
-  children: LogLine[] = []
+  children: LogLine[] = [],
 ): LogLine =>
   ({
     type: type as any,
@@ -67,7 +67,7 @@ const createMockLogLine = (
     cpuTotalTime: 0,
     parseTimestamp: () => 0,
     parseLineNumber: () => null,
-  } as unknown as LogLine);
+  }) as unknown as LogLine;
 
 describe("getLogSummary", () => {
   beforeEach(() => {
@@ -185,7 +185,7 @@ describe("getLogSummary", () => {
       expect(mockFs.access).toHaveBeenCalledWith("/path/to/test-log.log");
       expect(mockFs.readFile).toHaveBeenCalledWith(
         "/path/to/test-log.log",
-        "utf-8"
+        "utf-8",
       );
       expect(mockPath.basename).toHaveBeenCalledWith("/path/to/test-log.log");
       expect(mockParse).toHaveBeenCalledWith(mockLogContent);
@@ -194,26 +194,24 @@ describe("getLogSummary", () => {
         content: [
           {
             type: "text",
-            text: encode(
-              {
-                file: "test-log.log",
-                totalExecutionTime: 12500,
-                totalMethods: 3, // 2 METHOD_ENTRY + 1 with subCategory 'Method'
-                totalSOQLQueries: 5,
-                totalDMLOperations: 3,
-                totalSOQLRows: 150,
-                totalDMLRows: 25,
-                governorLimits: {
-                  cpuTime: { used: 1500, limit: 10000 },
-                  heapSize: { used: 2048, limit: 6000000 },
-                  soqlQueries: { used: 5, limit: 100 },
-                  dmlStatements: { used: 3, limit: 150 },
-                },
-                namespaces: ["default", "MyNamespace"],
-                logIssues: 0,
-                parsingErrors: 0,
-              }
-            ),
+            text: encode({
+              file: "test-log.log",
+              totalExecutionTime: 12500,
+              totalMethods: 3, // 2 METHOD_ENTRY + 1 with subCategory 'Method'
+              totalSOQLQueries: 5,
+              totalDMLOperations: 3,
+              totalSOQLRows: 150,
+              totalDMLRows: 25,
+              governorLimits: {
+                cpuTime: { used: 1500, limit: 10000 },
+                heapSize: { used: 2048, limit: 6000000 },
+                soqlQueries: { used: 5, limit: 100 },
+                dmlStatements: { used: 3, limit: 150 },
+              },
+              namespaces: ["default", "MyNamespace"],
+              logIssues: 0,
+              parsingErrors: 0,
+            }),
           },
         ],
       });
@@ -407,7 +405,7 @@ describe("getLogSummary", () => {
       };
 
       await expect(getLogSummary(args)).rejects.toThrow(
-        "Log file not found: /path/to/nonexistent.log"
+        "Log file not found: /path/to/nonexistent.log",
       );
 
       expect(mockFs.access).toHaveBeenCalledWith("/path/to/nonexistent.log");
@@ -424,7 +422,7 @@ describe("getLogSummary", () => {
       };
 
       await expect(getLogSummary(args)).rejects.toThrow(
-        "Log file not found: /path/to/restricted.log"
+        "Log file not found: /path/to/restricted.log",
       );
     });
 
@@ -442,7 +440,7 @@ describe("getLogSummary", () => {
       expect(mockFs.access).toHaveBeenCalledWith("/path/to/unreadable.log");
       expect(mockFs.readFile).toHaveBeenCalledWith(
         "/path/to/unreadable.log",
-        "utf-8"
+        "utf-8",
       );
       expect(mockParse).not.toHaveBeenCalled();
     });
@@ -464,7 +462,7 @@ describe("getLogSummary", () => {
       expect(mockFs.access).toHaveBeenCalledWith("/path/to/corrupted.log");
       expect(mockFs.readFile).toHaveBeenCalledWith(
         "/path/to/corrupted.log",
-        "utf-8"
+        "utf-8",
       );
       expect(mockParse).toHaveBeenCalledWith("invalid log content");
     });
@@ -683,8 +681,6 @@ describe("getLogSummary", () => {
 
   // Helper function for decoding TOON-formatted data
   function toonDecode(result: any): any {
-    return decode(
-      result.content[0].text
-    ) as any;
+    return decode(result.content[0].text) as any;
   }
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,14 +2,6 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import {
-  jest,
-  describe,
-  it,
-  expect,
-  beforeEach,
-  afterEach,
-} from "@jest/globals";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {

--- a/tests/salesforce/connection.test.ts
+++ b/tests/salesforce/connection.test.ts
@@ -2,7 +2,26 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+jest.mock("@salesforce/core", () => ({
+  Org: {
+    create: jest.fn(),
+  },
+  ConfigAggregator: {
+    create: jest.fn(),
+  },
+  OrgConfigProperties: {
+    TARGET_ORG: "target-org",
+  },
+}));
+
+import { Org, ConfigAggregator } from "@salesforce/core";
+import { connect } from "../../src/salesforce/connection";
+
+const mockOrgCreate = Org.create as jest.MockedFunction<typeof Org.create>;
+const mockConfigAggregatorCreate =
+  ConfigAggregator.create as jest.MockedFunction<
+    typeof ConfigAggregator.create
+  >;
 
 const mockConnectionInstance = {
   query: jest.fn(),
@@ -16,27 +35,9 @@ const mockOrgInstance = {
   getConnection: jest.fn().mockReturnValue(mockConnectionInstance),
 } as any;
 
-const mockOrgCreate = jest.fn() as jest.MockedFunction<any>;
-
 const mockConfigAggregator = {
   getPropertyValue: jest.fn(),
 } as any;
-
-const mockConfigAggregatorCreate = jest.fn() as jest.MockedFunction<any>;
-
-jest.mock("@salesforce/core", () => ({
-  Org: {
-    create: mockOrgCreate,
-  },
-  ConfigAggregator: {
-    create: mockConfigAggregatorCreate,
-  },
-  OrgConfigProperties: {
-    TARGET_ORG: "target-org",
-  },
-}));
-
-import { connect } from "../../src/salesforce/connection";
 
 describe("Salesforce Connection", () => {
   const testUsername = "test@example.com";

--- a/tests/salesforce/debugLevels.test.ts
+++ b/tests/salesforce/debugLevels.test.ts
@@ -2,13 +2,12 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { jest, describe, it, expect, beforeEach } from "@jest/globals";
 import { Connection } from "@salesforce/core";
 import { getOrCreateDebugLevelId } from "../../src/salesforce/debugLevels";
 
 describe("Debug Levels", () => {
   const testId = "000000000000000000";
-  
+
   let mockConnection: jest.Mocked<Connection>;
   let mockTooling: any;
   let mockQuery: any;
@@ -55,20 +54,20 @@ describe("Debug Levels", () => {
       expect(result).toBe(testId);
       expect(mockQuery).toHaveBeenCalledWith(
         expect.stringContaining(
-          "SELECT Id, DeveloperName, ApexCode, ApexProfiling, Database"
-        )
+          "SELECT Id, DeveloperName, ApexCode, ApexProfiling, Database",
+        ),
       );
       expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining("FROM DebugLevel")
+        expect.stringContaining("FROM DebugLevel"),
       );
       expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining("WHERE ApexCode = 'FINEST'")
+        expect.stringContaining("WHERE ApexCode = 'FINEST'"),
       );
       expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining("AND ApexProfiling = 'FINEST'")
+        expect.stringContaining("AND ApexProfiling = 'FINEST'"),
       );
       expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining("AND Database = 'FINEST'")
+        expect.stringContaining("AND Database = 'FINEST'"),
       );
       expect(mockCreate).not.toHaveBeenCalled();
     });
@@ -134,7 +133,7 @@ describe("Debug Levels", () => {
       });
 
       await expect(getOrCreateDebugLevelId(mockConnection)).rejects.toThrow(
-        "Failed to create DebugLevel"
+        "Failed to create DebugLevel",
       );
     });
 
@@ -149,7 +148,7 @@ describe("Debug Levels", () => {
       });
 
       await expect(getOrCreateDebugLevelId(mockConnection)).rejects.toThrow(
-        "Failed to create DebugLevel"
+        "Failed to create DebugLevel",
       );
     });
 
@@ -158,7 +157,7 @@ describe("Debug Levels", () => {
       mockQuery.mockRejectedValue(queryError);
 
       await expect(getOrCreateDebugLevelId(mockConnection)).rejects.toThrow(
-        "Query failed"
+        "Query failed",
       );
     });
 
@@ -171,7 +170,7 @@ describe("Debug Levels", () => {
       mockCreate.mockRejectedValue(createError);
 
       await expect(getOrCreateDebugLevelId(mockConnection)).rejects.toThrow(
-        "Creation failed"
+        "Creation failed",
       );
     });
 
@@ -191,7 +190,7 @@ describe("Debug Levels", () => {
       await getOrCreateDebugLevelId(mockConnection);
 
       expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining("LIMIT 1")
+        expect.stringContaining("LIMIT 1"),
       );
     });
 
@@ -212,13 +211,13 @@ describe("Debug Levels", () => {
 
       expect(result).toBe(testId);
       expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringMatching(/ApexCode = 'FINEST'/)
+        expect.stringMatching(/ApexCode = 'FINEST'/),
       );
       expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringMatching(/ApexProfiling = 'FINEST'/)
+        expect.stringMatching(/ApexProfiling = 'FINEST'/),
       );
       expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringMatching(/Database = 'FINEST'/)
+        expect.stringMatching(/Database = 'FINEST'/),
       );
     });
 

--- a/tests/salesforce/traceFlags.test.ts
+++ b/tests/salesforce/traceFlags.test.ts
@@ -2,7 +2,6 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { jest, describe, it, expect, beforeEach } from "@jest/globals";
 import { Connection } from "@salesforce/core";
 import { ensureTraceFlag } from "../../src/salesforce/traceFlags";
 

--- a/tests/salesforce/users.test.ts
+++ b/tests/salesforce/users.test.ts
@@ -2,7 +2,6 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { jest, describe, it, expect, beforeEach } from "@jest/globals";
 import { Connection } from "@salesforce/core";
 import { getUserIdByUsername } from "../../src/salesforce/users";
 
@@ -37,7 +36,7 @@ describe("Users", () => {
 
       expect(result).toBe(testUserId);
       expect(mockQuery).toHaveBeenCalledWith(
-        `SELECT Id FROM User WHERE Username = '${testUsername}'`
+        `SELECT Id FROM User WHERE Username = '${testUsername}'`,
       );
     });
 
@@ -49,7 +48,7 @@ describe("Users", () => {
       });
 
       await expect(
-        getUserIdByUsername(mockConnection, username)
+        getUserIdByUsername(mockConnection, username),
       ).rejects.toThrow(`User not found with username: ${username}`);
     });
 
@@ -63,7 +62,7 @@ describe("Users", () => {
       });
 
       await expect(
-        getUserIdByUsername(mockConnection, testUsername)
+        getUserIdByUsername(mockConnection, testUsername),
       ).rejects.toThrow("User Id is undefined");
     });
 
@@ -77,7 +76,7 @@ describe("Users", () => {
       });
 
       await expect(
-        getUserIdByUsername(mockConnection, testUsername)
+        getUserIdByUsername(mockConnection, testUsername),
       ).rejects.toThrow("User Id is undefined");
     });
 
@@ -96,7 +95,7 @@ describe("Users", () => {
 
       expect(result).toBe(testUserId);
       expect(mockQuery).toHaveBeenCalledWith(
-        `SELECT Id FROM User WHERE Username = '${username}'`
+        `SELECT Id FROM User WHERE Username = '${username}'`,
       );
     });
 
@@ -115,7 +114,7 @@ describe("Users", () => {
 
       expect(result).toBe(testUserId);
       expect(mockQuery).toHaveBeenCalledWith(
-        `SELECT Id FROM User WHERE Username = '${username}'`
+        `SELECT Id FROM User WHERE Username = '${username}'`,
       );
     });
 
@@ -127,7 +126,7 @@ describe("Users", () => {
       });
 
       await expect(
-        getUserIdByUsername(mockConnection, username)
+        getUserIdByUsername(mockConnection, username),
       ).rejects.toThrow(`User not found with username: ${username}`);
     });
 
@@ -145,9 +144,7 @@ describe("Users", () => {
       const result = await getUserIdByUsername(mockConnection, username);
 
       expect(result).toBe(testUserId);
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining(username)
-      );
+      expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining(username));
     });
 
     it("should return first user when multiple users match", async () => {
@@ -173,7 +170,7 @@ describe("Users", () => {
       mockQuery.mockRejectedValue(queryError);
 
       await expect(
-        getUserIdByUsername(mockConnection, testUsername)
+        getUserIdByUsername(mockConnection, testUsername),
       ).rejects.toThrow("Query failed");
     });
 


### PR DESCRIPTION
## Summary
- Replaces `ts-jest` with `@swc/jest` for significantly faster test transpilation
- Removes `ts-jest`, `ts-node`, and `@jest/globals` dependencies in favor of `@swc/core` and `@swc/jest`
- Updates all test files to remove explicit `@jest/globals` imports (Jest globals used natively)
- Configures SWC with TypeScript parser targeting ES2022

## Test plan
- [x] All existing tests pass with the new transform
- [x] Verify faster test execution compared to ts-jest