### PR TITLE
build: adopt typescript 7 with typescript 6 side-by-side for tooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,10 +54,10 @@ This server is designed to integrate with the Apex Log Analyzer VS Code extensio
 ## TypeScript Configuration
 
 - Target: ES2022
-- Module: ESNext with Node resolution
-- Strict mode enabled
+- Module: NodeNext (module + moduleResolution)
+- Strict mode plus extra strictness (noUncheckedIndexedAccess, noImplicitOverride, verbatimModuleSyntax, isolatedModules)
 - Output to `dist/` directory
-- Source maps and declarations generated
+- Emits `.js` only — no source maps or declarations
 
 ## File Structure
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint": "^10.7.0",
     "eslint-plugin-headers": "^1.3.4",
     "jest": "^30.4.2",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.64.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -65,8 +65,9 @@
     "eslint": "^10.7.0",
     "eslint-plugin-headers": "^1.3.4",
     "jest": "^30.4.2",
-    "typescript": "^6.0.3",
-    "typescript-eslint": "^8.64.0"
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-eslint": "^8.64.0",
+    "typescript7": "npm:typescript@^7.0.2"
   },
   "engines": {
     "node": ">=20.19.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,13 +44,13 @@ importers:
         version: 1.3.4(eslint@10.7.0)
       jest:
         specifier: ^30.4.2
-        version: 30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3))
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       typescript-eslint:
         specifier: ^8.64.0
-        version: 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+        version: 8.64.0(eslint@10.7.0)(typescript@6.0.3)
 
 packages:
 
@@ -2546,8 +2546,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2973,7 +2973,7 @@ snapshots:
       jest-util: 30.4.1
       slash: 3.0.0
 
-  '@jest/core@30.4.2(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@5.9.3))':
+  '@jest/core@30.4.2(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.4.1
       '@jest/pattern': 30.4.0
@@ -2989,7 +2989,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
       jest-changed-files: 30.4.1
-      jest-config: 30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@5.9.3))
+      jest-config: 30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3))
       jest-haste-map: 30.4.1
       jest-message-util: 30.4.1
       jest-regex-util: 30.4.0
@@ -3462,40 +3462,40 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.7.0)(typescript@5.9.3))(eslint@10.7.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.7.0)(typescript@6.0.3))(eslint@10.7.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/type-utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.64.0
       eslint: 10.7.0
       ignore: 7.0.6
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.64.0(eslint@10.7.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.64.0(eslint@10.7.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.64.0
       debug: 4.4.3
       eslint: 10.7.0
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.64.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.64.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.64.0
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3504,47 +3504,47 @@ snapshots:
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
 
-  '@typescript-eslint/tsconfig-utils@8.64.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.64.0(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.64.0(eslint@10.7.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.64.0(eslint@10.7.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       debug: 4.4.3
       eslint: 10.7.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.64.0': {}
 
-  '@typescript-eslint/typescript-estree@8.64.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.64.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.64.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.64.0(eslint@10.7.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.64.0(eslint@10.7.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
       eslint: 10.7.0
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4480,15 +4480,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@5.9.3)):
+  jest-cli@30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.4.2(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@5.9.3))
+      '@jest/core': 30.4.2(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3))
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@5.9.3))
+      jest-config: 30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3))
       jest-util: 30.4.1
       jest-validate: 30.4.1
       yargs: 17.7.3
@@ -4499,7 +4499,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@5.9.3)):
+  jest-config@30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/get-type': 30.1.0
@@ -4526,7 +4526,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.13
-      ts-node: 10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -4790,12 +4790,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@5.9.3)):
+  jest@30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.4.2(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@5.9.3))
+      '@jest/core': 30.4.2(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3))
       '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@5.9.3))
+      jest-cli: 30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5473,11 +5473,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -5491,7 +5491,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -5520,18 +5520,18 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript-eslint@8.64.0(eslint@10.7.0)(typescript@5.9.3):
+  typescript-eslint@8.64.0(eslint@10.7.0)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.7.0)(typescript@5.9.3))(eslint@10.7.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.7.0)(typescript@6.0.3))(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       eslint: 10.7.0
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   undici-types@6.21.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,13 +44,16 @@ importers:
         version: 1.3.4(eslint@10.7.0)
       jest:
         specifier: ^30.4.2
-        version: 30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3))
+        version: 30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(@typescript/typescript6@6.0.2))
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
       typescript-eslint:
         specifier: ^8.64.0
-        version: 8.64.0(eslint@10.7.0)(typescript@6.0.3)
+        version: 8.64.0(@typescript/typescript6@6.0.2)(eslint@10.7.0)
+      typescript7:
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
 
 packages:
 
