### PR TITLE
docs(.github): add issue templates, PR template, and security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: 🐛 Bug Report
+description: Found a bug? Report it so we can get it fixed.
+title: '🐛 bug: '
+type: Bug
+labels: ['bug', 'needs-triage']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! Before you start:
+        - Check the [existing issues](https://github.com/certinia/debug-log-analyzer-mcp/issues) first.
+        - Not sure it's a bug, or need setup/config help? Ask in [Q&A discussions](https://github.com/certinia/debug-log-analyzer-mcp/discussions/categories/q-a) instead.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: What went wrong, and what did you expect instead?
+      placeholder: 'e.g. "analyze_apex_log_performance returned an empty methods array for a log that clearly contains method calls. I expected the slow methods to be listed."'
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Ask the agent to run <tool> on <log file>.
+        2. See the incorrect result.
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Version & environment
+      description: '`@certinia/apex-log-mcp` version, plus your MCP client, Node version (`node -v`) and OS.'
+      placeholder: 'e.g. apex-log-mcp 1.0.0, Claude Desktop, Node v22.14.0, macOS 15.5'
+    validations:
+      required: true
+
+  - type: textarea
+    id: io
+    attributes:
+      label: Input & output (if possible)
+      description: The tool call/arguments you made and the response or error you got back. A **redacted** sample debug log helps too (remove usernames, IDs, credentials) — you can drag it in.
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirm
+      options:
+        - label: I searched the existing issues and this hasn't already been reported.
+          required: true

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,14 @@
+name: 🔧 Chore
+description: Tasks that aren't features or bugs (tooling, CI, config, dependencies).
+title: '🔧 chore: '
+type: Task
+labels: ['chore']
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 🔧 Chore description
+      description: What needs to be done?
+      placeholder: 'e.g. "Update ESLint to the latest major version and fix any new lint errors."'
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📖 User Guide / docs
+    url: https://certinia.github.io/debug-log-analyzer/
+    about: Read the docs for how the analyzer and its tools work.
+  - name: 🛠️ Setup & configuration help (Q&A)
+    url: https://github.com/certinia/debug-log-analyzer-mcp/discussions/categories/q-a
+    about: Trouble installing the server, configuring your MCP client, or setting --allowed-orgs? Ask in Q&A.
+  - name: 💡 Discuss an idea
+    url: https://github.com/certinia/debug-log-analyzer-mcp/discussions/categories/ideas
+    about: Suggest or validate a feature idea before opening a feature request.
+  - name: 💬 Browse all discussions
+    url: https://github.com/certinia/debug-log-analyzer-mcp/discussions
+    about: Browse all discussions or start a new one if nothing else fits.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: ✨ Feature Request
+description: Suggest a feature or improvement.
+title: '✨ feat: '
+type: Feature
+labels: ['enhancement', 'needs-triage']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search the [existing issues](https://github.com/certinia/debug-log-analyzer-mcp/issues) first. For early ideas or open questions, an [Ideas discussion](https://github.com/certinia/debug-log-analyzer-mcp/discussions/categories/ideas) is a great place to start.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What would you like to see?
+      description: Describe the feature and the problem or pain point it solves.
+      placeholder: 'e.g. "A tool that diffs two debug logs and reports what changed in CPU time and SOQL usage, so I can see the impact of a code change."'
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution (optional)
+      description: How might this work? Tool inputs/outputs, expected behavior, or rough ideas — anything helps. Include any alternatives you've considered.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirm
+      options:
+        - label: I searched the existing issues and this hasn't already been suggested.
+          required: true

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Don't report vulnerabilities in public issues, discussions, or PRs.** Instead, open a [private security advisory](https://github.com/certinia/debug-log-analyzer-mcp/security/advisories/new).
+
+Include the affected version and steps to reproduce. We'll acknowledge your report and let you know when a fix ships. Fixes target the latest published version of [`@certinia/apex-log-mcp`](https://www.npmjs.com/package/@certinia/apex-log-mcp).
+
+## Good to know
+
+- The server runs locally, makes no network calls of its own, and needs no API keys.
+- `execute_anonymous` runs Apex against real Salesforce orgs. It's disabled unless the `--allowed-orgs` flag is set — treat that allowlist as a security boundary.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## 📝 What & why
+
+_What does this PR do, and why is it needed?_
+
+> Example: "Adds a `debugLevel` parameter to `execute_anonymous` so callers can control trace flag verbosity."
+
+## 🧩 Type of change
+
+- [ ] 🐛 Bug fix
+- [ ] ✨ New feature
+- [ ] ♻️ Refactor
+- [ ] ⚡ Performance
+- [ ] 📝 Docs
+- [ ] 🔧 Chore (tooling, CI, deps)
+- [ ] 💥 Breaking change
+
+## 🔗 Related issues
+
+<!-- e.g. fixes #123, related #456 -->
+
+## 🧪 How was this tested?
+
+- [ ] `pnpm run build`
+- [ ] `pnpm run test`
+- [ ] `pnpm run lint`
+- [ ] Manually tested against an MCP client / debug log
+
+## ✅ Checklist
+
+- [ ] Added or updated tests (or not needed)
+- [ ] Updated docs — README / CHANGELOG (or not needed)


### PR DESCRIPTION
## 📝 What & why

Adds a GitHub community-health set so contributors get guidance instead of a blank issue box, and maintainers get the info needed to triage. Conventions (emoji titles, `type:`/`labels:` frontmatter, Conventional-Commits framing) match the sibling `certinia/debug-log-analyzer` repo, modernised to YAML issue forms. All four issue forms were validated to parse and to satisfy GitHub's issue-form schema (non-empty `checkboxes` labels).

## 🧩 Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance
- [x] 📝 Docs
- [ ] 🔧 Chore (tooling, CI, deps)
- [ ] 💥 Breaking change

## 🛠️ What's included

- **Bug / Feature / Chore issue forms** (`.github/ISSUE_TEMPLATE/*.yml`) — lean forms; the bug form asks what happened, steps, version & environment, and tool input/output, keeping required fields minimal to avoid deterring reporters.
- **`config.yml`** — contact links to the User Guide docs and Discussions, routing setup/config questions to Q&A rather than an issue template.
- **`pull_request_template.md`** — what/why, type of change, related issues, test plan, and a tests/docs checklist.
- **`SECURITY.md`** — directs vulnerability reports to private security advisories, with a note that `execute_anonymous` runs Apex against real orgs.

## 🧪 How was this tested?

- [ ] `pnpm run build`
- [ ] `pnpm run test`
- [ ] `pnpm run lint`
- [x] Docs-only change; issue-form YAML validated to parse and against GitHub's schema. Forms render on GitHub after merge.