### PR TITLE
feat: improve tool responses for token efficiency and richer metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Performance Analysis** (`analyze_apex_log_performance`) - Feed in a debug log and instantly see which methods are the slowest. See execution times, SOQL/DML counts.
-- **Log Summaries** (`get_apex_log_summary`) - Get a debug log summary. Total execution time, method count, governor limit usage.
-- **Bottleneck Detection** (`find_performance_bottlenecks`) - Detects CPU, database and method performance issues by type so you know exactly what to focus on.
+- **Performance Analysis** (`analyze_apex_log_performance`) - Feed in a debug log and instantly see which methods are the slowest. See execution times, SOQL/DML counts, and SOSL queries. All durations in milliseconds. Includes log size, debug levels, and thrown exception count.
+- **Log Summaries** (`get_apex_log_summary`) - Get a debug log summary. Total execution time, method count, governor limit usage (all limits with usage > 0), and log issues as structured `{type, summary}` objects.
+- **Bottleneck Detection** (`find_performance_bottlenecks`) - Detects CPU, database and method performance issues by type so you know exactly what to focus on. Empty sections are omitted for cleaner responses.
 - **Anonymous Apex Execution** (`execute_anonymous`) - Run Apex against any Salesforce org and get the debug log back for analysis. Specify a target org by alias or username, or use the project default. Response includes the org alias alongside the username when available.
   - **Debug levels** — Configurable via the `debugLevel` parameter. Set all categories at once (e.g. `"FINEST"`), reset to defaults, or override specific categories like apexCode, database, and nba.
   - **Org allowlist** (`--allowed-orgs`) — Disabled by default, must be explicitly enabled. Supports special tokens: `ALLOW_ALL_ORGS` (permit any org), `DEFAULT_TARGET_ORG` and `DEFAULT_TARGET_DEV_HUB` (resolve from Salesforce CLI config). Aliases in the allowlist are resolved to usernames for matching.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Identifies the slowest running methods in a debug log with detailed performance 
 | ------------- | ------ | -------- | ------------------------------------------------- |
 | `logFilePath` | string | Yes      | Absolute path to the .log file                    |
 | `topMethods`  | number | No       | Number of slowest methods to return (default: 10) |
-| `minDuration` | number | No       | Minimum duration in nanoseconds (default: 0)      |
+| `minDuration` | number | No       | Minimum duration in milliseconds (default: 0)     |
 | `namespace`   | string | No       | Filter by namespace                               |
 
 **Example prompts:**

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ class ApexLogServer {
           tools: {},
         },
         instructions:
-          "Use this server when you have an Apex debug log file to analyze, or when you need to execute anonymous Apex and inspect the resulting log. The log analysis tools accept absolute file paths and return structured JSON. Start with get_apex_log_summary for a quick overview, then use analyze_apex_log_performance or find_performance_bottlenecks for deeper analysis.",
+          "Use this server when you have an Apex debug log file to analyze, or when you need to execute anonymous Apex and inspect the resulting log. The log analysis tools accept absolute file paths and return structured data with all durations in milliseconds. Start with get_apex_log_summary for a quick overview, then use analyze_apex_log_performance or find_performance_bottlenecks for deeper analysis.",
       },
     );
 

--- a/src/tools/analyzeLogPerformance.ts
+++ b/src/tools/analyzeLogPerformance.ts
@@ -19,7 +19,7 @@ export const analyzeLogPerformanceInputSchema = {
     .number()
     .optional()
     .describe(
-      "Minimum duration in nanoseconds to include a method. For reference: 1ms = 1,000,000ns, 1s = 1,000,000,000ns (default: 0)",
+      "Minimum duration in milliseconds to include a method (default: 0)",
     ),
   namespace: z.string().optional().describe("Filter methods by namespace"),
 };