@@ -756,6 +759,130 @@ packages:
   '@typescript-eslint/visitor-keys@8.64.0':
     resolution: {integrity: sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
 
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
@@ -2551,6 +2678,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -2973,7 +3105,7 @@ snapshots:
       jest-util: 30.4.1
       slash: 3.0.0
 
-  '@jest/core@30.4.2(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3))':
+  '@jest/core@30.4.2(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(@typescript/typescript6@6.0.2))':
     dependencies:
       '@jest/console': 30.4.1
       '@jest/pattern': 30.4.0
@@ -2989,7 +3121,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
       jest-changed-files: 30.4.1
-      jest-config: 30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3))
+      jest-config: 30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(@typescript/typescript6@6.0.2))
       jest-haste-map: 30.4.1
       jest-message-util: 30.4.1
       jest-regex-util: 30.4.0
@@ -3462,40 +3594,40 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.7.0)(typescript@6.0.3))(eslint@10.7.0)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(@typescript/typescript6@6.0.2)(eslint@10.7.0))(@typescript/typescript6@6.0.2)(eslint@10.7.0)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.64.0(@typescript/typescript6@6.0.2)(eslint@10.7.0)
       '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/type-utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.64.0(@typescript/typescript6@6.0.2)(eslint@10.7.0)
+      '@typescript-eslint/utils': 8.64.0(@typescript/typescript6@6.0.2)(eslint@10.7.0)
       '@typescript-eslint/visitor-keys': 8.64.0
       eslint: 10.7.0
       ignore: 7.0.6
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.64.0(eslint@10.7.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.64.0(@typescript/typescript6@6.0.2)(eslint@10.7.0)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(@typescript/typescript6@6.0.2)
       '@typescript-eslint/visitor-keys': 8.64.0
       debug: 4.4.3
       eslint: 10.7.0
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.64.0(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.64.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.64.0(@typescript/typescript6@6.0.2)
       '@typescript-eslint/types': 8.64.0
       debug: 4.4.3
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -3504,47 +3636,47 @@ snapshots:
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
 
-  '@typescript-eslint/tsconfig-utils@8.64.0(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.64.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@typescript-eslint/type-utils@8.64.0(eslint@10.7.0)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.64.0(@typescript/typescript6@6.0.2)(eslint@10.7.0)':
     dependencies:
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/utils': 8.64.0(@typescript/typescript6@6.0.2)(eslint@10.7.0)
       debug: 4.4.3
       eslint: 10.7.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.64.0': {}
 
-  '@typescript-eslint/typescript-estree@8.64.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.64.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.64.0(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.64.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.64.0(@typescript/typescript6@6.0.2)
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.64.0(eslint@10.7.0)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.64.0(@typescript/typescript6@6.0.2)(eslint@10.7.0)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(@typescript/typescript6@6.0.2)
       eslint: 10.7.0
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -3552,6 +3684,70 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.64.0
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
 
   '@ungap/structured-clone@1.3.3': {}
 
@@ -4480,15 +4676,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3)):
+  jest-cli@30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(@typescript/typescript6@6.0.2)):
     dependencies:
-      '@jest/core': 30.4.2(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3))
+      '@jest/core': 30.4.2(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(@typescript/typescript6@6.0.2))
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3))
+      jest-config: 30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(@typescript/typescript6@6.0.2))
       jest-util: 30.4.1
       jest-validate: 30.4.1
       yargs: 17.7.3
@@ -4499,7 +4695,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3)):
+  jest-config@30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(@typescript/typescript6@6.0.2)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/get-type': 30.1.0
@@ -4526,7 +4722,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.13
-      ts-node: 10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3)
+      ts-node: 10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(@typescript/typescript6@6.0.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -4790,12 +4986,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3)):
+  jest@30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(@typescript/typescript6@6.0.2)):
     dependencies:
-      '@jest/core': 30.4.2(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3))
+      '@jest/core': 30.4.2(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(@typescript/typescript6@6.0.2))
       '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3))
+      jest-cli: 30.4.2(@types/node@22.19.13)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(@typescript/typescript6@6.0.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5473,11 +5669,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ts-api-utils@2.5.0(typescript@6.0.3):
+  ts-api-utils@2.5.0(@typescript/typescript6@6.0.2):
     dependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(typescript@6.0.3):
+  ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.19.13)(@typescript/typescript6@6.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -5491,7 +5687,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -5520,18 +5716,41 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript-eslint@8.64.0(eslint@10.7.0)(typescript@6.0.3):
+  typescript-eslint@8.64.0(@typescript/typescript6@6.0.2)(eslint@10.7.0):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.7.0)(typescript@6.0.3))(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(@typescript/typescript6@6.0.2)(eslint@10.7.0))(@typescript/typescript6@6.0.2)(eslint@10.7.0)
+      '@typescript-eslint/parser': 8.64.0(@typescript/typescript6@6.0.2)(eslint@10.7.0)
+      '@typescript-eslint/typescript-estree': 8.64.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/utils': 8.64.0(@typescript/typescript6@6.0.2)(eslint@10.7.0)
       eslint: 10.7.0
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@6.21.0: {}
 

