### PR TITLE
refactor: migrate ApexLogServer to MCP SDK with Zod schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.26.0",
     "@salesforce/core": "^8.23.4",
-    "@toon-format/toon": "^1.0.0"
+    "@toon-format/toon": "^1.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,16 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: 1.26.0
-        version: 1.26.0(zod@3.25.76)
+        version: 1.26.0(zod@4.3.6)
       '@salesforce/core':
         specifier: ^8.23.4
         version: 8.23.4
       '@toon-format/toon':
         specifier: ^1.0.0
         version: 1.0.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -2614,8 +2617,8 @@ packages:
     peerDependencies:
       zod: ^3.25 || ^4
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -3169,7 +3172,7 @@ snapshots:
       '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.26.0(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.7)
       ajv: 8.17.1
@@ -3186,8 +3189,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -5570,8 +5573,8 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-to-json-schema@3.25.1(zod@3.25.76):
+  zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
-      zod: 3.25.76
+      zod: 4.3.6
 
-  zod@3.25.76: {}
+  zod@4.3.6: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,44 +5,35 @@
  */
 
 import { parseArgs } from "node:util";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   analyzeLogPerformance,
-  analyzeLogPerformanceTool,
-  AnalyzeLogArgs,
+  analyzeLogPerformanceToolConfig,
 } from "./tools/analyzeLogPerformance.js";
 import {
   getLogSummary,
-  getLogSummaryTool,
-  LogSummaryArgs,
+  getLogSummaryToolConfig,
 } from "./tools/getLogSummary.js";
 import {
   findPerformanceBottlenecks,
-  findPerformanceBottlenecksTool,
-  BottleneckArgs,
+  findPerformanceBottlenecksToolConfig,
 } from "./tools/findPerformanceBottlenecks.js";
 import {
   executeAnonymous,
-  executeAnonymousTool,
+  executeAnonymousToolConfig,
   ExecuteAnonymousArgs,
 } from "./tools/executeAnonymous.js";
 
