### PR TITLE
chore: run CI lint, build, and test in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,23 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  setup:
-    name: Setup
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-      - name: Install Packages
-        run: HUSKY=0 pnpm install
-
   ci:
     name: ${{ matrix.task }}
-    needs: setup
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -44,5 +29,6 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
-      - run: HUSKY=0 pnpm install
+      - name: Install Packages
+        run: HUSKY=0 pnpm install --frozen-lockfile
       - run: ${{ matrix.command }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  ci:
-    name: Lint, Test & Build
+  setup:
+    name: Setup
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,9 +21,28 @@ jobs:
           cache: 'pnpm'
       - name: Install Packages
         run: HUSKY=0 pnpm install
-      - name: Lint Files
-        run: pnpm run lint
-      - name: Build
-        run: pnpm run build
-      - name: Tests
-        run: pnpm run test
+
+  ci:
+    name: ${{ matrix.task }}
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - task: Lint
+            command: pnpm run lint
+          - task: Build
+            command: pnpm run build
+          - task: Test
+            command: pnpm run test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - run: HUSKY=0 pnpm install
+      - run: ${{ matrix.command }}


### PR DESCRIPTION
## Summary

- Splits the single sequential CI job into a setup job + matrix strategy
- Lint, Build, and Test now run in parallel after setup primes the pnpm cache
- Uses `fail-fast: false` so all three report results even if one fails

## Test plan

- [x] CI workflow runs successfully with parallel jobs
- [x] All three matrix jobs (Lint, Build, Test) complete independently
- [x] Failure in one job doesn't cancel the others