### PR TITLE
ci(publish): use npm trusted publishing via OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest
@@ -33,5 +37,3 @@ jobs:
 
       - name: Publish
         run: pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Switch the `Publish Stable` workflow from a long-lived npm token to npm **Trusted Publishing** (OIDC). GitHub Actions mints a short-lived, workflow-scoped OIDC token that npm exchanges for publish rights, removing the stored `NPM_TOKEN` credential and enabling automatic provenance attestations.

## Changes

- Add top-level `permissions:` block — `id-token: write` so Actions can generate the OIDC token, and `contents: read` to keep `actions/checkout` working under least-privilege.
- Remove `NODE_AUTH_TOKEN`/`secrets.NPM_TOKEN` from the Publish step; auth now comes from OIDC.

## Requirements (already satisfied)

- Node 22 (≥ 22.14.0) and pnpm 10.30.2 (≥ 10.12.1 for trusted publishing).
- Registry pinned to `https://registry.npmjs.org` via `setup-node`.

## Follow-up — required before the next release

1. On npmjs.com, for `@certinia/apex-log-mcp` → Settings → Trusted Publisher, add a GitHub Actions publisher: org `certinia`, repo `debug-log-analyzer-mcp`, workflow `publish.yml`. This must exist before the next release or the publish step will fail auth.
2. After the first successful trusted publish, delete the now-unused `NPM_TOKEN` repo secret.

## Test plan

- [ ] Trusted publisher configured on npmjs.com
- [ ] Cut a GitHub Release and confirm the Publish step succeeds and the published version shows a provenance / Trusted Publisher badge