-function parseToolArgs<T>(args: Record<string, unknown> | undefined): T {
-  return (args ?? {}) as T;
-}
-
 class ApexLogServer {
-  private server: Server;
+  private server: McpServer;
   private allowedOrgs: string[];
+  private execAnonTool: RegisteredTool;
 
   constructor(allowedOrgs: string[] = []) {
     this.allowedOrgs = allowedOrgs;
-    this.server = new Server(
+    this.server = new McpServer(
       {
         name: "apex-log-mcp",
         version: "1.0.0",
@@ -58,12 +49,12 @@ class ApexLogServer {
       },
     );
 
-    this.setupToolHandlers();
+    this.execAnonTool = this.registerTools();
     this.setupErrorHandling();
   }
 
   private setupErrorHandling(): void {
-    this.server.onerror = (error) => {
+    this.server.server.onerror = (error) => {
       console.error("[MCP Error]", error);
     };
 
@@ -74,59 +65,47 @@ class ApexLogServer {
     process.once("SIGINT", shutdown);
   }
 
-  private setupToolHandlers(): void {
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: [
-        analyzeLogPerformanceTool,
-        getLogSummaryTool,
-        findPerformanceBottlenecksTool,
-        ...(this.allowedOrgs.length > 0 ? [executeAnonymousTool] : []),
-      ],
-    }));
+  private registerTools(): RegisteredTool {
+    this.server.registerTool(
+      "analyze_apex_log_performance",
+      analyzeLogPerformanceToolConfig,
+      async (args) => analyzeLogPerformance(args),
+    );
 
-    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      const { name, arguments: args } = request.params;
+    this.server.registerTool(
+      "get_apex_log_summary",
+      getLogSummaryToolConfig,
+      async (args) => getLogSummary(args),
+    );
 
-      try {
-        switch (name) {
-          case "analyze_apex_log_performance":
-            return await analyzeLogPerformance(
-              parseToolArgs<AnalyzeLogArgs>(args),
-            );
-          case "get_apex_log_summary":
-            return await getLogSummary(parseToolArgs<LogSummaryArgs>(args));
-          case "find_performance_bottlenecks":
-            return await findPerformanceBottlenecks(
-              parseToolArgs<BottleneckArgs>(args),
-            );
-          case "execute_anonymous":
-            if (this.allowedOrgs.length === 0) {
-              throw new Error(
-                "execute_anonymous is disabled. Configure --allowed-orgs to enable it.",
-              );
-            }
-            return await executeAnonymous(
-              this.server,
-              parseToolArgs<ExecuteAnonymousArgs>(args),
-              this.allowedOrgs,
-            );
-          default:
-            throw new Error(`Unknown tool: ${name}`);
+    this.server.registerTool(
+      "find_performance_bottlenecks",
+      findPerformanceBottlenecksToolConfig,
+      async (args) => findPerformanceBottlenecks(args),
+    );
+
+    const execAnon = this.server.registerTool(
+      "execute_anonymous",
+      executeAnonymousToolConfig,
+      async (args) => {
+        if (this.allowedOrgs.length === 0) {
+          throw new Error(
+            "execute_anonymous is disabled. Configure --allowed-orgs to enable it.",
+          );
         }
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Error: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            },
-          ],
-          isError: true,
-        };
-      }
-    });
+        return executeAnonymous(
+          this.server,
+          args as ExecuteAnonymousArgs,
+          this.allowedOrgs,
+        );
+      },
+    );
+
+    if (this.allowedOrgs.length === 0) {
+      execAnon.disable();
+    }
+
+    return execAnon;
   }
 
   async run(): Promise<void> {
@@ -140,6 +119,10 @@ class ApexLogServer {
     this.allowedOrgs = values["allowed-orgs"]
       ? values["allowed-orgs"].split(",").map((org) => org.trim())
       : [];
+
+    if (this.allowedOrgs.length > 0) {
+      this.execAnonTool.enable();
+    }
 
     const transport = new StdioServerTransport();
     await this.server.connect(transport);

--- a/src/tools/analyzeLogPerformance.ts
+++ b/src/tools/analyzeLogPerformance.ts
@@ -3,15 +3,44 @@
  */
 
 import { promises as fs } from "fs";
+import { z } from "zod";
 import { parse, ApexLog, LogLine } from "../ApexLogParser.js";
 import { encode } from "@toon-format/toon";
 
-export interface AnalyzeLogArgs {
-  logFilePath: string;
-  topMethods?: number;
-  minDuration?: number;
-  namespace?: string;
-}
+export const analyzeLogPerformanceInputSchema = {
+  logFilePath: z
+    .string()
+    .describe("Absolute path to the Apex debug log file (.log)"),
+  topMethods: z
+    .number()
+    .optional()
+    .describe("Number of slowest methods to return (default: 10)"),
+  minDuration: z
+    .number()
+    .optional()
+    .describe(
+      "Minimum duration in nanoseconds to include a method. For reference: 1ms = 1,000,000ns, 1s = 1,000,000,000ns (default: 0)",
+    ),
+  namespace: z.string().optional().describe("Filter methods by namespace"),
+};
+
+export type AnalyzeLogArgs = z.infer<
+  z.ZodObject<typeof analyzeLogPerformanceInputSchema>
+>;
+
+export const analyzeLogPerformanceToolConfig = {
+  title: "Analyze Apex Log Performance",
+  description:
+    "Rank methods in an Apex debug log by self-execution time. Returns method names, durations, SOQL/DML counts, and optimization recommendations. Best for finding which specific methods to optimize.",
+  inputSchema: analyzeLogPerformanceInputSchema,
+  annotations: {
+    title: "Analyze Apex Log Performance",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+};
 
 export interface SlowMethod {
   name: string;
@@ -33,44 +62,6 @@ export interface LogAnalysisResult {
   summary: string;
   recommendations: string[];
 }
-
-export const analyzeLogPerformanceTool = {
-  name: "analyze_apex_log_performance",
-  description:
-    "Rank methods in an Apex debug log by self-execution time. Returns method names, durations, SOQL/DML counts, and optimization recommendations. Best for finding which specific methods to optimize.",
-  annotations: {
-    title: "Analyze Apex Log Performance",
-    readOnlyHint: true,
-    destructiveHint: false,
-    idempotentHint: true,
-    openWorldHint: false,
-  },
-  inputSchema: {
-    type: "object",
-    properties: {
-      logFilePath: {
-        type: "string",
-        description: "Absolute path to the Apex debug log file (.log)",
-      },
-      topMethods: {
-        type: "number",
-        description: "Number of slowest methods to return (default: 10)",
-        default: 10,
-      },
-      minDuration: {
-        type: "number",
-        description:
-          "Minimum duration in nanoseconds to include a method. For reference: 1ms = 1,000,000ns, 1s = 1,000,000,000ns (default: 0)",
-        default: 0,
-      },
-      namespace: {
-        type: "string",
-        description: "Filter methods by namespace",
-      },
-    },
-    required: ["logFilePath"],
-  },
-};
 
 export async function analyzeLogPerformance(args: AnalyzeLogArgs) {
   const { logFilePath, topMethods = 10, minDuration = 0, namespace } = args;
@@ -106,7 +97,7 @@ export async function analyzeLogPerformance(args: AnalyzeLogArgs) {
   return {
     content: [
       {
-        type: "text",
+        type: "text" as const,
         text: encode(result),
       },
     ],

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -1,4 +1,5 @@
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   Connection,
   ConfigAggregator,
@@ -13,12 +14,6 @@ import {
 import { ensureTraceFlag } from "../salesforce/traceFlags.js";
 import { connect } from "../salesforce/connection.js";
 
-export interface ExecuteAnonymousArgs {
-  apex: string;
-  targetOrg?: string;
-  debugLevel?: DebugLevelInput;
-}
-
 type ApexLogRecord = {
   Id: string;
 };
@@ -32,16 +27,67 @@ const LOG_LEVEL_ENUM = [
   "FINE",
   "FINER",
   "FINEST",
-];
+] as const;
+
+const logLevelSchema = z.enum(LOG_LEVEL_ENUM);
 
 function logLevelProperty(description: string) {
-  return { type: "string", enum: LOG_LEVEL_ENUM, description };
+  return logLevelSchema.optional().describe(description);
 }
 
-export const executeAnonymousTool = {
-  name: "execute_anonymous",
+export const executeAnonymousInputSchema = {
+  apex: z.string().describe("The anonymous Apex to be executed"),
+  targetOrg: z
+    .string()
+    .optional()
+    .describe(
+      "Alias or username of the target Salesforce org. Uses the project default if not specified.",
+    ),
+  debugLevel: z
+    .union([
+      z
+        .enum(["default", ...LOG_LEVEL_ENUM])
+        .describe(
+          'Use "default" to reset to defaults, or a log level (e.g. "FINEST") to set all categories to that level.',
+        ),
+      z
+        .object({
+          apexCode: logLevelProperty("Apex code log level (default: FINE)"),
+          apexProfiling: logLevelProperty(
+            "Apex profiling log level (default: FINE)",
+          ),
+          callout: logLevelProperty("Callout log level (default: DEBUG)"),
+          database: logLevelProperty("Database log level (default: FINEST)"),
+          nba: logLevelProperty(
+            "NBA (Next Best Action) log level (default: INFO)",
+          ),
+          system: logLevelProperty("System log level (default: DEBUG)"),
+          validation: logLevelProperty("Validation log level (default: DEBUG)"),
+          visualforce: logLevelProperty(
+            "Visualforce log level (default: FINE)",
+          ),
+          wave: logLevelProperty("Wave/Analytics log level (default: INFO)"),
+          workflow: logLevelProperty("Workflow log level (default: FINE)"),
+        })
+        .describe(
+          "Override specific log categories. Only specified categories are updated; others remain unchanged.",
+        ),
+    ])
+    .optional()
+    .describe(
+      'Optional debug level configuration. Valid log levels: NONE, ERROR, WARN, INFO, DEBUG, FINE, FINER, FINEST. Pass "default" to reset, a single level string to set all categories, or an object with category overrides (apexCode, apexProfiling, callout, database, nba, system, validation, visualforce, wave, workflow).',
+    ),
+};
+
+export type ExecuteAnonymousArgs = z.infer<
+  z.ZodObject<typeof executeAnonymousInputSchema>
+>;
+
+export const executeAnonymousToolConfig = {
+  title: "Execute Anonymous Apex",
   description:
     "Execute a snippet of anonymous Apex against an authenticated Salesforce org (via SF CLI) and retrieve the resulting debug log. The response includes the target org username.",
+  inputSchema: executeAnonymousInputSchema,
   annotations: {
     title: "Execute Anonymous Apex",
     readOnlyHint: false,
@@ -49,68 +95,11 @@ export const executeAnonymousTool = {
     idempotentHint: false,
     openWorldHint: true,
   },
-  inputSchema: {
-    type: "object",
-    properties: {
-      apex: {
-        type: "string",
-        description: "The anonymous Apex to be executed",
-      },
-      targetOrg: {
-        type: "string",
-        description:
-          "Alias or username of the target Salesforce org. Uses the project default if not specified.",
-      },
-      debugLevel: {
-        description:
-          'Optional debug level configuration. Valid log levels: NONE, ERROR, WARN, INFO, DEBUG, FINE, FINER, FINEST. Pass "default" to reset, a single level string to set all categories, or an object with category overrides (apexCode, apexProfiling, callout, database, nba, system, validation, visualforce, wave, workflow).',
-        oneOf: [
-          {
-            type: "string",
-            enum: ["default", ...LOG_LEVEL_ENUM],
-            description:
-              'Use "default" to reset to defaults, or a log level (e.g. "FINEST") to set all categories to that level.',
-          },
-          {
-            type: "object",
-            description:
-              "Override specific log categories. Only specified categories are updated; others remain unchanged.",
-            properties: {
-              apexCode: logLevelProperty("Apex code log level (default: FINE)"),
-              apexProfiling: logLevelProperty(
-                "Apex profiling log level (default: FINE)",
-              ),
-              callout: logLevelProperty("Callout log level (default: DEBUG)"),
-              database: logLevelProperty(
-                "Database log level (default: FINEST)",
-              ),
-              nba: logLevelProperty(
-                "NBA (Next Best Action) log level (default: INFO)",
-              ),
-              system: logLevelProperty("System log level (default: DEBUG)"),
-              validation: logLevelProperty(
-                "Validation log level (default: DEBUG)",
-              ),
-              visualforce: logLevelProperty(
-                "Visualforce log level (default: FINE)",
-              ),
-              wave: logLevelProperty(
-                "Wave/Analytics log level (default: INFO)",
-              ),
-              workflow: logLevelProperty("Workflow log level (default: FINE)"),
-            },
-            additionalProperties: false,
-          },
-        ],
-      },
-    },
-    required: ["apex"],
-  },
 };
 
-async function getProjectPath(server: Server): Promise<string | undefined> {
+async function getProjectPath(server: McpServer): Promise<string | undefined> {
   try {
-    const { roots } = await server.listRoots();
+    const { roots } = await server.server.listRoots();
     const rootUri = roots[0]?.uri;
     return rootUri ? new URL(rootUri).pathname : undefined;
   } catch {
@@ -190,7 +179,7 @@ async function validateOrgAllowlist(
 }
 
 export async function executeAnonymous(
-  server: Server,
+  server: McpServer,
   args: ExecuteAnonymousArgs,
   allowedOrgs: string[] = [],
 ) {
@@ -240,7 +229,7 @@ export async function executeAnonymous(
   return {
     content: [
       {
-        type: "text",
+        type: "text" as const,
         text: `Org: ${orgLabel}\n\n${logBody}`,
       },
     ],

--- a/src/tools/findPerformanceBottlenecks.ts
+++ b/src/tools/findPerformanceBottlenecks.ts
@@ -3,14 +3,26 @@
  */
 
 import { promises as fs } from "fs";
+import { z } from "zod";
 import { parse, ApexLog } from "../ApexLogParser.js";
 import { SlowMethod, extractMethods } from "./analyzeLogPerformance.js";
 import { encode } from "@toon-format/toon";
 
-export interface BottleneckArgs {
-  logFilePath: string;
-  analysisType?: "cpu" | "database" | "methods" | "all";
-}
+export const findPerformanceBottlenecksInputSchema = {
+  logFilePath: z
+    .string()
+    .describe("Absolute path to the Apex debug log file (.log)"),
+  analysisType: z
+    .enum(["cpu", "database", "methods", "all"])
+    .optional()
+    .describe(
+      'Type of analysis: "cpu" checks CPU time governor limit, "database" checks SOQL query/DML statement/query row limits, "methods" groups methods by namespace with duration totals, "all" runs all three (default)',
+    ),
+};
+
+export type BottleneckArgs = z.infer<
+  z.ZodObject<typeof findPerformanceBottlenecksInputSchema>
+>;
 
 export interface BottleneckResult {
   cpuBottlenecks?: Record<string, unknown>;
@@ -19,33 +31,17 @@ export interface BottleneckResult {
   governorLimitWarnings: Record<string, unknown>;
 }
 
-export const findPerformanceBottlenecksTool = {
-  name: "find_performance_bottlenecks",
+export const findPerformanceBottlenecksToolConfig = {
+  title: "Find Performance Bottlenecks",
   description:
     "Check whether an Apex log transaction is approaching governor limits (flags usage above 80%). Analyzes CPU time, SOQL/DML limits, query rows, and method execution patterns by namespace. Best for checking if a transaction is at risk of hitting governor limits.",
+  inputSchema: findPerformanceBottlenecksInputSchema,
   annotations: {
     title: "Find Performance Bottlenecks",
     readOnlyHint: true,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: false,
-  },
-  inputSchema: {
-    type: "object",
-    properties: {
-      logFilePath: {
-        type: "string",
-        description: "Absolute path to the Apex debug log file (.log)",
-      },
-      analysisType: {
-        type: "string",
-        enum: ["cpu", "database", "methods", "all"],
-        description:
-          'Type of analysis: "cpu" checks CPU time governor limit, "database" checks SOQL query/DML statement/query row limits, "methods" groups methods by namespace with duration totals, "all" runs all three (default)',
-        default: "all",
-      },
-    },
-    required: ["logFilePath"],
   },
 };
 
@@ -82,7 +78,7 @@ export async function findPerformanceBottlenecks(args: BottleneckArgs) {
   return {
     content: [
       {
-        type: "text",
+        type: "text" as const,
         text: encode(bottlenecks),
       },
     ],

--- a/src/tools/getLogSummary.ts
+++ b/src/tools/getLogSummary.ts
@@ -4,33 +4,31 @@
 
 import { promises as fs } from "fs";
 import path from "path";
+import { z } from "zod";
 import { parse, ApexLog, LogLine } from "../ApexLogParser.js";
 import { encode } from "@toon-format/toon";
 
-export interface LogSummaryArgs {
-  logFilePath: string;
-}
+export const getLogSummaryInputSchema = {
+  logFilePath: z
+    .string()
+    .describe("Absolute path to the Apex debug log file (.log)"),
+};
 
-export const getLogSummaryTool = {
-  name: "get_apex_log_summary",
+export type LogSummaryArgs = z.infer<
+  z.ZodObject<typeof getLogSummaryInputSchema>
+>;
+
+export const getLogSummaryToolConfig = {
+  title: "Get Apex Log Summary",
   description:
     "Get a high-level summary of an Apex debug log including total execution time, method count, SOQL/DML totals, governor limits, and active namespaces. Best for a quick overview before deeper analysis.",
+  inputSchema: getLogSummaryInputSchema,
   annotations: {
     title: "Get Apex Log Summary",
     readOnlyHint: true,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: false,
-  },
-  inputSchema: {
-    type: "object",
-    properties: {
-      logFilePath: {
-        type: "string",
-        description: "Absolute path to the Apex debug log file (.log)",
-      },
-    },
-    required: ["logFilePath"],
   },
 };
 
@@ -68,7 +66,7 @@ export async function getLogSummary(args: LogSummaryArgs) {
   return {
     content: [
       {
-        type: "text",
+        type: "text" as const,
         text: encode(summary),
       },
     ],

--- a/tests/analyzeLogPerformance.test.ts
+++ b/tests/analyzeLogPerformance.test.ts
@@ -8,7 +8,8 @@ import {
   extractMethods,
   AnalyzeLogArgs,
   LogAnalysisResult,
-  analyzeLogPerformanceTool,
+  analyzeLogPerformanceToolConfig,
+  analyzeLogPerformanceInputSchema,
 } from "../src/tools/analyzeLogPerformance";
 import { parse } from "../src/ApexLogParser";
 import { decode } from "@toon-format/toon";
@@ -35,24 +36,13 @@ describe("analyzeLogPerformance", () => {
 
   describe("Tool Configuration", () => {
     it("should have correct tool configuration", () => {
-      expect(analyzeLogPerformanceTool.name).toBe(
-        "analyze_apex_log_performance",
-      );
-      expect(analyzeLogPerformanceTool.description).toContain(
+      expect(analyzeLogPerformanceToolConfig.description).toContain(
         "Rank methods in an Apex debug log by self-execution time",
       );
-      expect(analyzeLogPerformanceTool.inputSchema.required).toEqual([
-        "logFilePath",
-      ]);
-      expect(
-        analyzeLogPerformanceTool.inputSchema.properties.logFilePath.type,
-      ).toBe("string");
-      expect(
-        analyzeLogPerformanceTool.inputSchema.properties.topMethods.default,
-      ).toBe(10);
-      expect(
-        analyzeLogPerformanceTool.inputSchema.properties.minDuration.default,
-      ).toBe(0);
+      expect(analyzeLogPerformanceInputSchema.logFilePath).toBeDefined();
+      expect(analyzeLogPerformanceInputSchema.topMethods).toBeDefined();
+      expect(analyzeLogPerformanceInputSchema.minDuration).toBeDefined();
+      expect(analyzeLogPerformanceInputSchema.namespace).toBeDefined();
     });
   });
 

--- a/tests/executeAnonymous.test.ts
+++ b/tests/executeAnonymous.test.ts
@@ -31,9 +31,9 @@ jest.mock("@salesforce/core", () => {
   };
 });
 
-jest.mock("@modelcontextprotocol/sdk/server/index.js");
+jest.mock("@modelcontextprotocol/sdk/server/mcp.js");
 
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ConfigAggregator, StateAggregator } from "@salesforce/core";
 import {
   executeAnonymous,
@@ -55,7 +55,7 @@ describe("Execute Anonymous", () => {
   const testLogBody = "APEX DEBUG LOG CONTENT HERE";
   const testApexCode = "System.debug('Hello World');";
 
-  let mockServer: Server;
+  let mockServer: McpServer;
   let mockConnection: any;
   let mockTooling: any;
   let mockExecuteAnonymous: any;
@@ -68,8 +68,10 @@ describe("Execute Anonymous", () => {
     jest.clearAllMocks();
 
     mockServer = {
-      listRoots: jest.fn().mockResolvedValue({ roots: [] }),
-    } as unknown as Server;
+      server: {
+        listRoots: jest.fn().mockResolvedValue({ roots: [] }),
+      },
+    } as unknown as McpServer;
 
     mockExecuteAnonymous = jest.fn();
     mockRequest = jest.fn();
@@ -643,21 +645,17 @@ describe("Execute Anonymous", () => {
     });
   });
 
-  describe("executeAnonymousTool", () => {
+  describe("executeAnonymousToolConfig", () => {
     it("should have correct tool definition", async () => {
-      const { executeAnonymousTool } =
+      const { executeAnonymousToolConfig, executeAnonymousInputSchema } =
         await import("../src/tools/executeAnonymous");
 
-      expect(executeAnonymousTool.name).toBe("execute_anonymous");
-      expect(executeAnonymousTool.description).toContain(
+      expect(executeAnonymousToolConfig.description).toContain(
         "Execute a snippet of anonymous Apex",
       );
-      expect(executeAnonymousTool.inputSchema.type).toBe("object");
-      expect(executeAnonymousTool.inputSchema.properties.apex).toBeDefined();
-      expect(executeAnonymousTool.inputSchema.properties.apex.type).toBe(
-        "string",
-      );
-      expect(executeAnonymousTool.inputSchema.required).toContain("apex");
+      expect(executeAnonymousInputSchema.apex).toBeDefined();
+      expect(executeAnonymousInputSchema.targetOrg).toBeDefined();
+      expect(executeAnonymousInputSchema.debugLevel).toBeDefined();
     });
   });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,15 +2,25 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  ListToolsRequestSchema,
-  CallToolRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
 
 // Mock the MCP SDK components
-jest.mock("@modelcontextprotocol/sdk/server/index.js");
+jest.mock("@modelcontextprotocol/sdk/server/mcp.js", () => ({
+  McpServer: jest.fn().mockImplementation(() => ({
+    registerTool: jest.fn(() => ({
+      enable: jest.fn(),
+      disable: jest.fn(),
+      remove: jest.fn(),
+      update: jest.fn(),
+      enabled: true,
+    })),
+    connect: jest.fn(),
+    close: jest.fn(),
+    sendToolListChanged: jest.fn(),
+    server: { onerror: undefined },
+  })),
+}));
 jest.mock("@modelcontextprotocol/sdk/server/stdio.js");
 
 import { ApexLogServer } from "../src/index";
@@ -18,100 +28,51 @@ import { ApexLogServer } from "../src/index";
 // Mock the tool modules
 jest.mock("../src/tools/analyzeLogPerformance", () => ({
   analyzeLogPerformance: jest.fn(),
-  analyzeLogPerformanceTool: {
-    name: "analyze_apex_log_performance",
+  analyzeLogPerformanceToolConfig: {
+    title: "Analyze Apex Log Performance",
     description:
       "Analyze an Apex debug log file and identify the slowest running methods",
-    inputSchema: {
-      type: "object",
-      properties: {
-        logFilePath: {
-          type: "string",
-          description: "Absolute path to the log file",
-        },
-        topMethods: { type: "number", default: 10 },
-        minDuration: { type: "number", default: 0 },
-        namespace: { type: "string" },
-      },
-      required: ["logFilePath"],
-    },
+    inputSchema: {},
+    annotations: {},
   },
 }));
 
 jest.mock("../src/tools/getLogSummary", () => ({
   getLogSummary: jest.fn(),
-  getLogSummaryTool: {
-    name: "get_apex_log_summary",
+  getLogSummaryToolConfig: {
+    title: "Get Apex Log Summary",
     description: "Get a high-level summary of an Apex debug log",
-    inputSchema: {
-      type: "object",
-      properties: {
-        logFilePath: {
-          type: "string",
-          description: "Absolute path to the log file",
-        },
-      },
-      required: ["logFilePath"],
-    },
+    inputSchema: {},
+    annotations: {},
   },
 }));
 
 jest.mock("../src/tools/findPerformanceBottlenecks", () => ({
   findPerformanceBottlenecks: jest.fn(),
-  findPerformanceBottlenecksTool: {
-    name: "find_performance_bottlenecks",
+  findPerformanceBottlenecksToolConfig: {
+    title: "Find Performance Bottlenecks",
     description: "Identify performance bottlenecks in an Apex log",
-    inputSchema: {
-      type: "object",
-      properties: {
-        logFilePath: {
-          type: "string",
-          description: "Absolute path to the log file",
-        },
-        analysisType: {
-          type: "string",
-          enum: ["cpu", "database", "methods", "all"],
-          default: "all",
-        },
-      },
-      required: ["logFilePath"],
-    },
+    inputSchema: {},
+    annotations: {},
   },
 }));
 
 jest.mock("../src/tools/executeAnonymous", () => ({
   executeAnonymous: jest.fn(),
-  executeAnonymousTool: {
-    name: "execute_anonymous",
+  executeAnonymousToolConfig: {
+    title: "Execute Anonymous Apex",
     description:
       "Execute a snippet of anonymous Apex and retrieve the resulting log",
-    inputSchema: {
-      type: "object",
-      properties: {
-        apex: {
-          type: "string",
-          description: "The anonymous Apex to be executed",
-        },
-      },
-      required: ["apex"],
-    },
+    inputSchema: {},
+    annotations: {},
   },
 }));
 
 // Import the tools after mocking
-import {
-  analyzeLogPerformance,
-  analyzeLogPerformanceTool,
-} from "../src/tools/analyzeLogPerformance";
-import { getLogSummary, getLogSummaryTool } from "../src/tools/getLogSummary";
-import {
-  findPerformanceBottlenecks,
-  findPerformanceBottlenecksTool,
-} from "../src/tools/findPerformanceBottlenecks";
-import {
-  executeAnonymous,
-  executeAnonymousTool,
-} from "../src/tools/executeAnonymous";
+import { analyzeLogPerformance } from "../src/tools/analyzeLogPerformance";
+import { getLogSummary } from "../src/tools/getLogSummary";
+import { findPerformanceBottlenecks } from "../src/tools/findPerformanceBottlenecks";
+import { executeAnonymous } from "../src/tools/executeAnonymous";
 
 // Mock process methods
 const mockExit = jest.spyOn(process, "exit").mockImplementation((() => {
@@ -124,19 +85,20 @@ const mockConsoleError = jest
   .mockImplementation(() => {});
 
 describe("ApexLogServer", () => {
-  let mockServer: jest.Mocked<Server>;
+  let mockRegisterTool: jest.Mock;
+  let mockConnect: jest.Mock;
+  let mockClose: jest.Mock;
   let mockTransport: jest.Mocked<StdioServerTransport>;
-  let mockSetRequestHandler: jest.MockedFunction<
-    typeof Server.prototype.setRequestHandler
+  let registeredTools: Map<
+    string,
+    { config: any; callback: (...args: any[]) => any; enabled: boolean }
   >;
-  let mockConnect: jest.MockedFunction<typeof Server.prototype.connect>;
-  let mockClose: jest.MockedFunction<typeof Server.prototype.close>;
 
   // Mock data for testing
   const mockAnalysisResult = {
     content: [
       {
-        type: "text",
+        type: "text" as const,
         text: JSON.stringify({
           totalMethods: 5,
           totalExecutionTime: 1000000,
@@ -151,7 +113,7 @@ describe("ApexLogServer", () => {
   const mockSummaryResult = {
     content: [
       {
-        type: "text",
+        type: "text" as const,
         text: JSON.stringify({
           file: "test.log",
           totalExecutionTime: 1000000,
@@ -165,7 +127,7 @@ describe("ApexLogServer", () => {
   const mockBottleneckResult = {
     content: [
       {
-        type: "text",
+        type: "text" as const,
         text: JSON.stringify({
           cpuBottlenecks: {},
           databaseBottlenecks: {},
@@ -178,7 +140,7 @@ describe("ApexLogServer", () => {
   const mockExecuteAnonymousResult = {
     content: [
       {
-        type: "text",
+        type: "text" as const,
         text: "APEX DEBUG LOG CONTENT",
       },
     ],
@@ -187,23 +149,44 @@ describe("ApexLogServer", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    // Setup server mock
-    mockSetRequestHandler = jest.fn();
+    registeredTools = new Map();
+
+    mockRegisterTool = jest.fn((name, config, callback) => {
+      const tool = {
+        config,
+        callback,
+        enabled: true,
+        enable: jest.fn(() => {
+          tool.enabled = true;
+        }),
+        disable: jest.fn(() => {
+          tool.enabled = false;
+        }),
+        remove: jest.fn(),
+        update: jest.fn(),
+      };
+      registeredTools.set(name, tool);
+      return tool;
+    });
     mockConnect = jest.fn();
     mockClose = jest.fn();
 
-    mockServer = {
-      setRequestHandler: mockSetRequestHandler,
+    const mockServer = {
+      registerTool: mockRegisterTool,
       connect: mockConnect,
       close: mockClose,
-      onerror: undefined,
-    } as any;
+      sendToolListChanged: jest.fn(),
+      server: {
+        onerror: undefined as ((error: unknown) => void) | undefined,
+        listRoots: jest.fn(),
+      },
+    };
 
     // Setup transport mock
     mockTransport = {} as jest.Mocked<StdioServerTransport>;
 
-    (Server as jest.MockedClass<typeof Server>).mockImplementation(
-      () => mockServer,
+    (McpServer as jest.MockedClass<typeof McpServer>).mockImplementation(
+      () => mockServer as any,
     );
     (
       StdioServerTransport as jest.MockedClass<typeof StdioServerTransport>
@@ -238,7 +221,7 @@ describe("ApexLogServer", () => {
     it("should create server with correct configuration", async () => {
       new ApexLogServer();
 
-      expect(Server).toHaveBeenCalledWith(
+      expect(McpServer).toHaveBeenCalledWith(
         {
           name: "apex-log-mcp",
           version: "1.0.0",
@@ -256,13 +239,13 @@ describe("ApexLogServer", () => {
     it("should setup error handling", async () => {
       new ApexLogServer();
 
-      expect(mockServer.onerror).toBeDefined();
+      const mcpInstance = (McpServer as jest.MockedClass<typeof McpServer>).mock
+        .results[0].value;
+      expect(mcpInstance.server.onerror).toBeDefined();
 
       // Test error handler
       const testError = new Error("Test error");
-      if (mockServer.onerror) {
-        mockServer.onerror(testError);
-      }
+      mcpInstance.server.onerror(testError);
 
       expect(mockConsoleError).toHaveBeenCalledWith("[MCP Error]", testError);
     });
@@ -280,157 +263,88 @@ describe("ApexLogServer", () => {
   });
 
   describe("Tool Registration", () => {
-    it("should register ListToolsRequest handler", async () => {
+    it("should register all 4 tools via registerTool", async () => {
       new ApexLogServer();
 
-      expect(mockSetRequestHandler).toHaveBeenCalledWith(
-        ListToolsRequestSchema,
+      expect(mockRegisterTool).toHaveBeenCalledTimes(4);
+      expect(mockRegisterTool).toHaveBeenCalledWith(
+        "analyze_apex_log_performance",
+        expect.any(Object),
+        expect.any(Function),
+      );
+      expect(mockRegisterTool).toHaveBeenCalledWith(
+        "get_apex_log_summary",
+        expect.any(Object),
+        expect.any(Function),
+      );
+      expect(mockRegisterTool).toHaveBeenCalledWith(
+        "find_performance_bottlenecks",
+        expect.any(Object),
+        expect.any(Function),
+      );
+      expect(mockRegisterTool).toHaveBeenCalledWith(
+        "execute_anonymous",
+        expect.any(Object),
         expect.any(Function),
       );
     });
 
-    it("should register CallToolRequest handler", async () => {
-      new ApexLogServer();
-
-      expect(mockSetRequestHandler).toHaveBeenCalledWith(
-        CallToolRequestSchema,
-        expect.any(Function),
-      );
-    });
-
-    it("should return all 4 tools when allowedOrgs is provided", async () => {
+    it("should enable execute_anonymous when allowedOrgs is provided", async () => {
       new ApexLogServer(["ALLOW_ALL_ORGS"]);
 
-      const listToolsCall = mockSetRequestHandler.mock.calls.find(
-        (call: any) => call[0] === ListToolsRequestSchema,
-      );
-      expect(listToolsCall).toBeDefined();
-
-      const listToolsHandler = listToolsCall![1];
-      const result = await listToolsHandler({} as any, {} as any);
-
-      expect(result).toEqual({
-        tools: [
-          analyzeLogPerformanceTool,
-          getLogSummaryTool,
-          findPerformanceBottlenecksTool,
-          executeAnonymousTool,
-        ],
-      });
+      const execAnonTool = registeredTools.get("execute_anonymous")!;
+      expect(execAnonTool.enabled).toBe(true);
     });
 
-    it("should return 3 tools when allowedOrgs is empty", async () => {
+    it("should disable execute_anonymous when allowedOrgs is empty", async () => {
       new ApexLogServer();
 
-      const listToolsCall = mockSetRequestHandler.mock.calls.find(
-        (call: any) => call[0] === ListToolsRequestSchema,
-      );
-      expect(listToolsCall).toBeDefined();
-
-      const listToolsHandler = listToolsCall![1];
-      const result = await listToolsHandler({} as any, {} as any);
-
-      expect(result).toEqual({
-        tools: [
-          analyzeLogPerformanceTool,
-          getLogSummaryTool,
-          findPerformanceBottlenecksTool,
-        ],
-      });
+      const execAnonTool = registeredTools.get("execute_anonymous")!;
+      expect(execAnonTool.enabled).toBe(false);
     });
   });
 
   describe("Tool Request Handling", () => {
-    let callToolHandler: (request: any, extra: any) => Promise<any>;
-
-    beforeEach(async () => {
+    it("should handle analyze_apex_log_performance tool correctly", async () => {
       new ApexLogServer(["ALLOW_ALL_ORGS"]);
 
-      // Get the CallToolRequest handler
-      const callToolCall = mockSetRequestHandler.mock.calls.find(
-        (call: any) => call[0] === CallToolRequestSchema,
-      );
-      expect(callToolCall).toBeDefined();
-      callToolHandler = callToolCall![1];
-    });
-
-    it("should handle analyze_apex_log_performance tool correctly", async () => {
-      const request = {
-        params: {
-          name: "analyze_apex_log_performance",
-          arguments: {
-            logFilePath: "/path/to/test.log",
-            topMethods: 5,
-          },
-        },
-      };
-
-      const result = await callToolHandler(request, {} as any);
-
-      expect(analyzeLogPerformance).toHaveBeenCalledWith({
+      const tool = registeredTools.get("analyze_apex_log_performance")!;
+      const args = {
         logFilePath: "/path/to/test.log",
         topMethods: 5,
-      });
+      };
+
+      const result = await tool.callback(args, {} as any);
+
+      expect(analyzeLogPerformance).toHaveBeenCalledWith(args);
       expect(result).toEqual(mockAnalysisResult);
     });
 
     it("should handle get_apex_log_summary tool correctly", async () => {
-      const request = {
-        params: {
-          name: "get_apex_log_summary",
-          arguments: {
-            logFilePath: "/path/to/test.log",
-          },
-        },
-      };
+      new ApexLogServer(["ALLOW_ALL_ORGS"]);
 
-      const result = await callToolHandler(request, {} as any);
+      const tool = registeredTools.get("get_apex_log_summary")!;
+      const args = { logFilePath: "/path/to/test.log" };
 
-      expect(getLogSummary).toHaveBeenCalledWith({
-        logFilePath: "/path/to/test.log",
-      });
+      const result = await tool.callback(args, {} as any);
+
+      expect(getLogSummary).toHaveBeenCalledWith(args);
       expect(result).toEqual(mockSummaryResult);
     });
 
     it("should handle find_performance_bottlenecks tool correctly", async () => {
-      const request = {
-        params: {
-          name: "find_performance_bottlenecks",
-          arguments: {
-            logFilePath: "/path/to/test.log",
-            analysisType: "cpu",
-          },
-        },
-      };
+      new ApexLogServer(["ALLOW_ALL_ORGS"]);
 
-      const result = await callToolHandler(request, {} as any);
-
-      expect(findPerformanceBottlenecks).toHaveBeenCalledWith({
+      const tool = registeredTools.get("find_performance_bottlenecks")!;
+      const args = {
         logFilePath: "/path/to/test.log",
         analysisType: "cpu",
-      });
-      expect(result).toEqual(mockBottleneckResult);
-    });
-
-    it("should return error for unknown tool", async () => {
-      const request = {
-        params: {
-          name: "unknown_tool",
-          arguments: {},
-        },
       };
 
-      const result = await callToolHandler(request, {} as any);
+      const result = await tool.callback(args, {} as any);
 
-      expect(result).toEqual({
-        content: [
-          {
-            type: "text",
-            text: "Error: Unknown tool: unknown_tool",
-          },
-        ],
-        isError: true,
-      });
+      expect(findPerformanceBottlenecks).toHaveBeenCalledWith(args);
+      expect(result).toEqual(mockBottleneckResult);
     });
 
     it("should handle tool execution errors gracefully", async () => {
@@ -441,98 +355,25 @@ describe("ApexLogServer", () => {
         >
       ).mockRejectedValueOnce(error);
 
-      const request = {
-        params: {
-          name: "analyze_apex_log_performance",
-          arguments: {
-            logFilePath: "/path/to/test.log",
-          },
-        },
-      };
+      new ApexLogServer();
 
-      const result = await callToolHandler(request, {} as any);
+      const tool = registeredTools.get("analyze_apex_log_performance")!;
 
-      expect(result).toEqual({
-        content: [
-          {
-            type: "text",
-            text: "Error: Tool execution failed",
-          },
-        ],
-        isError: true,
-      });
-    });
-
-    it("should handle non-Error exceptions", async () => {
-      (
-        analyzeLogPerformance as jest.MockedFunction<
-          typeof analyzeLogPerformance
-        >
-      ).mockRejectedValueOnce("String error");
-
-      const request = {
-        params: {
-          name: "analyze_apex_log_performance",
-          arguments: {
-            logFilePath: "/path/to/test.log",
-          },
-        },
-      };
-
-      const result = await callToolHandler(request, {} as any);
-
-      expect(result).toEqual({
-        content: [
-          {
-            type: "text",
-            text: "Error: String error",
-          },
-        ],
-        isError: true,
-      });
+      await expect(
+        tool.callback({ logFilePath: "/path/to/test.log" }, {} as any),
+      ).rejects.toThrow("Tool execution failed");
     });
 
     it("should return error when execute_anonymous called with empty allowedOrgs", async () => {
-      // Create server with no allowed orgs
-      jest.clearAllMocks();
-      mockSetRequestHandler = jest.fn();
-      mockConnect = jest.fn();
-      mockClose = jest.fn();
-      mockServer = {
-        setRequestHandler: mockSetRequestHandler,
-        connect: mockConnect,
-        close: mockClose,
-        onerror: undefined,
-      } as any;
-      (Server as jest.MockedClass<typeof Server>).mockImplementation(
-        () => mockServer,
-      );
-
       new ApexLogServer();
 
-      const callToolCall = mockSetRequestHandler.mock.calls.find(
-        (call: any) => call[0] === CallToolRequestSchema,
+      const tool = registeredTools.get("execute_anonymous")!;
+
+      await expect(
+        tool.callback({ apex: "System.debug('test');" }, {} as any),
+      ).rejects.toThrow(
+        "execute_anonymous is disabled. Configure --allowed-orgs to enable it.",
       );
-      const handler = callToolCall![1];
-
-      const request = {
-        params: {
-          name: "execute_anonymous",
-          arguments: { apex: "System.debug('test');" },
-        },
-      };
-
-      const result = await handler(request, {} as any);
-
-      expect(result).toEqual({
-        content: [
-          {
-            type: "text",
-            text: "Error: execute_anonymous is disabled. Configure --allowed-orgs to enable it.",
-          },
-        ],
-        isError: true,
-      });
     });
   });
 
@@ -585,58 +426,24 @@ describe("ApexLogServer", () => {
     it("should handle complete workflow for analyze_apex_log_performance", async () => {
       new ApexLogServer(["ALLOW_ALL_ORGS"]);
 
-      // Get handlers
-      const listToolsCall = mockSetRequestHandler.mock.calls.find(
-        (call: any) => call[0] === ListToolsRequestSchema,
-      );
-      const callToolCall = mockSetRequestHandler.mock.calls.find(
-        (call: any) => call[0] === CallToolRequestSchema,
-      );
-
-      const listToolsHandler = listToolsCall![1];
-      const callToolHandler = callToolCall![1];
-
-      // Test tool listing
-      const toolsResult = await listToolsHandler({} as any, {} as any);
-      expect(toolsResult.tools).toHaveLength(4);
-      expect(toolsResult.tools[0].name).toBe("analyze_apex_log_performance");
+      // Verify all tools registered
+      expect(registeredTools.size).toBe(4);
 
       // Test tool execution
-      const request = {
-        params: {
-          name: "analyze_apex_log_performance",
-          arguments: {
-            logFilePath: "/path/to/test.log",
-            topMethods: 10,
-            minDuration: 1000,
-          },
-        },
-      };
-
-      const result = await callToolHandler(request as any, {} as any);
-      expect(result).toEqual(mockAnalysisResult);
-      expect(analyzeLogPerformance).toHaveBeenCalledWith({
+      const tool = registeredTools.get("analyze_apex_log_performance")!;
+      const args = {
         logFilePath: "/path/to/test.log",
         topMethods: 10,
         minDuration: 1000,
-      });
+      };
+
+      const result = await tool.callback(args, {} as any);
+      expect(result).toEqual(mockAnalysisResult);
+      expect(analyzeLogPerformance).toHaveBeenCalledWith(args);
     });
 
     it("should handle edge cases with malformed requests", async () => {
       new ApexLogServer();
-
-      const callToolCall = mockSetRequestHandler.mock.calls.find(
-        (call: any) => call[0] === CallToolRequestSchema,
-      );
-      const callToolHandler = callToolCall![1];
-
-      // Test with missing arguments
-      const request = {
-        params: {
-          name: "analyze_apex_log_performance",
-          arguments: null,
-        },
-      };
 
       (
         analyzeLogPerformance as jest.MockedFunction<
@@ -644,9 +451,11 @@ describe("ApexLogServer", () => {
         >
       ).mockRejectedValueOnce(new Error("Invalid arguments"));
 
-      const result = await callToolHandler(request as any, {} as any);
-      expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain("Error: Invalid arguments");
+      const tool = registeredTools.get("analyze_apex_log_performance")!;
+
+      await expect(tool.callback(null as any, {} as any)).rejects.toThrow(
+        "Invalid arguments",
+      );
     });
   });
 
@@ -654,27 +463,15 @@ describe("ApexLogServer", () => {
     it("should handle typed arguments correctly", async () => {
       new ApexLogServer();
 
-      const callToolCall = mockSetRequestHandler.mock.calls.find(
-        (call: any) => call[0] === CallToolRequestSchema,
-      );
-      const callToolHandler = callToolCall![1];
-
-      const request = {
-        params: {
-          name: "find_performance_bottlenecks",
-          arguments: {
-            logFilePath: "/path/to/test.log",
-            analysisType: "database" as const,
-          },
-        },
+      const tool = registeredTools.get("find_performance_bottlenecks")!;
+      const args = {
+        logFilePath: "/path/to/test.log",
+        analysisType: "database" as const,
       };
 
-      await callToolHandler(request as any, {} as any);
+      await tool.callback(args, {} as any);
 
-      expect(findPerformanceBottlenecks).toHaveBeenCalledWith({
-        logFilePath: "/path/to/test.log",
-        analysisType: "database",
-      });
+      expect(findPerformanceBottlenecks).toHaveBeenCalledWith(args);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Refactored `ApexLogServer` to use `McpServer` from the MCP SDK instead of the lower-level `Server` implementation
- Replaced manual tool handler methods with streamlined tool registration using Zod input schemas for type-safe argument validation
- Upgraded from Zod v3 to Zod v4 as a direct dependency
- Simplified test setup by removing low-level protocol mocking in favor of testing against the higher-level API

## Test plan
- [x] `pnpm run build` — TypeScript compilation succeeds
- [x] `pnpm test` — All 154 tests pass
- [x] `pnpm run lint` — No lint errors
- [X] Manual smoke test: run `pnpm start` and verify server starts on stdio

