### PR TITLE
chore: improve test suite quality and coverage

### DIFF
--- a/tests/getLogSummary.test.ts
+++ b/tests/getLogSummary.test.ts
@@ -74,6 +74,10 @@ describe("getLogSummary", () => {
     jest.clearAllMocks();
   });
 
+  function toonDecode(result: any): any {
+    return decode(result.content[0].text) as any;
+  }
+
   const createMockApexLog = (overrides: Partial<ApexLog> = {}): ApexLog => {
     const mockGovernorLimits: GovernorLimits = {
       soqlQueries: { used: 5, limit: 100 },
@@ -731,9 +735,4 @@ describe("getLogSummary", () => {
       expect(parsedResult.governorLimits.dmlStatements.limit).toBe(150);
     });
   });
-
-  // Helper function for decoding TOON-formatted data
-  function toonDecode(result: any): any {
-    return decode(result.content[0].text) as any;
-  }
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -207,14 +207,16 @@ describe("ApexLogServer", () => {
     (
       executeAnonymous as jest.MockedFunction<typeof executeAnonymous>
     ).mockResolvedValue(mockExecuteAnonymousResult);
-
-    // Clear the module cache and re-import
-    jest.resetModules();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
     process.removeAllListeners("SIGINT");
+  });
+
+  afterAll(() => {
+    mockExit.mockRestore();
+    mockConsoleError.mockRestore();
   });
 
   describe("Server Initialization", () => {
@@ -379,8 +381,8 @@ describe("ApexLogServer", () => {
 
   describe("Server Lifecycle", () => {
     it("should start server correctly", async () => {
-      const lanaServer = new ApexLogServer();
-      await lanaServer.run();
+      const apexLogServer = new ApexLogServer();
+      await apexLogServer.run();
 
       expect(StdioServerTransport).toHaveBeenCalled();
       expect(mockConnect).toHaveBeenCalledWith(mockTransport);
@@ -390,8 +392,8 @@ describe("ApexLogServer", () => {
     });
 
     it("should connect to stdio transport", async () => {
-      const lanaServer = new ApexLogServer();
-      await lanaServer.run();
+      const apexLogServer = new ApexLogServer();
+      await apexLogServer.run();
 
       expect(StdioServerTransport).toHaveBeenCalled();
       expect(mockConnect).toHaveBeenCalledWith(mockTransport);

--- a/tests/salesforce/users.test.ts
+++ b/tests/salesforce/users.test.ts
@@ -99,6 +99,25 @@ describe("Users", () => {
       );
     });
 
+    it("should escape single quotes in username to prevent SOQL injection", async () => {
+      const username = "test'injection@example.com";
+
+      mockQuery.mockResolvedValue({
+        records: [
+          {
+            Id: testUserId,
+          },
+        ],
+      });
+
+      const result = await getUserIdByUsername(mockConnection, username);
+
+      expect(result).toBe(testUserId);
+      expect(mockQuery).toHaveBeenCalledWith(
+        "SELECT Id FROM User WHERE Username = 'test\\'injection@example.com'",
+      );
+    });
+
     it("should handle usernames with spaces", async () => {
       const username = "test user@example.com";
 


### PR DESCRIPTION
## Summary
- Add test for SOQL injection prevention by verifying single quote escaping in `getUserIdByUsername`
- Restore `process.exit` and `console.error` spies in `afterAll` to prevent test pollution in `index.test.ts`
- Remove unnecessary `jest.resetModules()` call with misleading comment in `index.test.ts`
- Move `toonDecode` helper to top of describe block in `getLogSummary.test.ts` for readability

## Test plan
- [x] All existing tests pass
- [x] New SOQL injection escaping test passes