@@ -31,7 +31,7 @@ export type AnalyzeLogArgs = z.infer<
 export const analyzeLogPerformanceToolConfig = {
   title: "Analyze Apex Log Performance",
   description:
-    "Rank methods in an Apex debug log by self-execution time. Returns method names, durations, SOQL/DML counts, and optimization recommendations. Best for finding which specific methods to optimize.",
+    "Rank methods in an Apex debug log by self-execution time. Returns method names, durations (in ms), SOQL/DML counts, and optimization recommendations. Best for finding which specific methods to optimize.",
   inputSchema: analyzeLogPerformanceInputSchema,
   annotations: {
     title: "Analyze Apex Log Performance",
@@ -63,6 +63,8 @@ export interface LogAnalysisResult {
   recommendations: string[];
 }
 
+const NS_TO_MS = 1_000_000;
+
 export async function analyzeLogPerformance(args: AnalyzeLogArgs) {
   const { logFilePath, topMethods = 10, minDuration = 0, namespace } = args;
 
@@ -77,8 +79,11 @@ export async function analyzeLogPerformance(args: AnalyzeLogArgs) {
   const logContent = await fs.readFile(logFilePath, "utf-8");
   const apexLog = parse(logContent);
 
+  // Convert ms input to ns for internal filtering
+  const minDurationNs = minDuration * NS_TO_MS;
+
   // Extract all methods with their performance data
-  const methods = extractMethods(apexLog, minDuration, namespace);
+  const methods = extractMethods(apexLog, minDurationNs, namespace);
 
   // Sort by self duration (descending)
   methods.sort((a, b) => b.selfDuration - a.selfDuration);
@@ -86,12 +91,21 @@ export async function analyzeLogPerformance(args: AnalyzeLogArgs) {
   // Take top N methods
   const slowestMethods = methods.slice(0, topMethods);
 
+  const msMethods = slowestMethods.map((m) => ({
+    ...m,
+    duration: m.duration / NS_TO_MS,
+    selfDuration: m.selfDuration / NS_TO_MS,
+  }));
+
   const result: LogAnalysisResult = {
     totalMethods: methods.length,
-    totalExecutionTime: apexLog.duration.total,
-    slowestMethods,
-    summary: generatePerformanceSummary(slowestMethods, apexLog.duration.total),
-    recommendations: generateRecommendations(slowestMethods),
+    totalExecutionTime: apexLog.duration.total / NS_TO_MS,
+    slowestMethods: msMethods,
+    summary: generatePerformanceSummary(
+      msMethods,
+      apexLog.duration.total / NS_TO_MS,
+    ),
+    recommendations: generateRecommendations(msMethods),
   };
 
   return {
@@ -148,7 +162,7 @@ export function extractMethods(
 
 function generatePerformanceSummary(
   methods: SlowMethod[],
-  totalTime: number,
+  totalTimeMs: number,
 ): string {
   if (methods.length === 0) {
     return "No methods found matching the criteria.";
@@ -160,33 +174,20 @@ function generatePerformanceSummary(
     0,
   );
   const percentageOfTotal =
-    totalTime > 0 ? (totalSlowMethodsTime / totalTime) * 100 : 0;
+    totalTimeMs > 0 ? (totalSlowMethodsTime / totalTimeMs) * 100 : 0;
 
-  return `Analysis found ${methods.length} methods. The slowest method "${
-    slowestMethod.name
-  }" took ${(slowestMethod.selfDuration / 1000000).toFixed(
-    2,
-  )}ms (${slowestMethod.selfPercentage.toFixed(
-    1,
-  )}% of total execution time). The top ${
-    methods.length
-  } methods account for ${percentageOfTotal.toFixed(
-    1,
-  )}% of total execution time.`;
+  return `Analysis found ${methods.length} methods. The slowest method "${slowestMethod.name}" took ${slowestMethod.selfDuration.toFixed(2)}ms (${slowestMethod.selfPercentage.toFixed(1)}% of total execution time). The top ${methods.length} methods account for ${percentageOfTotal.toFixed(1)}% of total execution time.`;
 }
 
 function generateRecommendations(methods: SlowMethod[]): string[] {
   const recommendations: string[] = [];
 
-  methods.forEach((method, index) => {
-    if (index < 3) {
-      // Focus on top 3 methods
-      const recommendation = getRecommendations(method);
-      if (recommendation) {
-        recommendations.push(recommendation);
-      }
+  for (const method of methods.slice(0, 3)) {
+    const recommendation = getRecommendation(method);
+    if (recommendation) {
+      recommendations.push(recommendation);
     }
-  });
+  }
 
   if (recommendations.length === 0) {
     recommendations.push(
@@ -197,9 +198,8 @@ function generateRecommendations(methods: SlowMethod[]): string[] {
   return recommendations;
 }
 
-function getRecommendations(method: SlowMethod): string | null {
-  // High self time percentage, only include if self duration is significant
-  if (method.selfPercentage > 10 && method.selfDuration > 100) {
+function getRecommendation(method: SlowMethod): string | null {
+  if (method.selfPercentage > 10 && method.selfDuration > 0.1) {
     return `Method "${method.name}" consumes ${method.selfPercentage.toFixed(
       1,
     )}% self execution time. Consider if it can be optimized to make it faster, check how many times it is called and if that can be reduced.`;

--- a/src/tools/analyzeLogPerformance.ts
+++ b/src/tools/analyzeLogPerformance.ts
@@ -52,6 +52,9 @@ export interface SlowMethod {
   soqlCount: number;
   dmlRows: number;
   soqlRows: number;
+  thrownCount: number;
+  soslCount: number;
+  soslRows: number;
   selfPercentage: number;
 }
 
@@ -144,6 +147,9 @@ export function extractMethods(
             soqlCount: node.soqlCount.total,
             dmlRows: node.dmlRowCount.total,
             soqlRows: node.soqlRowCount.total,
+            thrownCount: node.totalThrownCount,
+            soslCount: node.soslCount.total,
+            soslRows: node.soslRowCount.total,
             selfPercentage:
               totalTime > 0 ? (node.duration.self / totalTime) * 100 : 0,
           });
@@ -212,6 +218,9 @@ function getRecommendation(method: SlowMethod): string | null {
   }
   if (method.dmlCount > 3) {
     return `Method "${method.name}" performs ${method.dmlCount} DML operations. Consider bulkifying DML operations.`;
+  }
+  if (method.soslCount > 3) {
+    return `Method "${method.name}" executes ${method.soslCount} SOSL searches. Consider reducing search count or caching results.`;
   }
 
   return null;

--- a/src/tools/findPerformanceBottlenecks.ts
+++ b/src/tools/findPerformanceBottlenecks.ts
@@ -28,7 +28,8 @@ export interface BottleneckResult {
   cpuBottlenecks?: Record<string, unknown>;
   databaseBottlenecks?: Record<string, unknown>;
   methodBottlenecks?: Record<string, unknown>;
-  governorLimitWarnings: Record<string, unknown>;
+  governorLimitWarnings?: Record<string, unknown>;
+  note?: string;
 }
 
 export const findPerformanceBottlenecksToolConfig = {
@@ -47,6 +48,8 @@ export const findPerformanceBottlenecksToolConfig = {
 
 export const WARNING_THRESHOLD = 80;
 
+const NS_TO_MS = 1_000_000;
+
 export async function findPerformanceBottlenecks(args: BottleneckArgs) {
   const { logFilePath, analysisType = "all" } = args;
 
@@ -59,20 +62,42 @@ export async function findPerformanceBottlenecks(args: BottleneckArgs) {
   const logContent = await fs.readFile(logFilePath, "utf-8");
   const apexLog = parse(logContent);
 
-  const bottlenecks: BottleneckResult = {
-    governorLimitWarnings: analyzeGovernorLimits(apexLog),
-  };
+  const hasCpuSection = analysisType === "cpu" || analysisType === "all";
 
-  if (analysisType === "cpu" || analysisType === "all") {
-    bottlenecks.cpuBottlenecks = analyzeCPUBottlenecks(apexLog);
+  const bottlenecks: BottleneckResult = {};
+
+  if (hasCpuSection) {
+    const cpu = analyzeCPUBottlenecks(apexLog);
+    if (Object.keys(cpu).length > 0) {
+      bottlenecks.cpuBottlenecks = cpu;
+    }
   }
 
   if (analysisType === "database" || analysisType === "all") {
-    bottlenecks.databaseBottlenecks = analyzeDatabaseBottlenecks(apexLog);
+    const db = analyzeDatabaseBottlenecks(apexLog);
+    if (Object.keys(db).length > 0) {
+      bottlenecks.databaseBottlenecks = db;
+    }
   }
 
   if (analysisType === "methods" || analysisType === "all") {
-    bottlenecks.methodBottlenecks = analyzeMethodBottlenecks(apexLog);
+    const methods = analyzeMethodBottlenecks(apexLog);
+    if (Object.keys(methods).length > 0) {
+      bottlenecks.methodBottlenecks = methods;
+    }
+  }
+
+  const governorWarnings = analyzeGovernorLimits(
+    apexLog,
+    hasCpuSection && bottlenecks.cpuBottlenecks !== undefined,
+  );
+  if (Object.keys(governorWarnings).length > 0) {
+    bottlenecks.governorLimitWarnings = governorWarnings;
+  }
+
+  if (Object.keys(bottlenecks).length === 0) {
+    bottlenecks.note =
+      "No performance bottlenecks or governor limit warnings found.";
   }
 
   return {
@@ -168,50 +193,33 @@ function analyzeMethodBottlenecks(apexLog: ApexLog): Record<string, unknown> {
     methodsByNamespace: Object.keys(methodsByNamespace).map((ns) => ({
       namespace: ns,
       methodCount: methodsByNamespace[ns].length,
-      totalDuration: methodsByNamespace[ns].reduce(
-        (sum: number, m: SlowMethod) => sum + m.duration,
-        0,
-      ),
+      totalDuration:
+        methodsByNamespace[ns].reduce(
+          (sum: number, m: SlowMethod) => sum + m.duration,
+          0,
+        ) / NS_TO_MS,
     })),
   };
 }
 
-function analyzeGovernorLimits(apexLog: ApexLog): Record<string, unknown> {
+function analyzeGovernorLimits(
+  apexLog: ApexLog,
+  excludeCpuTime: boolean,
+): Record<string, unknown> {
   const limits = apexLog.governorLimits;
-  const warnings: string[] = [];
+
+  const result: Record<string, unknown> = {};
 
   Object.entries(limits).forEach(([key, value]: [string, any]) => {
-    if (key !== "byNamespace" && value.limit > 0) {
+    if (key === "byNamespace") return;
+    if (excludeCpuTime && key === "cpuTime") return;
+    if (value.limit > 0) {
       const percentage = (value.used / value.limit) * 100;
       if (percentage > WARNING_THRESHOLD) {
-        warnings.push(
-          `${key}: ${percentage.toFixed(1)}% of limit used (${value.used}/${
-            value.limit
-          })`,
-        );
+        result[key] = value;
       }
     }
   });
 
-  const reducedLimits = Object.entries(limits).reduce(
-    (acc: Record<string, unknown>, [key, value]: [string, any]) => {
-      if (key !== "byNamespace" && value.limit > 0) {
-        const percentage = (value.used / value.limit) * 100;
-        if (percentage > WARNING_THRESHOLD) {
-          acc[key] = value;
-        }
-      }
-      return acc;
-    },
-    {},
-  );
-
-  return warnings.length === 0
-    ? { note: "No governor limits approaching their thresholds." }
-    : {
-        warnings,
-        // Only include limits with usage
-        details: reducedLimits,
-        note: undefined,
-      };
+  return result;
 }

--- a/src/tools/getLogSummary.ts
+++ b/src/tools/getLogSummary.ts
@@ -21,7 +21,7 @@ export type LogSummaryArgs = z.infer<
 export const getLogSummaryToolConfig = {
   title: "Get Apex Log Summary",
   description:
-    "Get a high-level summary of an Apex debug log including total execution time, method count, SOQL/DML totals, governor limits, and active namespaces. Best for a quick overview before deeper analysis.",
+    "Get a high-level summary of an Apex debug log including total execution time (in ms), method count, SOQL/DML totals, governor limits, and active namespaces. Best for a quick overview before deeper analysis.",
   inputSchema: getLogSummaryInputSchema,
   annotations: {
     title: "Get Apex Log Summary",
@@ -31,6 +31,8 @@ export const getLogSummaryToolConfig = {
     openWorldHint: false,
   },
 };
+
+const NS_TO_MS = 1_000_000;
 
 export async function getLogSummary(args: LogSummaryArgs) {
   const { logFilePath } = args;
@@ -44,22 +46,31 @@ export async function getLogSummary(args: LogSummaryArgs) {
   const logContent = await fs.readFile(logFilePath, "utf-8");
   const apexLog = parse(logContent);
 
+  const governorLimits: Record<string, { used: number; limit: number }> = {};
+  Object.entries(apexLog.governorLimits).forEach(
+    ([key, value]: [string, any]) => {
+      if (key !== "byNamespace" && (value.used > 0 || value.limit > 0)) {
+        governorLimits[key] = { used: value.used, limit: value.limit };
+      }
+    },
+  );
+
+  const logIssues = apexLog.logIssues.map((issue) => ({
+    type: issue.type,
+    summary: issue.summary,
+  }));
+
   const summary = {
     file: path.basename(logFilePath),
-    totalExecutionTime: apexLog.duration.total,
+    totalExecutionTime: apexLog.duration.total / NS_TO_MS,
     totalMethods: countMethods(apexLog),
     totalSOQLQueries: apexLog.soqlCount.total,
     totalDMLOperations: apexLog.dmlCount.total,
     totalSOQLRows: apexLog.soqlRowCount.total,
     totalDMLRows: apexLog.dmlRowCount.total,
-    governorLimits: {
-      cpuTime: apexLog.governorLimits.cpuTime,
-      heapSize: apexLog.governorLimits.heapSize,
-      soqlQueries: apexLog.governorLimits.soqlQueries,
-      dmlStatements: apexLog.governorLimits.dmlStatements,
-    },
+    governorLimits,
     namespaces: apexLog.namespaces,
-    logIssues: apexLog.logIssues.length,
+    logIssues,
     parsingErrors: apexLog.parsingErrors.length,
   };
 

--- a/src/tools/getLogSummary.ts
+++ b/src/tools/getLogSummary.ts
@@ -62,6 +62,7 @@ export async function getLogSummary(args: LogSummaryArgs) {
 
   const summary = {
     file: path.basename(logFilePath),
+    size: apexLog.size,
     totalExecutionTime: apexLog.duration.total / NS_TO_MS,
     totalMethods: countMethods(apexLog),
     totalSOQLQueries: apexLog.soqlCount.total,
@@ -70,6 +71,10 @@ export async function getLogSummary(args: LogSummaryArgs) {
     totalDMLRows: apexLog.dmlRowCount.total,
     governorLimits,
     namespaces: apexLog.namespaces,
+    debugLevels: apexLog.debugLevels.map((d) => ({
+      category: d.logCategory,
+      level: d.logLevel,
+    })),
     logIssues,
     parsingErrors: apexLog.parsingErrors.length,
   };

--- a/tests/analyzeLogPerformance.test.ts
+++ b/tests/analyzeLogPerformance.test.ts
@@ -216,6 +216,43 @@ describe("analyzeLogPerformance", () => {
       expect(methods[2].selfPercentage).toBe(10); // 100000000 / 1000000000 * 100
     });
 
+    it("should extract thrownCount and SOSL metrics from log lines", () => {
+      const methodWithSOSL = createMockLogLine(
+        "SOSLMethod",
+        500000000,
+        500000000,
+        "default",
+        1,
+        0, // dmlCount
+        0, // soqlCount
+        0, // dmlRows
+        0, // soqlRows
+        5, // soslCount
+        250, // soslRows
+        3, // totalThrownCount
+      );
+
+      const mockApexLog = {
+        duration: { total: 1000000000, self: 0 },
+        children: [methodWithSOSL],
+        type: "EXECUTION_STARTED",
+        text: "Root",
+        namespace: "default",
+        lineNumber: null,
+        dmlCount: { total: 0, self: 0 },
+        soqlCount: { total: 0, self: 0 },
+        dmlRowCount: { total: 0, self: 0 },
+        soqlRowCount: { total: 0, self: 0 },
+      };
+
+      const methods = extractMethods(mockApexLog as any, 0);
+
+      expect(methods).toHaveLength(1);
+      expect(methods[0].thrownCount).toBe(3);
+      expect(methods[0].soslCount).toBe(5);
+      expect(methods[0].soslRows).toBe(250);
+    });
+
     it("should handle zero total time", () => {
       const mockApexLog = createMockApexLogWithZeroTotalTime();
       const methods = extractMethods(mockApexLog, 0);
@@ -400,6 +437,23 @@ describe("analyzeLogPerformance", () => {
       expect(percentageRecommendation).toBeDefined();
     });
 
+    it("should generate SOSL search recommendations", async () => {
+      const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
+      const mockApexLog = createMockApexLogWithHighSOSL();
+
+      setupMocksForSuccess(mockApexLog);
+
+      const result = await analyzeLogPerformance(args);
+      const parsedResult = toonDecode(result);
+
+      const soslRecommendation = parsedResult.recommendations.find(
+        (rec) =>
+          rec.includes("SOSL searches") &&
+          rec.includes("reducing search count"),
+      );
+      expect(soslRecommendation).toBeDefined();
+    });
+
     it("should generate positive message when no issues found", async () => {
       const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
       const mockApexLog = createMockApexLogWithGoodPerformance();
@@ -455,6 +509,9 @@ describe("analyzeLogPerformance", () => {
     soqlCount: number = 0,
     dmlRows: number = 0,
     soqlRows: number = 0,
+    soslCount: number = 0,
+    soslRows: number = 0,
+    totalThrownCount: number = 0,
   ): any {
     return {
       type: "METHOD_ENTRY",
@@ -466,6 +523,9 @@ describe("analyzeLogPerformance", () => {
       soqlCount: { total: soqlCount, self: soqlCount },
       dmlRowCount: { total: dmlRows, self: dmlRows },
       soqlRowCount: { total: soqlRows, self: soqlRows },
+      soslCount: { total: soslCount, self: soslCount },
+      soslRowCount: { total: soslRows, self: soslRows },
+      totalThrownCount,
       children: [],
     };
   }
@@ -560,6 +620,9 @@ describe("analyzeLogPerformance", () => {
       soqlCount: { total: 0, self: 0 },
       dmlRowCount: { total: 0, self: 0 },
       soqlRowCount: { total: 0, self: 0 },
+      soslCount: { total: 0, self: 0 },
+      soslRowCount: { total: 0, self: 0 },
+      totalThrownCount: 0,
       children: [],
     };
 
@@ -659,6 +722,35 @@ describe("analyzeLogPerformance", () => {
       dmlCount: { total: 6, self: 0 },
       soqlCount: { total: 2, self: 0 },
       dmlRowCount: { total: 100, self: 0 },
+      soqlRowCount: { total: 50, self: 0 },
+    };
+  }
+
+  function createMockApexLogWithHighSOSL(): any {
+    const highSOSLMethod = createMockLogLine(
+      "HighSOSLMethod",
+      500000000,
+      50000000, // Low self duration to get selfPercentage < 10%
+      "default",
+      1,
+      1, // dmlCount
+      2, // soqlCount
+      10, // dmlRows
+      50, // soqlRows
+      5, // soslCount (> 3 triggers recommendation)
+      200, // soslRows
+    );
+
+    return {
+      duration: { total: 1000000000, self: 500000000 },
+      children: [highSOSLMethod],
+      type: "EXECUTION_STARTED",
+      text: "Root",
+      namespace: "default",
+      lineNumber: null,
+      dmlCount: { total: 1, self: 0 },
+      soqlCount: { total: 2, self: 0 },
+      dmlRowCount: { total: 10, self: 0 },
       soqlRowCount: { total: 50, self: 0 },
     };
   }

--- a/tests/analyzeLogPerformance.test.ts
+++ b/tests/analyzeLogPerformance.test.ts
@@ -91,11 +91,25 @@ describe("analyzeLogPerformance", () => {
       const parsedResult = toonDecode(result);
 
       expect(parsedResult.totalMethods).toBe(3);
-      expect(parsedResult.totalExecutionTime).toBe(1000000000); // 1 second in ns
+      expect(parsedResult.totalExecutionTime).toBe(1000); // 1s in ms
       expect(parsedResult.slowestMethods).toHaveLength(3);
       expect(parsedResult.slowestMethods[0].name).toBe("SlowMethod");
-      expect(parsedResult.summary).toContain("Analysis found 3 methods");
       expect(parsedResult.recommendations).toBeInstanceOf(Array);
+    });
+
+    it("should return durations in milliseconds", async () => {
+      const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
+      const mockApexLog = createMockApexLog();
+
+      setupMocksForSuccess(mockApexLog);
+
+      const result = await analyzeLogPerformance(args);
+      const parsedResult = toonDecode(result);
+
+      expect(parsedResult.slowestMethods[0].duration).toBe(500); // 500ms
+      expect(parsedResult.slowestMethods[0].selfDuration).toBe(500); // 500ms
+      expect(parsedResult.slowestMethods[1].duration).toBe(400); // 400ms
+      expect(parsedResult.slowestMethods[2].duration).toBe(100); // 100ms
     });
 
     it("should limit results with topMethods parameter", async () => {
@@ -115,10 +129,10 @@ describe("analyzeLogPerformance", () => {
       expect(parsedResult.slowestMethods[1].name).toBe("MediumMethod");
     });
 
-    it("should filter by minimum duration", async () => {
+    it("should filter by minimum duration in milliseconds", async () => {
       const args: AnalyzeLogArgs = {
         logFilePath: "/test/file.log",
-        minDuration: 300000000, // 300ms in ns
+        minDuration: 300, // 300ms
       };
       const mockApexLog = createMockApexLog();
 
@@ -130,9 +144,7 @@ describe("analyzeLogPerformance", () => {
       expect(parsedResult.totalMethods).toBe(2); // Only SlowMethod and MediumMethod
       expect(parsedResult.slowestMethods).toHaveLength(2);
       expect(
-        parsedResult.slowestMethods.every(
-          (method) => method.duration >= 300000000,
-        ),
+        parsedResult.slowestMethods.every((method) => method.duration >= 300),
       ).toBe(true);
     });
 
@@ -167,9 +179,9 @@ describe("analyzeLogPerformance", () => {
       expect(methods[0].soqlCount).toBe(10);
     });
 
-    it("should filter methods by minimum duration", () => {
+    it("should filter methods by minimum duration in nanoseconds", () => {
       const mockApexLog = createMockApexLog();
-      const methods = extractMethods(mockApexLog, 300000000); // 300ms
+      const methods = extractMethods(mockApexLog, 300000000); // 300ms in ns
 
       expect(methods).toHaveLength(2);
       expect(methods.every((method) => method.duration >= 300000000)).toBe(
@@ -212,27 +224,24 @@ describe("analyzeLogPerformance", () => {
     });
   });
 
-  describe("Performance Summary Generation", () => {
-    it("should generate correct summary for multiple methods", async () => {
+  describe("Edge Cases", () => {
+    it("should handle empty log gracefully", async () => {
       const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
-      const mockApexLog = createMockApexLog();
+      const mockApexLog = createEmptyMockApexLog();
 
       setupMocksForSuccess(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.summary).toContain("Analysis found 3 methods");
-      expect(parsedResult.summary).toContain("SlowMethod");
-      expect(parsedResult.summary).toContain("500.00ms");
-      expect(parsedResult.summary).toContain("50.0% of total execution time");
-      expect(parsedResult.summary).toContain("100.0% of total execution time"); // All methods combined
+      expect(parsedResult.totalMethods).toBe(0);
+      expect(parsedResult.slowestMethods).toHaveLength(0);
     });
 
-    it("should generate appropriate summary for no methods", async () => {
+    it("should handle log with no matching methods after filtering", async () => {
       const args: AnalyzeLogArgs = {
         logFilePath: "/test/file.log",
-        minDuration: 2000000000,
+        namespace: "NonExistentNamespace",
       };
       const mockApexLog = createMockApexLog();
 
@@ -241,10 +250,89 @@ describe("analyzeLogPerformance", () => {
       const result = await analyzeLogPerformance(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.summary).toBe(
-        "No methods found matching the criteria.",
-      );
       expect(parsedResult.totalMethods).toBe(0);
+      expect(parsedResult.slowestMethods).toHaveLength(0);
+    });
+
+    it("should handle parsing errors gracefully", async () => {
+      const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
+
+      mockedFs.access.mockResolvedValue(undefined);
+      mockedFs.readFile.mockResolvedValue("invalid log content");
+      mockedParse.mockImplementation(() => {
+        throw new Error("Parsing failed");
+      });
+
+      await expect(analyzeLogPerformance(args)).rejects.toThrow(
+        "Parsing failed",
+      );
+    });
+
+    it("should handle file read errors", async () => {
+      const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
+
+      mockedFs.access.mockResolvedValue(undefined);
+      mockedFs.readFile.mockRejectedValue(new Error("Permission denied"));
+
+      await expect(analyzeLogPerformance(args)).rejects.toThrow(
+        "Permission denied",
+      );
+    });
+  });
+
+  describe("Interface Contracts", () => {
+    it("should return SlowMethod objects with correct structure", async () => {
+      const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
+      const mockApexLog = createMockApexLog();
+
+      setupMocksForSuccess(mockApexLog);
+
+      const result = await analyzeLogPerformance(args);
+      const parsedResult = toonDecode(result);
+
+      const method = parsedResult.slowestMethods[0];
+      expect(typeof method.name).toBe("string");
+      expect(typeof method.duration).toBe("number");
+      expect(typeof method.selfDuration).toBe("number");
+      expect(typeof method.namespace).toBe("string");
+      expect(typeof method.dmlCount).toBe("number");
+      expect(typeof method.soqlCount).toBe("number");
+      expect(typeof method.dmlRows).toBe("number");
+      expect(typeof method.soqlRows).toBe("number");
+      expect(typeof method.selfPercentage).toBe("number");
+      expect(["number", "string", "object"]).toContain(
+        typeof method.lineNumber,
+      );
+    });
+
+    it("should return LogAnalysisResult with correct structure", async () => {
+      const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
+      const mockApexLog = createMockApexLog();
+
+      setupMocksForSuccess(mockApexLog);
+
+      const result = await analyzeLogPerformance(args);
+      const parsedResult = toonDecode(result);
+
+      expect(typeof parsedResult.totalMethods).toBe("number");
+      expect(typeof parsedResult.totalExecutionTime).toBe("number");
+      expect(Array.isArray(parsedResult.slowestMethods)).toBe(true);
+      expect(Array.isArray(parsedResult.recommendations)).toBe(true);
+    });
+
+    it("should return LogAnalysisResult with summary string", async () => {
+      const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
+      const mockApexLog = createMockApexLog();
+
+      setupMocksForSuccess(mockApexLog);
+
+      const result = await analyzeLogPerformance(args);
+      const parsedResult = toonDecode(result);
+
+      expect(typeof parsedResult.summary).toBe("string");
+      expect(parsedResult.summary).toContain("Analysis found 3 methods");
+      expect(parsedResult.summary).toContain("SlowMethod");
+      expect(parsedResult.summary).toContain("500.00ms");
     });
   });
 
@@ -338,120 +426,10 @@ describe("analyzeLogPerformance", () => {
       const result = await analyzeLogPerformance(args);
       const parsedResult = toonDecode(result);
 
-      // Should only mention first 3 methods in recommendations
-      const methodMentions = parsedResult.recommendations.filter(
-        (rec) =>
-          rec.includes("Method1") ||
-          rec.includes("Method2") ||
-          rec.includes("Method3") ||
-          rec.includes("Method4"),
-      );
-
-      const mentionsMethod4 = methodMentions.some((rec) =>
+      const mentionsMethod4 = parsedResult.recommendations.some((rec) =>
         rec.includes("Method4"),
       );
       expect(mentionsMethod4).toBe(false);
-    });
-  });
-
-  describe("Edge Cases", () => {
-    it("should handle empty log gracefully", async () => {
-      const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
-      const mockApexLog = createEmptyMockApexLog();
-
-      setupMocksForSuccess(mockApexLog);
-
-      const result = await analyzeLogPerformance(args);
-      const parsedResult = toonDecode(result);
-
-      expect(parsedResult.totalMethods).toBe(0);
-      expect(parsedResult.slowestMethods).toHaveLength(0);
-      expect(parsedResult.summary).toBe(
-        "No methods found matching the criteria.",
-      );
-    });
-
-    it("should handle log with no matching methods after filtering", async () => {
-      const args: AnalyzeLogArgs = {
-        logFilePath: "/test/file.log",
-        namespace: "NonExistentNamespace",
-      };
-      const mockApexLog = createMockApexLog();
-
-      setupMocksForSuccess(mockApexLog);
-
-      const result = await analyzeLogPerformance(args);
-      const parsedResult = toonDecode(result);
-
-      expect(parsedResult.totalMethods).toBe(0);
-      expect(parsedResult.slowestMethods).toHaveLength(0);
-    });
-
-    it("should handle parsing errors gracefully", async () => {
-      const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
-
-      mockedFs.access.mockResolvedValue(undefined);
-      mockedFs.readFile.mockResolvedValue("invalid log content");
-      mockedParse.mockImplementation(() => {
-        throw new Error("Parsing failed");
-      });
-
-      await expect(analyzeLogPerformance(args)).rejects.toThrow(
-        "Parsing failed",
-      );
-    });
-
-    it("should handle file read errors", async () => {
-      const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
-
-      mockedFs.access.mockResolvedValue(undefined);
-      mockedFs.readFile.mockRejectedValue(new Error("Permission denied"));
-
-      await expect(analyzeLogPerformance(args)).rejects.toThrow(
-        "Permission denied",
-      );
-    });
-  });
-
-  describe("Interface Contracts", () => {
-    it("should return SlowMethod objects with correct structure", async () => {
-      const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
-      const mockApexLog = createMockApexLog();
-
-      setupMocksForSuccess(mockApexLog);
-
-      const result = await analyzeLogPerformance(args);
-      const parsedResult = toonDecode(result);
-
-      const method = parsedResult.slowestMethods[0];
-      expect(typeof method.name).toBe("string");
-      expect(typeof method.duration).toBe("number");
-      expect(typeof method.selfDuration).toBe("number");
-      expect(typeof method.namespace).toBe("string");
-      expect(typeof method.dmlCount).toBe("number");
-      expect(typeof method.soqlCount).toBe("number");
-      expect(typeof method.dmlRows).toBe("number");
-      expect(typeof method.soqlRows).toBe("number");
-      expect(typeof method.selfPercentage).toBe("number");
-      expect(["number", "string", "object"]).toContain(
-        typeof method.lineNumber,
-      );
-    });
-
-    it("should return LogAnalysisResult with correct structure", async () => {
-      const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
-      const mockApexLog = createMockApexLog();
-
-      setupMocksForSuccess(mockApexLog);
-
-      const result = await analyzeLogPerformance(args);
-      const parsedResult = toonDecode(result);
-
-      expect(typeof parsedResult.totalMethods).toBe("number");
-      expect(typeof parsedResult.totalExecutionTime).toBe("number");
-      expect(Array.isArray(parsedResult.slowestMethods)).toBe(true);
-      expect(typeof parsedResult.summary).toBe("string");
-      expect(Array.isArray(parsedResult.recommendations)).toBe(true);
     });
   });
 
@@ -605,6 +583,21 @@ describe("analyzeLogPerformance", () => {
     return {
       duration: { total: 0, self: 0 },
       children: [method],
+      type: "EXECUTION_STARTED",
+      text: "Root",
+      namespace: "default",
+      lineNumber: null,
+      dmlCount: { total: 0, self: 0 },
+      soqlCount: { total: 0, self: 0 },
+      dmlRowCount: { total: 0, self: 0 },
+      soqlRowCount: { total: 0, self: 0 },
+    };
+  }
+
+  function createEmptyMockApexLog(): any {
+    return {
+      duration: { total: 0, self: 0 },
+      children: [],
       type: "EXECUTION_STARTED",
       text: "Root",
       namespace: "default",
@@ -795,7 +788,7 @@ describe("analyzeLogPerformance", () => {
       8,
       100,
       1200,
-    ); // Should not appear in recommendations
+    );
 
     return {
       duration: { total: 1000000000, self: 0 },
@@ -808,21 +801,6 @@ describe("analyzeLogPerformance", () => {
       soqlCount: { total: 26, self: 0 },
       dmlRowCount: { total: 340, self: 0 },
       soqlRowCount: { total: 4200, self: 0 },
-    };
-  }
-
-  function createEmptyMockApexLog(): any {
-    return {
-      duration: { total: 0, self: 0 },
-      children: [],
-      type: "EXECUTION_STARTED",
-      text: "Root",
-      namespace: "default",
-      lineNumber: null,
-      dmlCount: { total: 0, self: 0 },
-      soqlCount: { total: 0, self: 0 },
-      dmlRowCount: { total: 0, self: 0 },
-      soqlRowCount: { total: 0, self: 0 },
     };
   }
 });

--- a/tests/findPerformanceBottlenecks.test.ts
+++ b/tests/findPerformanceBottlenecks.test.ts
@@ -105,6 +105,9 @@ function createMockSlowMethods(): SlowMethod[] {
       soqlCount: 8,
       dmlRows: 100,
       soqlRows: 1500,
+      thrownCount: 0,
+      soslCount: 0,
+      soslRows: 0,
       selfPercentage: 50.0,
     },
     {
@@ -117,6 +120,9 @@ function createMockSlowMethods(): SlowMethod[] {
       soqlCount: 3,
       dmlRows: 50,
       soqlRows: 500,
+      thrownCount: 0,
+      soslCount: 0,
+      soslRows: 0,
       selfPercentage: 30.0,
     },
     {
@@ -129,6 +135,9 @@ function createMockSlowMethods(): SlowMethod[] {
       soqlCount: 2,
       dmlRows: 25,
       soqlRows: 200,
+      thrownCount: 0,
+      soslCount: 0,
+      soslRows: 0,
       selfPercentage: 20.0,
     },
   ];
@@ -465,6 +474,9 @@ describe("findPerformanceBottlenecks", () => {
           soqlCount: 1,
           dmlRows: 10,
           soqlRows: 100,
+          thrownCount: 0,
+          soslCount: 0,
+          soslRows: 0,
           selfPercentage: 10,
         },
         {
@@ -477,6 +489,9 @@ describe("findPerformanceBottlenecks", () => {
           soqlCount: 2,
           dmlRows: 20,
           soqlRows: 200,
+          thrownCount: 0,
+          soslCount: 0,
+          soslRows: 0,
           selfPercentage: 20,
         },
       ];
@@ -659,6 +674,9 @@ describe("findPerformanceBottlenecks", () => {
           soqlCount: 20, // High SOQL
           dmlRows: 2000,
           soqlRows: 10000, // High rows
+          thrownCount: 0,
+          soslCount: 0,
+          soslRows: 0,
           selfPercentage: 80,
         },
         {
@@ -671,6 +689,9 @@ describe("findPerformanceBottlenecks", () => {
           soqlCount: 30, // Very high SOQL
           dmlRows: 5000,
           soqlRows: 25000, // Very high rows
+          thrownCount: 0,
+          soslCount: 0,
+          soslRows: 0,
           selfPercentage: 15,
         },
       ];
@@ -737,6 +758,9 @@ describe("findPerformanceBottlenecks", () => {
           soqlCount: 1,
           dmlRows: 10,
           soqlRows: 100,
+          thrownCount: 0,
+          soslCount: 0,
+          soslRows: 0,
           selfPercentage: 5,
         },
       ];

--- a/tests/findPerformanceBottlenecks.test.ts
+++ b/tests/findPerformanceBottlenecks.test.ts
@@ -214,7 +214,6 @@ describe("findPerformanceBottlenecks", () => {
       expect(parsedResult).toHaveProperty("cpuBottlenecks");
       expect(parsedResult).toHaveProperty("databaseBottlenecks");
       expect(parsedResult).toHaveProperty("methodBottlenecks");
-      expect(parsedResult).toHaveProperty("governorLimitWarnings");
 
       // Verify CPU analysis
       expect(parsedResult.cpuBottlenecks).toMatchObject({
@@ -232,30 +231,27 @@ describe("findPerformanceBottlenecks", () => {
       });
       expect(parsedResult.databaseBottlenecks!.dmlStatements).toBeUndefined();
 
-      // Verify method analysis
+      // Verify method analysis with ms durations
       expect(parsedResult.methodBottlenecks).toMatchObject({
         totalMethods: 3,
         methodsByNamespace: expect.arrayContaining([
           expect.objectContaining({
             namespace: "MyNamespace",
             methodCount: 2,
-            totalDuration: 700000000, // 500ms + 200ms
+            totalDuration: 700, // 700ms
           }),
           expect.objectContaining({
             namespace: "default",
             methodCount: 1,
-            totalDuration: 300000000,
+            totalDuration: 300, // 300ms
           }),
         ]),
       });
 
-      // Verify governor limit warnings
-      expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "cpuTime: 85.0% of limit used (8500/10000)",
-      );
-      expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "soqlQueries: 90.0% of limit used (90/100)",
-      );
+      // Verify governor limit warnings exclude cpuTime (deduplicated with cpuBottlenecks)
+      expect(parsedResult.governorLimitWarnings).toBeDefined();
+      expect(parsedResult.governorLimitWarnings!.cpuTime).toBeUndefined();
+      expect(parsedResult.governorLimitWarnings!.soqlQueries).toBeDefined();
     });
 
     it('should use "all" as default when analysisType is not specified', async () => {
@@ -268,10 +264,10 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult).toHaveProperty("cpuBottlenecks");
-      expect(parsedResult).toHaveProperty("databaseBottlenecks");
+      // Methods section is always present when analysisType includes it
       expect(parsedResult).toHaveProperty("methodBottlenecks");
-      expect(parsedResult).toHaveProperty("governorLimitWarnings");
+      // No governor limit warnings when usage is low
+      expect(parsedResult).not.toHaveProperty("governorLimitWarnings");
     });
   });
 
@@ -291,11 +287,10 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      // Should only contain CPU analysis and governor limit warnings
+      // Should only contain CPU analysis (no database or methods)
       expect(parsedResult).toHaveProperty("cpuBottlenecks");
       expect(parsedResult).not.toHaveProperty("databaseBottlenecks");
       expect(parsedResult).not.toHaveProperty("methodBottlenecks");
-      expect(parsedResult).toHaveProperty("governorLimitWarnings");
 
       expect(parsedResult.cpuBottlenecks).toMatchObject({
         cpuTimeUsed: 9000,
@@ -320,7 +315,9 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.cpuBottlenecks).toMatchObject({});
+      // Empty section omitted
+      expect(parsedResult).not.toHaveProperty("cpuBottlenecks");
+      expect(parsedResult).toHaveProperty("note");
     });
 
     it("should handle zero CPU limit", async () => {
@@ -338,8 +335,8 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      // When limit is 0, percentage is 0, which is not > 80%, so no bottleneck info
-      expect(parsedResult.cpuBottlenecks).toMatchObject({});
+      expect(parsedResult).not.toHaveProperty("cpuBottlenecks");
+      expect(parsedResult).toHaveProperty("note");
     });
   });
 
@@ -361,14 +358,12 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      // Should only contain database analysis and governor limit warnings
+      // Should not contain CPU or method analysis
       expect(parsedResult).not.toHaveProperty("cpuBottlenecks");
-      expect(parsedResult).toHaveProperty("databaseBottlenecks");
       expect(parsedResult).not.toHaveProperty("methodBottlenecks");
-      expect(parsedResult).toHaveProperty("governorLimitWarnings");
 
-      // None of these exceed 80%, so should return empty object
-      expect(parsedResult.databaseBottlenecks).toMatchObject({});
+      // None of these exceed 80%, so databaseBottlenecks omitted
+      expect(parsedResult).not.toHaveProperty("databaseBottlenecks");
     });
 
     it("should handle zero database limits", async () => {
@@ -388,7 +383,7 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.databaseBottlenecks).toMatchObject({});
+      expect(parsedResult).not.toHaveProperty("databaseBottlenecks");
     });
   });
 
@@ -408,11 +403,10 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      // Should only contain method analysis and governor limit warnings
+      // Should not contain CPU or database analysis
       expect(parsedResult).not.toHaveProperty("cpuBottlenecks");
       expect(parsedResult).not.toHaveProperty("databaseBottlenecks");
       expect(parsedResult).toHaveProperty("methodBottlenecks");
-      expect(parsedResult).toHaveProperty("governorLimitWarnings");
 
       expect(parsedResult.methodBottlenecks).toMatchObject({
         totalMethods: 3,
@@ -420,12 +414,12 @@ describe("findPerformanceBottlenecks", () => {
           expect.objectContaining({
             namespace: "MyNamespace",
             methodCount: 2,
-            totalDuration: 700000000,
+            totalDuration: 700, // 700ms
           }),
           expect.objectContaining({
             namespace: "default",
             methodCount: 1,
-            totalDuration: 300000000,
+            totalDuration: 300, // 300ms
           }),
         ]),
       });
@@ -498,13 +492,13 @@ describe("findPerformanceBottlenecks", () => {
       expect(methodBottlenecks.methodsByNamespace[0]).toMatchObject({
         namespace: "TestNamespace",
         methodCount: 2,
-        totalDuration: 300000000,
+        totalDuration: 300, // 300ms
       });
     });
   });
 
   describe("Governor limit warnings", () => {
-    it("should generate warnings for high governor limit usage (>80%)", async () => {
+    it("should return structured limit data for high governor limit usage (>80%)", async () => {
       const args: BottleneckArgs = { logFilePath: mockLogFilePath };
 
       const mockLog = createMockApexLog({
@@ -521,24 +515,28 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "cpuTime: 85.0% of limit used (8500/10000)",
-      );
-      expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "soqlQueries: 90.0% of limit used (90/100)",
-      );
-      expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "dmlStatements: 90.0% of limit used (135/150)",
-      );
-      expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "queryRows: 90.0% of limit used (45000/50000)",
-      );
-      expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "heapSize: 85.0% of limit used (5100000/6000000)",
-      );
+      // cpuTime excluded from governorLimitWarnings (deduplicated with cpuBottlenecks)
+      expect(parsedResult.governorLimitWarnings!.cpuTime).toBeUndefined();
+      // Other limits should be present as structured data
+      expect(parsedResult.governorLimitWarnings!.soqlQueries).toMatchObject({
+        used: 90,
+        limit: 100,
+      });
+      expect(parsedResult.governorLimitWarnings!.dmlStatements).toMatchObject({
+        used: 135,
+        limit: 150,
+      });
+      expect(parsedResult.governorLimitWarnings!.queryRows).toMatchObject({
+        used: 45000,
+        limit: 50000,
+      });
+      expect(parsedResult.governorLimitWarnings!.heapSize).toMatchObject({
+        used: 5100000,
+        limit: 6000000,
+      });
     });
 
-    it("should not generate warnings for low governor limit usage (<=80%)", async () => {
+    it("should not include governorLimitWarnings when usage is low (<=80%)", async () => {
       const args: BottleneckArgs = { logFilePath: mockLogFilePath };
 
       const mockLog = createMockApexLog({
@@ -554,12 +552,11 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      // When usage is low, governorLimitWarnings should have a note instead of warnings
-      expect(parsedResult.governorLimitWarnings).toHaveProperty("note");
-      expect(parsedResult.governorLimitWarnings).not.toHaveProperty("warnings");
+      // No governor warnings when usage is low
+      expect(parsedResult).not.toHaveProperty("governorLimitWarnings");
     });
 
-    it("should not generate warnings for zero limits", async () => {
+    it("should not include governorLimitWarnings for zero limits", async () => {
       const args: BottleneckArgs = { logFilePath: mockLogFilePath };
 
       const mockLog = createMockApexLog({
@@ -574,11 +571,10 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.governorLimitWarnings).toHaveProperty("note");
-      expect(parsedResult.governorLimitWarnings).not.toHaveProperty("warnings");
+      expect(parsedResult).not.toHaveProperty("governorLimitWarnings");
     });
 
-    it("should include governor limit details in the response", async () => {
+    it("should not include governorLimitWarnings when usage is low", async () => {
       const args: BottleneckArgs = { logFilePath: mockLogFilePath };
 
       const customLimits = {
@@ -594,8 +590,7 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.governorLimitWarnings).toHaveProperty("note");
-      expect(parsedResult.governorLimitWarnings).not.toHaveProperty("details");
+      expect(parsedResult).not.toHaveProperty("governorLimitWarnings");
     });
 
     it("should handle edge case of exactly 80% usage", async () => {
@@ -611,8 +606,8 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.governorLimitWarnings).toHaveProperty("note");
-      expect(parsedResult.governorLimitWarnings).not.toHaveProperty("warnings");
+      // Exactly 80% is not > 80%
+      expect(parsedResult).not.toHaveProperty("governorLimitWarnings");
     });
 
     it("should handle edge case of just over 80% usage", async () => {
@@ -628,10 +623,12 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      // Should generate warning for just over 80%
-      expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "cpuTime: 80.0% of limit used (8001/10000)",
-      );
+      // cpuTime should be in cpuBottlenecks, not in governorLimitWarnings (deduplicated)
+      expect(parsedResult).toHaveProperty("cpuBottlenecks");
+      // governorLimitWarnings should not have cpuTime since it's deduplicated
+      if (parsedResult.governorLimitWarnings) {
+        expect(parsedResult.governorLimitWarnings.cpuTime).toBeUndefined();
+      }
     });
   });
 
@@ -685,7 +682,6 @@ describe("findPerformanceBottlenecks", () => {
       const parsedResult = toonDecode(result);
       const databaseBottlenecks = parsedResult.databaseBottlenecks as any;
       const methodBottlenecks = parsedResult.methodBottlenecks as any;
-      const governorLimitWarnings = parsedResult.governorLimitWarnings as any;
 
       // Should identify all bottleneck types
       expect(parsedResult.cpuBottlenecks!.warning).toBe(
@@ -705,14 +701,14 @@ describe("findPerformanceBottlenecks", () => {
       expect(methodBottlenecks.totalMethods).toBe(2);
       expect(methodBottlenecks.methodsByNamespace).toHaveLength(2);
 
-      // Multiple governor limit warnings
-      expect(governorLimitWarnings.warnings.length).toBeGreaterThan(3);
-      expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "cpuTime: 95.0% of limit used (9500/10000)",
-      );
-      expect(parsedResult.governorLimitWarnings.warnings).toContain(
-        "soqlQueries: 95.0% of limit used (95/100)",
-      );
+      // Governor warnings should have non-CPU limits as structured data
+      expect(parsedResult.governorLimitWarnings).toBeDefined();
+      expect(parsedResult.governorLimitWarnings!.soqlQueries).toMatchObject({
+        used: 95,
+        limit: 100,
+      });
+      // cpuTime excluded from governorLimitWarnings (deduplicated)
+      expect(parsedResult.governorLimitWarnings!.cpuTime).toBeUndefined();
     });
 
     it("should handle optimal performance scenario", async () => {
@@ -750,21 +746,19 @@ describe("findPerformanceBottlenecks", () => {
 
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
-      const databaseBottlenecks = parsedResult.databaseBottlenecks as any;
+
+      // No CPU bottleneck (below 80%) — section omitted
+      expect(parsedResult).not.toHaveProperty("cpuBottlenecks");
+
+      // Low database usage - section omitted
+      expect(parsedResult).not.toHaveProperty("databaseBottlenecks");
+
+      // Method analysis still present
       const methodBottlenecks = parsedResult.methodBottlenecks as any;
-
-      // No CPU bottleneck (below 80%)
-      expect(parsedResult.cpuBottlenecks).toMatchObject({});
-
-      // Low database usage - no bottlenecks
-      expect(databaseBottlenecks).toMatchObject({});
-
-      // Simple method analysis
       expect(methodBottlenecks.totalMethods).toBe(1);
 
       // No governor limit warnings
-      expect(parsedResult.governorLimitWarnings).toHaveProperty("note");
-      expect(parsedResult.governorLimitWarnings).not.toHaveProperty("warnings");
+      expect(parsedResult).not.toHaveProperty("governorLimitWarnings");
     });
   });
 
@@ -784,10 +778,9 @@ describe("findPerformanceBottlenecks", () => {
       expect(result.content[0]).toHaveProperty("type", "text");
       expect(result.content[0]).toHaveProperty("text");
 
-      // Validate JSON structure
+      // Validate structure — methodBottlenecks always present for "all"
       const parsedResult = toonDecode(result);
-      expect(parsedResult).toHaveProperty("governorLimitWarnings");
-      expect(parsedResult.governorLimitWarnings).toHaveProperty("note");
+      expect(parsedResult).toHaveProperty("methodBottlenecks");
     });
 
     it("should handle undefined values gracefully", async () => {
@@ -804,7 +797,7 @@ describe("findPerformanceBottlenecks", () => {
       const parsedResult = toonDecode(result);
 
       // Should still work without errors
-      expect(parsedResult).toHaveProperty("governorLimitWarnings");
+      expect(parsedResult).toBeDefined();
     });
   });
 

--- a/tests/getLogSummary.test.ts
+++ b/tests/getLogSummary.test.ts
@@ -15,7 +15,7 @@ import {
   LogIssue,
   ApexLogParser,
 } from "../src/ApexLogParser";
-import { decode, encode } from "@toon-format/toon";
+import { decode } from "@toon-format/toon";
 
 // Mock the dependencies
 jest.mock("fs", () => ({
@@ -140,7 +140,7 @@ describe("getLogSummary", () => {
       textData: "",
 
       // Counting properties
-      duration: { total: 12500, self: 12500 },
+      duration: { total: 12500000000, self: 12500000000 },
       dmlRowCount: { total: 25, self: 25 },
       soqlRowCount: { total: 150, self: 150 },
       soqlCount: { total: 5, self: 5 },
@@ -190,30 +190,31 @@ describe("getLogSummary", () => {
       expect(mockPath.basename).toHaveBeenCalledWith("/path/to/test-log.log");
       expect(mockParse).toHaveBeenCalledWith(mockLogContent);
 
-      expect(result).toEqual({
-        content: [
-          {
-            type: "text",
-            text: encode({
-              file: "test-log.log",
-              totalExecutionTime: 12500,
-              totalMethods: 3, // 2 METHOD_ENTRY + 1 with subCategory 'Method'
-              totalSOQLQueries: 5,
-              totalDMLOperations: 3,
-              totalSOQLRows: 150,
-              totalDMLRows: 25,
-              governorLimits: {
-                cpuTime: { used: 1500, limit: 10000 },
-                heapSize: { used: 2048, limit: 6000000 },
-                soqlQueries: { used: 5, limit: 100 },
-                dmlStatements: { used: 3, limit: 150 },
-              },
-              namespaces: ["default", "MyNamespace"],
-              logIssues: 0,
-              parsingErrors: 0,
-            }),
-          },
-        ],
+      const parsedResult = toonDecode(result);
+
+      expect(parsedResult.file).toBe("test-log.log");
+      expect(parsedResult.totalExecutionTime).toBe(12500); // ms
+      expect(parsedResult.totalMethods).toBe(3); // 2 METHOD_ENTRY + 1 with subCategory 'Method'
+      expect(parsedResult.totalSOQLQueries).toBe(5);
+      expect(parsedResult.totalDMLOperations).toBe(3);
+      expect(parsedResult.totalSOQLRows).toBe(150);
+      expect(parsedResult.totalDMLRows).toBe(25);
+      expect(parsedResult.namespaces).toEqual(["default", "MyNamespace"]);
+      expect(parsedResult.logIssues).toEqual([]);
+      expect(parsedResult.parsingErrors).toBe(0);
+
+      // Governor limits: only those with used > 0 or limit > 0
+      expect(parsedResult.governorLimits.cpuTime).toEqual({
+        used: 1500,
+        limit: 10000,
+      });
+      expect(parsedResult.governorLimits.soqlQueries).toEqual({
+        used: 5,
+        limit: 100,
+      });
+      expect(parsedResult.governorLimits.dmlStatements).toEqual({
+        used: 3,
+        limit: 150,
       });
     });
 
@@ -242,7 +243,7 @@ describe("getLogSummary", () => {
       expect(parsedResult.file).toBe("namespace-test.log");
     });
 
-    it("should handle logs with log issues and parsing errors", async () => {
+    it("should include log issues as array of {type, summary} objects", async () => {
       const mockLogIssues: LogIssue[] = [
         {
           summary: "CPU time exceeded",
@@ -269,7 +270,9 @@ describe("getLogSummary", () => {
       const result = await getLogSummary(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.logIssues).toBe(1);
+      expect(parsedResult.logIssues).toEqual([
+        { type: "error", summary: "CPU time exceeded" },
+      ]);
       expect(parsedResult.parsingErrors).toBe(1);
     });
 
@@ -353,14 +356,8 @@ describe("getLogSummary", () => {
       expect(parsedResult.totalDMLOperations).toBe(0);
       expect(parsedResult.totalSOQLRows).toBe(0);
       expect(parsedResult.totalDMLRows).toBe(0);
-      expect(parsedResult.governorLimits.cpuTime).toEqual({
-        used: 0,
-        limit: 0,
-      });
-      expect(parsedResult.governorLimits.heapSize).toEqual({
-        used: 0,
-        limit: 0,
-      });
+      // All limits are 0/0, so governorLimits should be empty
+      expect(parsedResult.governorLimits).toEqual({});
     });
 
     it("should handle different file paths and extensions", async () => {
@@ -488,7 +485,7 @@ describe("getLogSummary", () => {
       const parsedResult = toonDecode(result);
 
       expect(parsedResult.namespaces).toEqual([]);
-      expect(parsedResult.logIssues).toBe(0);
+      expect(parsedResult.logIssues).toEqual([]);
       expect(parsedResult.parsingErrors).toBe(0);
       expect(parsedResult.file).toBe("edge-case.log");
     });
@@ -592,7 +589,7 @@ describe("getLogSummary", () => {
   });
 
   describe("governor limits handling", () => {
-    it("should handle various governor limit configurations", async () => {
+    it("should include all governor limits with used > 0 or limit > 0", async () => {
       const customGovernorLimits: GovernorLimits = {
         soqlQueries: { used: 50, limit: 100 },
         soslQueries: { used: 5, limit: 20 },
@@ -626,11 +623,39 @@ describe("getLogSummary", () => {
       const result = await getLogSummary(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.governorLimits).toEqual({
-        cpuTime: { used: 8000, limit: 10000 },
-        heapSize: { used: 5000000, limit: 6000000 },
-        soqlQueries: { used: 50, limit: 100 },
-        dmlStatements: { used: 25, limit: 150 },
+      // All limits with used > 0 or limit > 0 should be included
+      expect(parsedResult.governorLimits.cpuTime).toEqual({
+        used: 8000,
+        limit: 10000,
+      });
+      expect(parsedResult.governorLimits.heapSize).toEqual({
+        used: 5000000,
+        limit: 6000000,
+      });
+      expect(parsedResult.governorLimits.soqlQueries).toEqual({
+        used: 50,
+        limit: 100,
+      });
+      expect(parsedResult.governorLimits.dmlStatements).toEqual({
+        used: 25,
+        limit: 150,
+      });
+      expect(parsedResult.governorLimits.queryRows).toEqual({
+        used: 2500,
+        limit: 50000,
+      });
+      expect(parsedResult.governorLimits.callouts).toEqual({
+        used: 3,
+        limit: 100,
+      });
+      expect(parsedResult.governorLimits.dmlRows).toEqual({
+        used: 500,
+        limit: 10000,
+      });
+      // mobileApexPushCalls has used: 0, limit: 10 — included since limit > 0
+      expect(parsedResult.governorLimits.mobileApexPushCalls).toEqual({
+        used: 0,
+        limit: 10,
       });
     });
 

--- a/tests/getLogSummary.test.ts
+++ b/tests/getLogSummary.test.ts
@@ -193,6 +193,8 @@ describe("getLogSummary", () => {
       const parsedResult = toonDecode(result);
 
       expect(parsedResult.file).toBe("test-log.log");
+      expect(parsedResult.size).toBe(15000);
+      expect(parsedResult.debugLevels).toEqual([]);
       expect(parsedResult.totalExecutionTime).toBe(12500); // ms
       expect(parsedResult.totalMethods).toBe(3); // 2 METHOD_ENTRY + 1 with subCategory 'Method'
       expect(parsedResult.totalSOQLQueries).toBe(5);
@@ -216,6 +218,32 @@ describe("getLogSummary", () => {
         used: 3,
         limit: 150,
       });
+    });
+
+    it("should map debugLevels to compact category/level objects", async () => {
+      const mockApexLog = createMockApexLog({
+        debugLevels: [
+          { logCategory: "Apex_code", logLevel: "DEBUG" },
+          { logCategory: "System", logLevel: "INFO" },
+        ] as any,
+      });
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue("mock log content");
+      mockPath.basename.mockReturnValue("debug-levels.log");
+      mockParse.mockReturnValue(mockApexLog);
+
+      const args: LogSummaryArgs = {
+        logFilePath: "/path/to/debug-levels.log",
+      };
+
+      const result = await getLogSummary(args);
+      const parsedResult = toonDecode(result);
+
+      expect(parsedResult.debugLevels).toEqual([
+        { category: "Apex_code", level: "DEBUG" },
+        { category: "System", level: "INFO" },
+      ]);
     });
 
     it("should handle logs with different namespaces", async () => {


### PR DESCRIPTION
## Summary
- Optimize all tool responses for token efficiency: convert durations from nanoseconds to milliseconds at the response boundary, deduplicate data, and omit empty sections
- Add new metrics to tool responses: log size, debug levels, thrown exception count, and SOSL query tracking
- Expand governor limits in `getLogSummary` to include all limits with usage > 0, and surface log issues as structured `{type, summary}` objects

## Test plan
- [x] Existing tests updated to reflect new response shapes and ms units
- [ ] Verify `analyze_apex_log_performance` returns durations in ms and includes new metrics
- [ ] Verify `find_performance_bottlenecks` omits empty sections and deduplicates CPU data
- [ ] Verify `get_apex_log_summary` returns expanded governor limits and structured log issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)