### PR TITLE
feat: improve MCP tool descriptions and add annotations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,11 +43,15 @@ class ApexLogServer {
       {
         name: "apex-log-mcp",
         version: "1.0.0",
+        description:
+          "Analyzes Salesforce Apex debug logs for performance bottlenecks, governor limit usage, and optimization opportunities.",
       },
       {
         capabilities: {
           tools: {},
         },
+        instructions:
+          "Use this server when you have an Apex debug log file to analyze, or when you need to execute anonymous Apex and inspect the resulting log. The log analysis tools accept absolute file paths and return structured JSON. Start with get_apex_log_summary for a quick overview, then use analyze_apex_log_performance or find_performance_bottlenecks for deeper analysis.",
       },
     );
 

--- a/src/tools/analyzeLogPerformance.ts
+++ b/src/tools/analyzeLogPerformance.ts
@@ -38,6 +38,13 @@ export const analyzeLogPerformanceTool = {
   name: "analyze_apex_log_performance",
   description:
     "Rank methods in an Apex debug log by self-execution time. Returns method names, durations, SOQL/DML counts, and optimization recommendations. Best for finding which specific methods to optimize.",
+  annotations: {
+    title: "Analyze Apex Log Performance",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     properties: {
@@ -53,7 +60,7 @@ export const analyzeLogPerformanceTool = {
       minDuration: {
         type: "number",
         description:
-          "Minimum duration in nanoseconds to include a method (default: 0)",
+          "Minimum duration in nanoseconds to include a method. For reference: 1ms = 1,000,000ns, 1s = 1,000,000,000ns (default: 0)",
         default: 0,
       },
       namespace: {

--- a/src/tools/analyzeLogPerformance.ts
+++ b/src/tools/analyzeLogPerformance.ts
@@ -37,7 +37,7 @@ export interface LogAnalysisResult {
 export const analyzeLogPerformanceTool = {
   name: "analyze_apex_log_performance",
   description:
-    "Analyze an Apex debug log file and identify the slowest running methods with performance metrics",
+    "Rank methods in an Apex debug log by self-execution time. Returns method names, durations, SOQL/DML counts, and optimization recommendations. Best for finding which specific methods to optimize.",
   inputSchema: {
     type: "object",
     properties: {
@@ -58,7 +58,7 @@ export const analyzeLogPerformanceTool = {
       },
       namespace: {
         type: "string",
-        description: "Filter methods by namespace (optional)",
+        description: "Filter methods by namespace",
       },
     },
     required: ["logFilePath"],
@@ -100,7 +100,7 @@ export async function analyzeLogPerformance(args: AnalyzeLogArgs) {
     content: [
       {
         type: "text",
-        text: encode(result)
+        text: encode(result),
       },
     ],
   };
@@ -109,7 +109,7 @@ export async function analyzeLogPerformance(args: AnalyzeLogArgs) {
 export function extractMethods(
   apexLog: ApexLog,
   minDuration: number,
-  namespaceFilter?: string
+  namespaceFilter?: string,
 ): SlowMethod[] {
   const methods: SlowMethod[] = [];
   const totalTime = apexLog.duration.total;
@@ -150,7 +150,7 @@ export function extractMethods(
 
 function generatePerformanceSummary(
   methods: SlowMethod[],
-  totalTime: number
+  totalTime: number,
 ): string {
   if (methods.length === 0) {
     return "No methods found matching the criteria.";
@@ -159,7 +159,7 @@ function generatePerformanceSummary(
   const slowestMethod = methods[0];
   const totalSlowMethodsTime = methods.reduce(
     (sum, method) => sum + method.selfDuration,
-    0
+    0,
   );
   const percentageOfTotal =
     totalTime > 0 ? (totalSlowMethodsTime / totalTime) * 100 : 0;
@@ -167,13 +167,13 @@ function generatePerformanceSummary(
   return `Analysis found ${methods.length} methods. The slowest method "${
     slowestMethod.name
   }" took ${(slowestMethod.selfDuration / 1000000).toFixed(
-    2
+    2,
   )}ms (${slowestMethod.selfPercentage.toFixed(
-    1
+    1,
   )}% of total execution time). The top ${
     methods.length
   } methods account for ${percentageOfTotal.toFixed(
-    1
+    1,
   )}% of total execution time.`;
 }
 
@@ -192,7 +192,7 @@ function generateRecommendations(methods: SlowMethod[]): string[] {
 
   if (recommendations.length === 0) {
     recommendations.push(
-      "Performance looks good! No obvious bottlenecks detected in the analyzed methods."
+      "Performance looks good! No obvious bottlenecks detected in the analyzed methods.",
     );
   }
 
@@ -203,7 +203,7 @@ function getRecommendations(method: SlowMethod): string | null {
   // High self time percentage, only include if self duration is significant
   if (method.selfPercentage > 10 && method.selfDuration > 100) {
     return `Method "${method.name}" consumes ${method.selfPercentage.toFixed(
-      1
+      1,
     )}% self execution time. Consider if it can be optimized to make it faster, check how many times it is called and if that can be reduced.`;
   }
   if (method.soqlRows > 1000) {

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -36,7 +36,7 @@ function logLevelProperty(description: string) {
 export const executeAnonymousTool = {
   name: "execute_anonymous",
   description:
-    "Execute a snippet of anonymous Apex against any Salesforce org and retrieve the resulting debug log",
+    "Execute a snippet of anonymous Apex against an authenticated Salesforce org (via SF CLI) and retrieve the resulting debug log",
   inputSchema: {
     type: "object",
     properties: {

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -37,6 +37,13 @@ export const executeAnonymousTool = {
   name: "execute_anonymous",
   description:
     "Execute a snippet of anonymous Apex against an authenticated Salesforce org (via SF CLI) and retrieve the resulting debug log",
+  annotations: {
+    title: "Execute Anonymous Apex",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
   inputSchema: {
     type: "object",
     properties: {
@@ -51,7 +58,7 @@ export const executeAnonymousTool = {
       },
       debugLevel: {
         description:
-          'Optional debug level configuration. Use "default" to reset all categories to defaults. Use a log level string (e.g. "FINEST") to set all categories to that level. Use an object to override specific categories. Omit entirely to keep the existing configuration.',
+          'Optional debug level configuration. Valid log levels: NONE, ERROR, WARN, INFO, DEBUG, FINE, FINER, FINEST. Pass "default" to reset, a single level string to set all categories, or an object with category overrides (apexCode, apexProfiling, callout, database, nba, system, validation, visualforce, wave, workflow).',
         oneOf: [
           {
             type: "string",

--- a/src/tools/findPerformanceBottlenecks.ts
+++ b/src/tools/findPerformanceBottlenecks.ts
@@ -23,6 +23,13 @@ export const findPerformanceBottlenecksTool = {
   name: "find_performance_bottlenecks",
   description:
     "Check whether an Apex log transaction is approaching governor limits (flags usage above 80%). Analyzes CPU time, SOQL/DML limits, query rows, and method execution patterns by namespace. Best for checking if a transaction is at risk of hitting governor limits.",
+  annotations: {
+    title: "Find Performance Bottlenecks",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     properties: {

--- a/src/tools/findPerformanceBottlenecks.ts
+++ b/src/tools/findPerformanceBottlenecks.ts
@@ -22,7 +22,7 @@ export interface BottleneckResult {
 export const findPerformanceBottlenecksTool = {
   name: "find_performance_bottlenecks",
   description:
-    "Identify performance bottlenecks in an Apex log by analyzing CPU time, database operations, and method execution patterns",
+    "Check whether an Apex log transaction is approaching governor limits (flags usage above 80%). Analyzes CPU time, SOQL/DML limits, query rows, and method execution patterns by namespace. Best for checking if a transaction is at risk of hitting governor limits.",
   inputSchema: {
     type: "object",
     properties: {
@@ -33,7 +33,8 @@ export const findPerformanceBottlenecksTool = {
       analysisType: {
         type: "string",
         enum: ["cpu", "database", "methods", "all"],
-        description: "Type of bottleneck analysis to perform",
+        description:
+          'Type of analysis: "cpu" checks CPU time governor limit, "database" checks SOQL query/DML statement/query row limits, "methods" groups methods by namespace with duration totals, "all" runs all three (default)',
         default: "all",
       },
     },
@@ -156,7 +157,7 @@ function analyzeMethodBottlenecks(apexLog: ApexLog): Record<string, unknown> {
       acc[method.namespace].push(method);
       return acc;
     },
-    {}
+    {},
   );
 
   return {
@@ -166,7 +167,7 @@ function analyzeMethodBottlenecks(apexLog: ApexLog): Record<string, unknown> {
       methodCount: methodsByNamespace[ns].length,
       totalDuration: methodsByNamespace[ns].reduce(
         (sum: number, m: SlowMethod) => sum + m.duration,
-        0
+        0,
       ),
     })),
   };
@@ -183,7 +184,7 @@ function analyzeGovernorLimits(apexLog: ApexLog): Record<string, unknown> {
         warnings.push(
           `${key}: ${percentage.toFixed(1)}% of limit used (${value.used}/${
             value.limit
-          })`
+          })`,
         );
       }
     }
@@ -199,7 +200,7 @@ function analyzeGovernorLimits(apexLog: ApexLog): Record<string, unknown> {
       }
       return acc;
     },
-    {}
+    {},
   );
 
   return warnings.length === 0

--- a/src/tools/getLogSummary.ts
+++ b/src/tools/getLogSummary.ts
@@ -14,7 +14,7 @@ export interface LogSummaryArgs {
 export const getLogSummaryTool = {
   name: "get_apex_log_summary",
   description:
-    "Get a high-level summary of an Apex debug log including total execution time, method count, and governor limits",
+    "Get a high-level summary of an Apex debug log including total execution time, method count, SOQL/DML totals, governor limits, and active namespaces. Best for a quick overview before deeper analysis.",
   inputSchema: {
     type: "object",
     properties: {
@@ -62,7 +62,7 @@ export async function getLogSummary(args: LogSummaryArgs) {
     content: [
       {
         type: "text",
-        text: encode(summary)
+        text: encode(summary),
       },
     ],
   };

--- a/src/tools/getLogSummary.ts
+++ b/src/tools/getLogSummary.ts
@@ -15,6 +15,13 @@ export const getLogSummaryTool = {
   name: "get_apex_log_summary",
   description:
     "Get a high-level summary of an Apex debug log including total execution time, method count, SOQL/DML totals, governor limits, and active namespaces. Best for a quick overview before deeper analysis.",
+  annotations: {
+    title: "Get Apex Log Summary",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     properties: {

--- a/tests/analyzeLogPerformance.test.ts
+++ b/tests/analyzeLogPerformance.test.ts
@@ -39,7 +39,7 @@ describe("analyzeLogPerformance", () => {
         "analyze_apex_log_performance",
       );
       expect(analyzeLogPerformanceTool.description).toContain(
-        "Analyze an Apex debug log file",
+        "Rank methods in an Apex debug log by self-execution time",
       );
       expect(analyzeLogPerformanceTool.inputSchema.required).toEqual([
         "logFilePath",

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -242,11 +242,13 @@ describe("ApexLogServer", () => {
         {
           name: "apex-log-mcp",
           version: "1.0.0",
+          description: expect.any(String),
         },
         {
           capabilities: {
             tools: {},
           },
+          instructions: expect.any(String),
         },
       );
     });


### PR DESCRIPTION
## Summary
- Add MCP tool `annotations` (readOnlyHint, destructiveHint, idempotentHint, openWorldHint) to all 4 tool definitions so agents can auto-approve safe read-only tools
- Improve `minDuration` description with nanosecond-to-ms/s conversion reference
- Improve `debugLevel` description to summarize valid log levels and category names inline
- Enhance server-level `description` and `instructions` fields
- Improve `analysisType` enum description with per-value explanations

## Test plan
- [x] `pnpm run build` — no compile errors
- [x] `pnpm test` — all 144 tests pass
- [x] `pnpm run lint` — no lint errors
- [x] Changes are additive (annotations + description text only) — no logic changes