--- a/src/ApexLogParser.ts
+++ b/src/ApexLogParser.ts
@@ -792,7 +792,7 @@ export abstract class LogLine {
 
 class BasicLogLine extends LogLine {}
 class BasicExitLine extends LogLine {
-  isExit = true;
+  override isExit = true;
 }
 
 type CPUType = "loading" | "custom" | "method" | "free" | "system" | "pkg" | "";
@@ -870,10 +870,10 @@ export class Method extends TimedNode {
  * Since it has children it extends "Method".
  */
 export class ApexLog extends Method {
-  type = null;
-  text = "LOG_ROOT";
-  timestamp = 0;
-  exitStamp = 0;
+  override type = null;
+  override text = "LOG_ROOT";
+  override timestamp = 0;
+  override exitStamp = 0;
   /**
    * The size of the log, in bytes
    */
@@ -1036,8 +1036,8 @@ class NamedCredentialResponseDetailLine extends LogLine {
 }
 
 class ConstructorEntryLine extends Method {
-  hasValidSymbols = true;
-  suffix = " (constructor)";
+  override hasValidSymbols = true;
+  override suffix = " (constructor)";
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["CONSTRUCTOR_EXIT"], "Method", "method");
@@ -1069,7 +1069,7 @@ class ConstructorEntryLine extends Method {
 }
 
 class ConstructorExitLine extends LogLine {
-  isExit = true;
+  override isExit = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -1078,7 +1078,7 @@ class ConstructorExitLine extends LogLine {
 }
 
 class EmailQueueLine extends LogLine {
-  acceptsText = true;
+  override acceptsText = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
     this.lineNumber = this.parseLineNumber(parts[2]);
@@ -1086,7 +1086,7 @@ class EmailQueueLine extends LogLine {
 }
 
 export class MethodEntryLine extends Method {
-  hasValidSymbols = true;
+  override hasValidSymbols = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["METHOD_EXIT"], "Method", "method");
@@ -1103,7 +1103,7 @@ export class MethodEntryLine extends Method {
     }
   }
 
-  onEnd(end: MethodExitLine, _stack: LogLine[]): void {
+  override onEnd(end: MethodExitLine, _stack: LogLine[]): void {
     if (end.namespace && !end.text.endsWith(")")) {
       this.namespace = end.namespace;
     }
@@ -1140,7 +1140,7 @@ export class MethodEntryLine extends Method {
   }
 }
 class MethodExitLine extends LogLine {
-  isExit = true;
+  override isExit = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -1160,7 +1160,7 @@ class MethodExitLine extends LogLine {
 }
 
 class SystemConstructorEntryLine extends Method {
-  suffix = "(system constructor)";
+  override suffix = "(system constructor)";
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(
@@ -1176,7 +1176,7 @@ class SystemConstructorEntryLine extends Method {
 }
 
 class SystemConstructorExitLine extends LogLine {
-  isExit = true;
+  override isExit = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -1192,7 +1192,7 @@ class SystemMethodEntryLine extends Method {
 }
 
 class SystemMethodExitLine extends LogLine {
-  isExit = true;
+  override isExit = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -1201,7 +1201,7 @@ class SystemMethodExitLine extends LogLine {
 }
 
 export class CodeUnitStartedLine extends Method {
-  suffix = " (entrypoint)";
+  override suffix = " (entrypoint)";
   codeUnitType = "";
 
   constructor(parser: ApexLogParser, parts: string[]) {
@@ -1282,7 +1282,7 @@ export class CodeUnitStartedLine extends Method {
   }
 }
 export class CodeUnitFinishedLine extends LogLine {
-  isExit = true;
+  override isExit = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -1291,7 +1291,7 @@ export class CodeUnitFinishedLine extends LogLine {
 }
 
 class VFApexCallStartLine extends Method {
-  suffix = " (VF APEX)";
+  override suffix = " (VF APEX)";
   invalidClasses = [
     "pagemessagescomponentcontroller",
     "pagemessagecomponentcontroller",
@@ -1339,7 +1339,7 @@ class VFApexCallStartLine extends Method {
 }
 
 class VFApexCallEndLine extends LogLine {
-  isExit = true;
+  override isExit = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -1360,7 +1360,7 @@ class VFDeserializeViewstateBeginLine extends Method {
 }
 
 class VFFormulaStartLine extends Method {
-  suffix = " (VF FORMULA)";
+  override suffix = " (VF FORMULA)";
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(
@@ -1375,7 +1375,7 @@ class VFFormulaStartLine extends Method {
 }
 
 class VFFormulaEndLine extends LogLine {
-  isExit = true;
+  override isExit = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -1396,7 +1396,7 @@ class VFSeralizeViewStateStartLine extends Method {
 }
 
 class VFPageMessageLine extends LogLine {
-  acceptsText = true;
+  override acceptsText = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
     this.text = parts[2] || "";
@@ -1404,12 +1404,12 @@ class VFPageMessageLine extends LogLine {
 }
 
 class DMLBeginLine extends Method {
-  dmlCount = {
+  override dmlCount = {
     self: 1,
     total: 1,
   };
 
-  namespace = "default";
+  override namespace = "default";
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["DML_END"], "DML", "free");
@@ -1423,7 +1423,7 @@ class DMLBeginLine extends Method {
 }
 
 class DMLEndLine extends LogLine {
-  isExit = true;
+  override isExit = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -1440,7 +1440,7 @@ class IdeasQueryExecuteLine extends LogLine {
 
 class SOQLExecuteBeginLine extends Method {
   aggregations = 0;
-  soqlCount = {
+  override soqlCount = {
     self: 1,
     total: 1,
   };
@@ -1459,13 +1459,13 @@ class SOQLExecuteBeginLine extends Method {
     this.text = soqlString || "";
   }
 
-  onEnd(end: SOQLExecuteEndLine, _stack: LogLine[]): void {
+  override onEnd(end: SOQLExecuteEndLine, _stack: LogLine[]): void {
     this.soqlRowCount.total = this.soqlRowCount.self = end.soqlRowCount.total;
   }
 }
 
 class SOQLExecuteEndLine extends LogLine {
-  isExit = true;
+  override isExit = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -1544,13 +1544,13 @@ class SOSLExecuteBeginLine extends Method {
     };
   }
 
-  onEnd(end: SOSLExecuteEndLine, _stack: LogLine[]): void {
+  override onEnd(end: SOSLExecuteEndLine, _stack: LogLine[]): void {
     this.soslRowCount.total = this.soslRowCount.self = end.soslRowCount.total;
   }
 }
 
 class SOSLExecuteEndLine extends LogLine {
-  isExit = true;
+  override isExit = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -1607,7 +1607,7 @@ class UserInfoLine extends LogLine {
 }
 
 class UserDebugLine extends LogLine {
-  acceptsText = true;
+  override acceptsText = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -1617,7 +1617,7 @@ class UserDebugLine extends LogLine {
 }
 
 class CumulativeLimitUsageLine extends Method {
-  namespace = "default";
+  override namespace = "default";
   constructor(parser: ApexLogParser, parts: string[]) {
     super(
       parser,
@@ -1630,8 +1630,8 @@ class CumulativeLimitUsageLine extends Method {
 }
 
 class CumulativeProfilingLine extends LogLine {
-  acceptsText = true;
-  namespace = "default";
+  override acceptsText = true;
+  override namespace = "default";
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
     this.text = parts[2] + " " + (parts[3] ?? "");
@@ -1639,7 +1639,7 @@ class CumulativeProfilingLine extends LogLine {
 }
 
 class CumulativeProfilingBeginLine extends Method {
-  namespace = "default";
+  override namespace = "default";
   constructor(parser: ApexLogParser, parts: string[]) {
     super(
       parser,
@@ -1652,7 +1652,7 @@ class CumulativeProfilingBeginLine extends Method {
 }
 
 class LimitUsageLine extends LogLine {
-  namespace = "default";
+  override namespace = "default";
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
     this.lineNumber = this.parseLineNumber(parts[2]);
@@ -1688,7 +1688,7 @@ class LimitUsageForNSLine extends LogLine {
     this.text = parts[2] || "";
   }
 
-  onAfter(parser: ApexLogParser, _next?: LogLine): void {
+  override onAfter(parser: ApexLogParser, _next?: LogLine): void {
     // Parse the namespace from the first line (before any newline)
     this.namespace = this.text
       .slice(0, this.text.indexOf("\n"))
@@ -1754,7 +1754,7 @@ class NBANodeDetail extends LogLine {
   }
 }
 class NBANodeEnd extends LogLine {
-  isExit = true;
+  override isExit = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
     this.text = parts.slice(2).join(" | ");
@@ -1779,7 +1779,7 @@ class NBAStrategyBegin extends Method {
   }
 }
 class NBAStrategyEnd extends LogLine {
-  isExit = true;
+  override isExit = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
     this.text = parts.slice(2).join(" | ");
@@ -1817,7 +1817,7 @@ class QueryMoreBeginLine extends Method {
 }
 
 class QueryMoreEndLine extends LogLine {
-  isExit = true;
+  override isExit = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -1857,7 +1857,7 @@ class TotalEmailRecipientsQueuedLine extends LogLine {
 }
 
 class StackFrameVariableListLine extends LogLine {
-  acceptsText = true;
+  override acceptsText = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -1865,7 +1865,7 @@ class StackFrameVariableListLine extends LogLine {
 }
 
 class StaticVariableListLine extends LogLine {
-  acceptsText = true;
+  override acceptsText = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -1890,7 +1890,7 @@ class SystemModeExitLine extends LogLine {
 }
 
 export class ExecutionStartedLine extends Method {
-  namespace = "default";
+  override namespace = "default";
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["EXECUTION_FINISHED"], "Method", "method");
   }
@@ -1906,7 +1906,7 @@ class EnteringManagedPackageLine extends Method {
       lastDot < 0 ? rawNs : rawNs.substring(lastDot + 1);
   }
 
-  onAfter(parser: ApexLogParser, end?: LogLine): void {
+  override onAfter(parser: ApexLogParser, end?: LogLine): void {
     if (end) {
       this.exitStamp = end.timestamp;
     }
@@ -1921,7 +1921,7 @@ class EventSericePubBeginLine extends Method {
 }
 
 class EventSericePubEndLine extends LogLine {
-  isExit = true;
+  override isExit = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -1944,7 +1944,7 @@ class EventSericeSubBeginLine extends Method {
 }
 
 class EventSericeSubEndLine extends LogLine {
-  isExit = true;
+  override isExit = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -1960,14 +1960,14 @@ class EventSericeSubDetailLine extends LogLine {
 }
 
 export class FlowStartInterviewsBeginLine extends Method {
-  declarative = true;
-  text = "FLOW_START_INTERVIEWS : ";
+  override declarative = true;
+  override text = "FLOW_START_INTERVIEWS : ";
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["FLOW_START_INTERVIEWS_END"], "Flow", "custom");
   }
 
-  onEnd(end: LogLine, stack: LogLine[]) {
+  override onEnd(end: LogLine, stack: LogLine[]) {
     const flowType = this.getFlowType(stack);
     this.suffix = ` (${flowType})`;
     this.text += this.getFlowName();
@@ -2001,7 +2001,7 @@ export class FlowStartInterviewsBeginLine extends Method {
 }
 
 class FlowStartInterviewsErrorLine extends LogLine {
-  acceptsText = true;
+  override acceptsText = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
     this.text = `${parts[2]} - ${parts[4]}`;
@@ -2037,7 +2037,7 @@ class FlowCreateInterviewErrorLine extends LogLine {
 }
 
 class FlowElementBeginLine extends Method {
-  declarative = true;
+  override declarative = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["FLOW_ELEMENT_END"], "Flow", "custom");
@@ -2046,7 +2046,7 @@ class FlowElementBeginLine extends Method {
 }
 
 class FlowElementDeferredLine extends LogLine {
-  declarative = true;
+  override declarative = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -2055,8 +2055,8 @@ class FlowElementDeferredLine extends LogLine {
 }
 
 class FlowElementAssignmentLine extends LogLine {
-  declarative = true;
-  acceptsText = true;
+  override declarative = true;
+  override acceptsText = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -2114,7 +2114,7 @@ class FlowInterviewPausedLine extends LogLine {
 }
 
 class FlowElementErrorLine extends LogLine {
-  acceptsText = true;
+  override acceptsText = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
     this.text = parts[1] || "" + parts[2] + " " + parts[3] + " " + parts[4];
@@ -2179,7 +2179,7 @@ class FlowRuleDetailLine extends LogLine {
 }
 
 class FlowBulkElementBeginLine extends Method {
-  declarative = true;
+  override declarative = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["FLOW_BULK_ELEMENT_END"], "Flow", "custom");
@@ -2188,7 +2188,7 @@ class FlowBulkElementBeginLine extends Method {
 }
 
 class FlowBulkElementDetailLine extends LogLine {
-  declarative = true;
+  override declarative = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -2204,7 +2204,7 @@ class FlowBulkElementNotSupportedLine extends LogLine {
 }
 
 class FlowBulkElementLimitUsageLine extends LogLine {
-  declarative = true;
+  override declarative = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -2267,7 +2267,7 @@ class SLAProcessCaseLine extends LogLine {
 }
 
 class TestingLimitsLine extends LogLine {
-  acceptsText = true;
+  override acceptsText = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -2282,7 +2282,7 @@ class ValidationRuleLine extends LogLine {
 }
 
 class ValidationErrorLine extends LogLine {
-  acceptsText = true;
+  override acceptsText = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
     this.text = parts[2] || "";
@@ -2290,7 +2290,7 @@ class ValidationErrorLine extends LogLine {
 }
 
 class ValidationFormulaLine extends LogLine {
-  acceptsText = true;
+  override acceptsText = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -2308,7 +2308,7 @@ class ValidationPassLine extends LogLine {
 }
 
 class WFFlowActionErrorLine extends LogLine {
-  acceptsText = true;
+  override acceptsText = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
     this.text = parts[1] + " " + parts[4];
@@ -2316,7 +2316,7 @@ class WFFlowActionErrorLine extends LogLine {
 }
 
 class WFFlowActionErrorDetailLine extends LogLine {
-  acceptsText = true;
+  override acceptsText = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
     this.text = parts[1] + " " + parts[2];
@@ -2324,8 +2324,8 @@ class WFFlowActionErrorDetailLine extends LogLine {
 }
 
 class WFFieldUpdateLine extends Method {
-  isExit = true;
-  nextLineIsExit = true;
+  override isExit = true;
+  override nextLineIsExit = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["WF_FIELD_UPDATE"], "Workflow", "custom");
     this.text =
@@ -2343,7 +2343,7 @@ class WFFieldUpdateLine extends Method {
 }
 
 class WFRuleEvalBeginLine extends Method {
-  declarative = true;
+  override declarative = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["WF_RULE_EVAL_END"], "Workflow", "custom");
@@ -2359,7 +2359,7 @@ class WFRuleEvalValueLine extends LogLine {
 }
 
 class WFRuleFilterLine extends LogLine {
-  acceptsText = true;
+  override acceptsText = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -2368,7 +2368,7 @@ class WFRuleFilterLine extends LogLine {
 }
 
 class WFCriteriaBeginLine extends Method {
-  declarative = true;
+  override declarative = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(
@@ -2383,9 +2383,9 @@ class WFCriteriaBeginLine extends Method {
 }
 
 class WFFormulaLine extends Method {
-  acceptsText = true;
-  isExit = true;
-  nextLineIsExit = true;
+  override acceptsText = true;
+  override isExit = true;
+  override nextLineIsExit = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["WF_FORMULA"], "Workflow", "custom");
@@ -2415,8 +2415,8 @@ class WFActionTaskLine extends LogLine {
 }
 
 class WFApprovalLine extends Method {
-  isExit = true;
-  nextLineIsExit = true;
+  override isExit = true;
+  override nextLineIsExit = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["WF_APPROVAL"], "Workflow", "custom");
     this.text = `${parts[2]} : ${parts[3]} : ${parts[4]}`;
@@ -2431,8 +2431,8 @@ class WFApprovalRemoveLine extends LogLine {
 }
 
 class WFApprovalSubmitLine extends Method {
-  isExit = true;
-  nextLineIsExit = true;
+  override isExit = true;
+  override nextLineIsExit = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["WF_APPROVAL_SUBMIT"], "Workflow", "custom");
     this.text = `${parts[2]}`;
@@ -2454,8 +2454,8 @@ class WFAssignLine extends LogLine {
 }
 
 class WFEmailAlertLine extends Method {
-  isExit = true;
-  nextLineIsExit = true;
+  override isExit = true;
+  override nextLineIsExit = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["WF_EMAIL_ALERT"], "Workflow", "custom");
     this.text = `${parts[2]} : ${parts[3]} : ${parts[4]}`;
@@ -2463,8 +2463,8 @@ class WFEmailAlertLine extends Method {
 }
 
 class WFEmailSentLine extends Method {
-  isExit = true;
-  nextLineIsExit = true;
+  override isExit = true;
+  override nextLineIsExit = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["WF_EMAIL_SENT"], "Workflow", "custom");
     this.text = `${parts[2]} : ${parts[3]} : ${parts[4]}`;
@@ -2486,8 +2486,8 @@ class WFEscalationActionLine extends LogLine {
 }
 
 class WFEvalEntryCriteriaLine extends Method {
-  isExit = true;
-  nextLineIsExit = true;
+  override isExit = true;
+  override nextLineIsExit = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["WF_EVAL_ENTRY_CRITERIA"], "Workflow", "custom");
     this.text = `${parts[2]} : ${parts[3]} : ${parts[4]}`;
@@ -2503,8 +2503,8 @@ class WFFlowActionDetailLine extends LogLine {
 }
 
 class WFNextApproverLine extends Method {
-  isExit = true;
-  nextLineIsExit = true;
+  override isExit = true;
+  override nextLineIsExit = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["WF_NEXT_APPROVER"], "Workflow", "custom");
     this.text = `${parts[2]} : ${parts[3]} : ${parts[4]}`;
@@ -2519,8 +2519,8 @@ class WFOutboundMsgLine extends LogLine {
 }
 
 class WFProcessFoundLine extends Method {
-  isExit = true;
-  nextLineIsExit = true;
+  override isExit = true;
+  override nextLineIsExit = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["WF_PROCESS_FOUND"], "Workflow", "custom");
     this.text = `${parts[2]} : ${parts[3]}`;
@@ -2528,8 +2528,8 @@ class WFProcessFoundLine extends Method {
 }
 
 class WFProcessNode extends Method {
-  isExit = true;
-  nextLineIsExit = true;
+  override isExit = true;
+  override nextLineIsExit = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["WF_PROCESS_NODE"], "Workflow", "custom");
     this.text = parts[2] || "";
@@ -2558,8 +2558,8 @@ class WFRuleEntryOrderLine extends LogLine {
 }
 
 class WFRuleInvocationLine extends Method {
-  isExit = true;
-  nextLineIsExit = true;
+  override isExit = true;
+  override nextLineIsExit = true;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["WF_RULE_INVOCATION"], "Workflow", "custom");
     this.text = parts[2] || "";
@@ -2588,9 +2588,9 @@ class WFSpoolActionBeginLine extends LogLine {
 }
 
 class ExceptionThrownLine extends LogLine {
-  discontinuity = true;
-  acceptsText = true;
-  totalThrownCount = 1;
+  override discontinuity = true;
+  override acceptsText = true;
+  override totalThrownCount = 1;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
@@ -2598,7 +2598,7 @@ class ExceptionThrownLine extends LogLine {
     this.text = parts[3] || "";
   }
 
-  onAfter(parser: ApexLogParser, _next?: LogLine): void {
+  override onAfter(parser: ApexLogParser, _next?: LogLine): void {
     if (this.text.indexOf("System.LimitException") >= 0) {
       const isMultiLine = this.text.indexOf("\n");
       const len = isMultiLine < 0 ? 99 : isMultiLine;
@@ -2611,16 +2611,16 @@ class ExceptionThrownLine extends LogLine {
 }
 
 class FatalErrorLine extends LogLine {
-  acceptsText = true;
+  override acceptsText = true;
   hideable = false;
-  discontinuity = true;
+  override discontinuity = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
     this.text = parts[2] || "";
   }
 
-  onAfter(parser: ApexLogParser, _next?: LogLine): void {
+  override onAfter(parser: ApexLogParser, _next?: LogLine): void {
     const newLineIndex = this.text.indexOf("\n");
     const summary =
       newLineIndex > -1 ? this.text.slice(0, newLineIndex + 1) : this.text;
@@ -2663,7 +2663,7 @@ class XDSResponseErrorLine extends LogLine {
 
 // e.g. "09:45:31.888 (38889007737)|DUPLICATE_DETECTION_BEGIN"
 class DuplicateDetectionBegin extends Method {
-  declarative = true;
+  override declarative = true;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ["DUPLICATE_DETECTION_END"], "Workflow", "custom");

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import {
 import {
   executeAnonymous,
   executeAnonymousToolConfig,
-  ExecuteAnonymousArgs,
+  type ExecuteAnonymousArgs,
 } from "./tools/executeAnonymous.js";
 
 class ApexLogServer {

--- a/src/salesforce/users.ts
+++ b/src/salesforce/users.ts
@@ -13,7 +13,7 @@ export async function getUserIdByUsername(
     throw new Error(`User not found with username: ${username}`);
   }
 
-  const userId = result.records[0].Id;
+  const userId = result.records[0]?.Id;
   if (!userId) {
     throw new Error("User Id is undefined");
   }

--- a/src/tools/analyzeLogPerformance.ts
+++ b/src/tools/analyzeLogPerformance.ts
@@ -174,7 +174,7 @@ function generatePerformanceSummary(
     return "No methods found matching the criteria.";
   }
 
-  const slowestMethod = methods[0];
+  const slowestMethod = methods[0]!;
   const totalSlowMethodsTime = methods.reduce(
     (sum, method) => sum + method.selfDuration,
     0,

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -12,7 +12,7 @@ import { encode } from "@toon-format/toon";
 import { getUserIdByUsername } from "../salesforce/users.js";
 import {
   getOrCreateDebugLevelId,
-  DebugLevelInput,
+  type DebugLevelInput,
 } from "../salesforce/debugLevels.js";
 import { ensureTraceFlag } from "../salesforce/traceFlags.js";
 import { connect } from "../salesforce/connection.js";

--- a/src/tools/findPerformanceBottlenecks.ts
+++ b/src/tools/findPerformanceBottlenecks.ts
@@ -5,7 +5,7 @@
 import { promises as fs } from "fs";
 import { z } from "zod";
 import { parse, ApexLog } from "../ApexLogParser.js";
-import { SlowMethod, extractMethods } from "./analyzeLogPerformance.js";
+import { type SlowMethod, extractMethods } from "./analyzeLogPerformance.js";
 import { encode } from "@toon-format/toon";
 
 export const findPerformanceBottlenecksInputSchema = {
@@ -179,10 +179,7 @@ function analyzeMethodBottlenecks(apexLog: ApexLog): Record<string, unknown> {
   const methods = extractMethods(apexLog, 0);
   const methodsByNamespace = methods.reduce(
     (acc: Record<string, SlowMethod[]>, method) => {
-      if (!acc[method.namespace]) {
-        acc[method.namespace] = [];
-      }
-      acc[method.namespace].push(method);
+      (acc[method.namespace] ??= []).push(method);
       return acc;
     },
     {},
@@ -190,14 +187,12 @@ function analyzeMethodBottlenecks(apexLog: ApexLog): Record<string, unknown> {
 
   return {
     totalMethods: methods.length,
-    methodsByNamespace: Object.keys(methodsByNamespace).map((ns) => ({
+    methodsByNamespace: Object.entries(methodsByNamespace).map(([ns, group]) => ({
       namespace: ns,
-      methodCount: methodsByNamespace[ns].length,
+      methodCount: group.length,
       totalDuration:
-        methodsByNamespace[ns].reduce(
-          (sum: number, m: SlowMethod) => sum + m.duration,
-          0,
-        ) / NS_TO_MS,
+        group.reduce((sum: number, m: SlowMethod) => sum + m.duration, 0) /
+        NS_TO_MS,
     })),
   };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,33 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "lib": ["ES2022"],
+    "types": ["node"],
     "outDir": "./dist",
     "rootDir": "./src",
+    "sourceMap": false,
+    "declaration": false,
+    "declarationMap": false,
+    "resolveJsonModule": true,
+
     "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "erasableSyntaxOnly": true,
+    "moduleDetection": "force",
+    "noUncheckedSideEffectImports": true,
+    "noEmitOnError": true,
+
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "declaration": false,
-    "declarationMap": false,
-    "sourceMap": true,
-    "resolveJsonModule": true,
-    "moduleResolution": "node",
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]


### PR DESCRIPTION
## Summary

Runs the build on **TypeScript 7.0** (the native Go compiler) while keeping **TypeScript 6** available side-by-side, so `typescript-eslint` and the editor language service keep a working JS compiler API (TS 7 ships none until 7.1). Also hardens `tsconfig.json` to a best-practice, 7-ready configuration.

## Changes

- **TS 7 build via npm aliases:** `typescript7` → `npm:typescript@7` provides the native `tsc` used by `build`/`dev`; the real `typescript` name is aliased to `@typescript/typescript6` (bin `tsc6`) for `typescript-eslint` + the editor. No bin collision (`tsc`=v7, `tsc6`=v6); `typescript-eslint@8.64` is unchanged (its `typescript <6.1.0` peer is met by the aliased v6).
- **tsconfig modernization:** `nodenext` module/resolution and `types: ["node"]` (6.0 defaults `types` to `[]`).
- **Best-practice strictness/module flags:** `noUncheckedIndexedAccess`, `noImplicitOverride`, `verbatimModuleSyntax`, `isolatedModules`, `erasableSyntaxOnly`, `moduleDetection`, `noUncheckedSideEffectImports`, `noEmitOnError`.
- **Source adjusted to satisfy the flags:** `override` modifiers across the `ApexLogParser` `LogLine`/`Method` hierarchy (97 members), type-only imports, and undefined guards.
- **Cleanup:** drop unused `experimentalDecorators`/`emitDecoratorMetadata`; disable `sourceMap` (maps aren't shipped via the package `files` allowlist, so they added no value).

## Test plan

- [x] `pnpm run lint` — clean (typescript-eslint on v6)
- [x] `pnpm run build` — native TS 7, 0 errors, emits `dist/*.js` only
- [x] `pnpm run test` — 165 tests pass (swc/jest)
- [x] `pnpm install --frozen-lockfile` — resolves per-platform TS 7 binaries incl. `linux-x64` (CI on `ubuntu-latest`)

## Reviewer guidance

The diff is large but low-risk: the bulk is the 97 mechanical `override` additions in `src/ApexLogParser.ts` plus the regenerated `pnpm-lock.yaml`. The substantive review surface is **`package.json`** (the alias setup) and **`tsconfig.json`** (the flag changes). No behavioral source changes beyond the small undefined-guards in `analyzeLogPerformance.ts`/`findPerformanceBottlenecks.ts`/`users.ts`.

## Follow-ups (separate PRs)

- Drop the side-by-side and set `typescript` to plain `^7.x` once `typescript-eslint` ships a release allowing TS 7 — a one-line change.
- Bump the Node floor to 22 (Node 20 is EOL), pin `@types/node` to match, and add a CI Node version matrix.