### PR TITLE
chore: publish to public npm registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,10 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Dependencies
-        run: HUSKY=0 pnpm install
+        run: HUSKY=0 pnpm install --frozen-lockfile
 
       - name: Lint Files
         run: pnpm run lint
@@ -30,17 +31,7 @@ jobs:
       - name: Tests
         run: pnpm run test
 
-      - name: Configure NPM
-        run: |
-          cat ci/.npmrc > .npmrc
-          echo $NPM_CERT | base64 --decode > ci/client.cert
-          echo $NPM_KEY | base64 --decode > ci/client.key
-        env:
-          NPM_CERT: ${{ secrets.ARTIFACTORY_MTLS_CERT_BASE64 }}
-          NPM_KEY: ${{ secrets.ARTIFACTORY_MTLS_KEY_BASE64 }}
-
       - name: Publish
-        run: pnpm publish --registry ${{ secrets.REGISTRY_URL }} --no-git-checks
+        run: pnpm publish --access public --no-git-checks
         env:
-          REGISTRY_BASE_URL: ${{ secrets.REGISTRY_BASE_URL }}
-          REGISTRY_AUTH: ${{ secrets.REGISTRY_AUTH }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/ci/.npmrc
+++ b/ci/.npmrc
@@ -1,4 +1,0 @@
-//${REGISTRY_BASE_URL}/:_auth=${REGISTRY_AUTH}
-//${REGISTRY_BASE_URL}/:certfile=${GITHUB_WORKSPACE}/ci/client.cert
-//${REGISTRY_BASE_URL}/:keyfile=${GITHUB_WORKSPACE}/ci/client.key
-always-auth=true


### PR DESCRIPTION
## Summary
- Replace Artifactory mTLS-based publishing with public npm registry
- Configure `setup-node` with `registry-url` for npm auth via `NODE_AUTH_TOKEN`
- Remove unused `ci/.npmrc` configuration file
- Use `--frozen-lockfile` for deterministic CI installs

## Prerequisites
Add an `NPM_TOKEN` secret to the repository (Settings > Secrets > Actions) with an npm access token that has publish permissions.