### PR TITLE
ci: add code scanning and dependency review

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm' # reads pnpm-lock.yaml
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    versioning-strategy: auto
+    groups:
+      npm-minor-patch:
+        update-types: ['minor', 'patch']
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      github-actions:
+        patterns: ['*']

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: 'CodeQL'
+
+on:
+  push:
+    branches: [main, release/**]
+    paths-ignore: ['**/*.md', '**/*.txt']
+  pull_request:
+    branches: [main, release/**]
+    paths-ignore: ['**/*.md', '**/*.txt']
+  schedule:
+    - cron: '26 5 * * 3' # weekly
+
+# Cancel superseded PR runs; main/schedule always finish (baseline).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      security-events: write # upload findings
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript-typescript', 'actions']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      # TS analyzed from source; no build needed.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,25 @@
+name: 'Dependency Review'
+
+on:
+  pull_request:
+    branches: [main, release/**]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # post the summary comment on the PR
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v5
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
## Summary

Adds automated security scanning to complement the existing CI. CodeQL analyses run on push/PR to `main` and `release/**`, Dependabot keeps dependencies and workflow actions current, and a dependency-review gate blocks PRs that introduce known-vulnerable dependencies. CodeQL findings surface as inline comments on the affected lines in each PR.

## Changes

- **`codeql.yml`**: CodeQL on push/PR to `main`+`release/**` plus a weekly schedule; analyses `javascript-typescript` and `actions` with the `security-extended` query suite. Per-ref `concurrency` cancels superseded PR runs while letting main/schedule runs finish (baseline integrity).
- **`dependabot.yml`**: weekly update PRs for the `npm` (pnpm) and `github-actions` ecosystems, grouped (npm minor/patch, all actions) to keep PR volume low.
- **`dependency-review.yml`**: runs `dependency-review-action@v5` on PRs, failing on high-severity vulnerable/bad-license dependencies and posting a summary comment on failure.

## Test plan

- [ ] CodeQL workflow completes on this PR (2 matrix legs: `javascript-typescript`, `actions`)
- [ ] Dependency Review check runs on this PR
- [ ] After merge: Dependabot begins producing grouped update PRs

## Notes

To make scanning blocking, add `CodeQL` and `Dependency Review` as required status checks in branch protection. No source code changes — CI/config only.