### PR TITLE
build: require node 22, drop end-of-life node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,30 @@ on:
   workflow_dispatch:
 
 jobs:
-  ci:
-    name: ${{ matrix.task }}
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - name: Install Packages
+        run: HUSKY=0 pnpm install --frozen-lockfile
+      - run: pnpm run lint
+
+  build-test:
+    name: ${{ matrix.task }} (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        node: ['22', '24', '26']
+        task: [Build, Test]
         include:
-          - task: Lint
-            command: pnpm run lint
           - task: Build
             command: pnpm run build
           - task: Test
@@ -27,7 +42,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: ${{ matrix.node }}
           cache: 'pnpm'
       - name: Install Packages
         run: HUSKY=0 pnpm install --frozen-lockfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Minimum supported Node.js is now **22**.
+
 ## [1.0.0] - 2026-03-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "typescript7": "npm:typescript@^7.0.2"
   },
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22"
   },
   "packageManager": "pnpm@10.30.2"
 }


### PR DESCRIPTION
## Summary

Raises the minimum supported Node.js to **22** and drops Node 20, which reached end-of-life in April 2026. CI now exercises the supported range instead of a single version, so the advertised floor is actually verified.

## Changes

- Bump `engines.node` to `>=22`. `@types/node` stays `^22` — it already matches the new floor, so type-checking reflects the oldest supported runtime.
- CI: split `Lint` into its own job (Node-independent, runs once) and fan **Build + Test across Node 22, 24, and 26** (min LTS → current release).
- `CHANGELOG.md`: add an `[Unreleased]` entry noting the new minimum.
- `publish.yml` left on Node 22 — a single supported version is sufficient for the publish run.

## Test plan

- [x] `pnpm run build` — 0 errors
- [x] `pnpm run test` — 165 tests pass
- [x] `pnpm run lint` — clean
- [x] `pnpm install --frozen-lockfile` — still valid (the `engines` change doesn't touch the lockfile)

## Notes

Dropping a supported Node major conventionally warrants at least a minor version bump; the `[Unreleased]` changelog entry will roll into whatever version is tagged at release time.