### PR TITLE
ci: update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -37,10 +37,10 @@ jobs:
           - task: Test
             command: pnpm run test
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write # post the summary comment on the PR
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: "pnpm"


### PR DESCRIPTION
## 📝 What & why

Bumps all GitHub Actions used across the workflows to their latest stable major versions, keeping CI on supported action runtimes (the older majors pin the deprecated Node 20 runner). Aligns the workflows with `codeql.yml`, which already uses `actions/checkout@v7`.

- `actions/checkout` v4 → v7 (ci, publish, dependency-review)
- `actions/setup-node` v4 → v7 (ci, publish)
- `pnpm/action-setup` v4 → v6 (ci, publish)

No breaking changes affect this repo: `setup-node` caching stays explicit (`cache: 'pnpm'`) and the pnpm version is read from the `packageManager` field, so behaviour is unchanged. `dependency-review-action@v5` and `codeql-action@v4` were already on their latest majors and are untouched.

## 🧩 Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance
- [ ] 📝 Docs
- [x] 🔧 Chore (tooling, CI, deps)
- [ ] 💥 Breaking change

## 🔗 Related issues

_None._

## 🧪 How was this tested?

- [ ] `pnpm run build`
- [ ] `pnpm run test`
- [ ] `pnpm run lint`
- [ ] Manually tested against an MCP client / debug log

YAML validated locally; the CI, dependency-review, and CodeQL workflows exercise the updated actions on this PR.

## ✅ Checklist

- [ ] Added or updated tests (or not needed)
- [ ] Updated docs — README / CHANGELOG (or not needed)