### PR TITLE
perf(tools): cut redundant data from tool responses without losing facts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,20 @@ jobs:
       - name: Install Packages
         run: HUSKY=0 pnpm install --frozen-lockfile
       - run: ${{ matrix.command }}
+
+  eval:
+    name: Eval (tool responses)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - name: Install Packages
+        run: HUSKY=0 pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - name: Check tool responses stay answerable and lean
+        run: pnpm run eval

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@ node_modules
 dist
 coverage
 
-# Ignore test logs
+# Ignore test logs, except the committed eval fixtures
 *.log
+!tests/eval/fixtures/*.log
 
 # Environment files
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Tool responses are smaller, with no loss of fact.** Every field a response used to carry is still there — the saving comes from shape, from not saying the same thing twice, and from not emitting digits nobody reads. Measured on a real 19 MB log: `get_apex_log_summary` ~305 → ~233 tokens, `analyze_apex_log_performance` ~420 → ~294, `find_performance_bottlenecks` ~93 → ~87 (~25% across the three).
+  - `get_apex_log_summary` returns `governorLimits` as a flat table of `{name, used, limit}` rows instead of thirteen nested objects. All thirteen limits are still listed, including those at zero — "no DML statements ran" has to be answerable from the response.
+  - Durations are rounded to 3 decimal places (ms) and percentages to 1, instead of emitting full float precision.
+  - Zero counts, empty tables and every fixed field are still reported. Only lists of things that happened — `logIssues`, `recommendations` — are omitted, and only when nothing happened.
+- **`analyze_apex_log_performance` no longer returns `summary`.** The prose paragraph restated figures already present in `slowestMethods`. Its one unique fact — what share of the run the returned methods account for — is now the scalar `topMethodsSelfPercentage`. `recommendations` is kept, reworded to say what to do without repeating the numbers, and is omitted when nothing stands out; it no longer claims performance looks good on a log that blew the CPU limit.
+- **`get_apex_log_summary` no longer returns `file`.** The caller supplied the path.
+- **`find_performance_bottlenecks` no longer reports a governor limit twice.** SOQL query, DML statement and query row limits detailed by `databaseBottlenecks` are excluded from `governorLimitWarnings`, as CPU time already was.
+- **`execute_anonymous` only includes the `.gitignore` tip when it just created the output directory**, rather than on every call.
+
+### Added
+
+- **`pnpm run eval`** — an evaluation suite that drives the built server over stdio against committed log fixtures and asserts, per tool, that realistic user questions are still answerable, that no figure is reported twice, that the payload is under a token budget, and that it matches its golden file. It runs in CI, and is the gate for any change to a response shape. See [`tests/eval/README.md`](tests/eval/README.md).
+
 ## [2.0.0] - 2026-07-28
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ pnpm start
   - Uses stdio transport for communication
   - Handles file validation, log parsing, analysis, and anonymous Apex execution
 
+- **src/tools/responseShaping.ts**: Shared helpers for keeping responses lean — `omitEmpty`, `pruneColumns`, `roundMs`, `roundPercent`
+
 - **src/ApexLogParser.ts**: Complex log parsing engine (33k+ tokens)
   - Exports `parse()` function and `ApexLogParser` class
   - Handles Apex debug log format parsing into structured data
@@ -83,6 +85,16 @@ The server provides four main capabilities:
 4. **Execute Anonymous**: Executes anonymous Apex code snippets, saves the debug log to a file, and returns a summary with the file path
 
 Log analysis tools (1-3) accept absolute file paths to `.log` files and return structured JSON for AI processing.
+
+## Response Shaping
+
+Responses are TOON-encoded and deliberately lean, but the saving comes from shape, never from dropping a fact — see the conventions in [DEVELOPING.md](DEVELOPING.md#️-shaping-tool-responses) and the helpers in `src/tools/responseShaping.ts`. In short: restructure before you delete (flatten nested objects into TOON tables — `toLimitRows` is the worked example, 45% cheaper than the nested form and still complete); always report a fixed-schema field even at zero, because an absent count cannot be told apart from one that was never parsed; use `omitEmpty` **only** for occurrence lists, where absence unambiguously means nothing happened; never report the same figure twice; never echo the caller's input back; round durations and percentages (`roundMs`/`roundPercent`); and keep every row of a table on the same key set so TOON keeps its one-header-plus-one-line-per-row form.
+
+Concretely: `analyze_apex_log_performance` returns no prose `summary` — its one unique fact is the scalar `topMethodsSelfPercentage` — and omits `recommendations` only when nothing stands out; `get_apex_log_summary` returns no `file`, all thirteen governor limits as `{name, used, limit}` rows, the full `debugLevels` list, and omits only `logIssues`; `find_performance_bottlenecks` excludes from `governorLimitWarnings` any limit already detailed by a dedicated section; `execute_anonymous` emits the `.gitignore` tip only when it created the output directory.
+
+`pnpm run eval` (`scripts/eval.mjs`, wired into CI) is the gate for response-shape changes: it drives the built server over stdio against `tests/eval/fixtures/` and checks answerability, no duplication, a token budget and golden files. The jest suite cannot do this — `moduleNameMapper` swaps `@toon-format/toon` for a JSON stand-in, so it never sees the real encoding. Re-record goldens with `pnpm run build && pnpm run eval:update` and read the diff.
+
+`outputSchema`/`structuredContent` are deliberately not implemented — the MCP spec asks for the payload to also be serialized into a text block, which would send it twice. Tracked separately.
 Anonymous execution (4) accepts multi-line strings containing Apex, saves the resulting debug log to a local file (default: `.apex-log-mcp/` in the project root), and returns a summary with the file path. The `outputDir` parameter overrides the default save location. It supports an optional `debugLevel` parameter to configure trace flag log levels per category or set all categories at once. The response includes the org alias alongside the username when available, plus the detected org type.
 
 `execute_anonymous` is **always registered** so agents can discover it; authorization happens per call in `src/policy/orgExecutionPolicy.ts`. `src/salesforce/orgClassification.ts` identifies the target org (`sandbox`, `scratch`, `trial`, `developer`, `production`, or `unknown` when it cannot be queried), caching one `Organization` query per org id for the server's lifetime. Non-production orgs run silently. Production and `unknown` orgs need either the `--allow-production-orgs` flag or a per-call user confirmation via MCP elicitation; without either, the call is refused with an `isError` result whose text explains both routes. Authorization runs before any `DebugLevel` or `TraceFlag` record is created, so refused calls leave the org untouched. `--no-apex-execution` refuses every call before contacting Salesforce and marks the tool `[DISABLED on this server]` in its description. The 1.x `--allowed-orgs` flag is accepted but ignored, with a stderr deprecation warning.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -12,6 +12,8 @@ Welcome to the development guide for the **Apex Log MCP Server**. This document 
 2. [Setting Up the Development Environment](#-setting-up-the-development-environment)
 3. [Building](#-building)
 4. [Running the Server Locally](#-running-the-server-locally)
+5. [Shaping Tool Responses](#️-shaping-tool-responses)
+6. [Testing Your Changes](#-testing-your-changes)
 
 ## 🔧 Prerequisites
 
@@ -105,6 +107,68 @@ Once you’ve built the server or run the watcher, you can run the MCP server fo
 
    To disable Apex execution altogether, use `--no-apex-execution`. See the [README](README.md#production-safety) for the full policy.
 
+## ✂️ Shaping Tool Responses
+
+Every token a tool returns is a token the agent cannot spend on reasoning, so responses are kept as
+small as they can be — but the saving has to come from *shape*, never from dropping a fact. If a user
+asks "how many DML statements did this transaction consume?", the agent has to be able to answer from
+the payload alone.
+
+### Restructure before you delete
+
+Flattening a nested object into a TOON table is almost always a bigger win than deleting rows from
+it, and it costs nothing. Measured on the 13 governor limits of a real 19 MB log:
+
+| `governorLimits`, 13 entries | tokens | can answer "0 DML statements"? |
+| --- | --- | --- |
+| Nested objects, all 13 | ~151 | yes |
+| Nested objects, `used > 0` only | ~42 | **no** |
+| **Flat table (`{name, used, limit}`), all 13** | **~84** | yes |
+
+The flat table is 45% cheaper than the nested form *and* complete. Deleting the zero rows buys 42
+more tokens and costs the answer, so we don't. `toLimitRows` is the helper that does this.
+
+### The conventions
+
+The helpers in [`src/tools/responseShaping.ts`](src/tools/responseShaping.ts) exist to make these
+one-liners.
+
+- **A fixed-schema field is always reported, even at zero.** The set of governor limits, debug
+  categories and method columns is fixed and known, so a zero is a fact and an absent key is an
+  ambiguity — the reader cannot tell "nothing ran" from "never parsed". Report the zero.
+- **Only occurrence lists are omitted when empty** — issues found, recommendations made, errors
+  encountered. There, absence is unambiguous: nothing occurred. `omitEmpty` is for these and nothing
+  else; never pass a fixed-schema scalar through it. (`false` is *not* empty — it is an answer.)
+- **Say it once.** Never restate in prose a figure that is already in a table, and never report a
+  value in two sections. Recommendations say what to *do*; the numbers stay in the data. Where prose
+  carried a fact the table could not, replace it with a scalar rather than deleting it —
+  `topMethodsSelfPercentage` is ~8 tokens where the paragraph it replaced was ~55.
+- **Don't echo the input back.** If the caller supplied it (a file path, a flag), it does not belong
+  in the response.
+- **Round to the precision someone acts on.** `roundMs` for durations (3dp, keeps microsecond
+  resolution) and `roundPercent` for percentages (1dp). Raw float division produces things like
+  `62.569866677679975`, and every one of those digits is a token nobody reads.
+- **Keep table rows identical in shape.** TOON emits one header plus one line per row only while the
+  rows agree on their keys, so a column is either present on every row or on none.
+- **Make conditional information conditional.** A static tip that is only relevant sometimes should
+  be emitted only then.
+- **Say in the tool description what is omitted and when.** Currently that is one sentence per tool,
+  because there is one omission per tool.
+
+### The gate
+
+Output changes are checked by [`pnpm run eval`](tests/eval/README.md), which drives the built server
+over stdio against committed fixtures and asserts four things per (tool, fixture): that realistic
+user questions are still answerable, that no figure appears twice, that the payload is under a token
+budget, and that it matches its golden file. Run it — and `pnpm run eval:update` to re-record the
+goldens — for any change to a response shape; the golden diff *is* the review of the change.
+
+The unit tests cannot substitute for it: jest maps `@toon-format/toon` to a JSON stand-in, so it
+never sees the real encoding.
+
+If you change a tool's output shape, update the [CHANGELOG](CHANGELOG.md) and the tool's entry in the
+[README](README.md#tools-reference) — the output contract is part of the public API.
+
 ## 🧪 Testing Your Changes
 
 Make sure your changes don’t break anything. If you’re working on a feature or bug fix that requires tests, be sure to add or update the relevant tests.
@@ -117,5 +181,11 @@ pnpm test
 ```
 
 or run the tests from the test explorer in VScode
+
+If you changed anything a tool returns, also run the evaluation suite against the built server:
+
+```zsh
+pnpm run build && pnpm run eval
+```
 
 Ensure all tests pass before submitting your pull request.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Ask your AI assistant to work with Apex debug logs using natural language:
 
 ## Tools Reference
 
+All tools return [TOON](https://github.com/toon-format/toon)-encoded data, kept deliberately lean to save tokens — without dropping anything you might need to ask about:
+
+- **Every governor limit, debug category and method column is returned**, including the ones at zero. "How many DML statements did this consume?" is answerable from the response, and `0` means none rather than not measured.
+- **The leanness comes from shape.** Data that used to be nested objects is returned as flat tables, which TOON encodes as one header plus one line per row.
+- **Nothing is reported twice.** No prose summary restates the numbers in the table alongside it, and a governor limit detailed in its own section is not repeated in the generic warnings.
+- **Durations are rounded** to 3 decimal places (ms) and percentages to 1.
+- **Only lists of things that happened are omitted when empty** — log issues, recommendations. Nothing to report means the key is absent.
+
 ### analyze_apex_log_performance
 
 Rank methods in an Apex debug log by self-execution time. Returns method names, durations (in ms), SOQL/DML counts, and optimization recommendations. Best for finding which specific methods to optimize.
@@ -71,7 +79,9 @@ Rank methods in an Apex debug log by self-execution time. Returns method names, 
 
 ### get_apex_log_summary
 
-Get a high-level summary of an Apex debug log including total execution time (in ms), method count, SOQL/DML totals, governor limits, and active namespaces. Best for a quick overview before deeper analysis.
+Get a high-level summary of an Apex debug log including total execution time (in ms), method count, SOQL/DML totals, governor limits, debug levels and active namespaces. Best for a quick overview before deeper analysis.
+
+All thirteen governor limits are listed as `{name, used, limit}` rows, at zero included, so you can ask what a transaction consumed and get an answer either way. `debugLevels` names every log category and its level, which is what tells you whether a missing detail was absent from the run or simply never logged.
 
 | Parameter     | Type   | Required | Description                                     |
 | ------------- | ------ | -------- | ----------------------------------------------- |
@@ -210,6 +220,7 @@ This server implements the [Model Context Protocol (MCP)](https://modelcontextpr
 - **Runs as a local process** — your AI client spawns the server and communicates locally. No network requests, no API keys.
 - **Uses the same parser as the [Apex Log Analyzer VS Code extension](https://github.com/certinia/debug-log-analyzer)** — battle-tested parsing of the Apex debug log format.
 - **Returns structured data** — all durations in milliseconds, governor limits as used/limit pairs, methods with SOQL/DML counts — so your AI assistant can reason about the results.
+- **Keeps responses lean** — TOON encoding, no duplicated figures, and zero/empty fields omitted, so more of the context window is left for reasoning.
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
+    "eval": "node scripts/eval.mjs",
+    "eval:update": "node scripts/eval.mjs --update",
     "lint": "eslint ./src ./tests"
   },
   "keywords": [

--- a/scripts/eval.mjs
+++ b/scripts/eval.mjs
@@ -1,0 +1,416 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * Response-quality evaluation for the log analysis tools.
+ *
+ * Drives the *built* server over real stdio, so what is asserted is the bytes an
+ * agent actually receives — TOON encoding included. The jest suite cannot do
+ * this: it maps `@toon-format/toon` to a JSON stand-in, so it verifies field
+ * shape and nothing about the payload.
+ *
+ * Four things are checked for every (tool, fixture) pair:
+ *
+ * 1. Answerability — a realistic user question is only answerable if the fields
+ *    it needs are present. Shrinking a response must not cost an answer.
+ * 2. No duplication — a figure reported once costs once. No top-level scalar may
+ *    be restated in prose, and no unexpected top-level key may appear.
+ * 3. Token budget — a per-case ceiling, so bloat fails instead of creeping.
+ * 4. Golden files — the exact payload, committed, so any shape change is a diff
+ *    a reviewer can read.
+ *
+ * Usage:
+ *   node scripts/eval.mjs            # assert
+ *   node scripts/eval.mjs --update   # rewrite the golden files
+ *   node scripts/eval.mjs --report <log>   # token report for one log, no assertions
+ */
+
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SERVER = path.join(ROOT, "dist", "index.js");
+const FIXTURES = path.join(ROOT, "tests", "eval", "fixtures");
+const GOLDEN = path.join(ROOT, "tests", "eval", "golden");
+
+/**
+ * Questions a user actually asks, and the fields without which the tool cannot
+ * answer them.
+ */
+const ANSWERABILITY = {
+  get_apex_log_summary: [
+    {
+      question: "How many DML statements and SOQL queries were consumed?",
+      fields: ["totalDMLOperations", "totalSOQLQueries"],
+      limits: ["dmlStatements", "soqlQueries"],
+    },
+    {
+      question: "Are we close to any governor limit?",
+      limits: ["cpuTime", "heapSize", "queryRows", "dmlRows"],
+    },
+    {
+      question: "How long did the transaction take, and how much code ran?",
+      fields: ["totalExecutionTime", "totalMethods", "size"],
+    },
+    {
+      question: "Is detail missing because a log category was switched off?",
+      keys: ["debugLevels"],
+    },
+    { question: "Did the log parse cleanly?", fields: ["parsingErrors"] },
+    { question: "Which namespaces ran?", keys: ["namespaces"] },
+  ],
+  analyze_apex_log_performance: [
+    { question: "Which methods are the slowest?", keys: ["slowestMethods"] },
+    {
+      question: "What share of the runtime do those methods account for?",
+      fields: ["topMethodsSelfPercentage", "totalExecutionTime"],
+    },
+    { question: "How many methods were considered?", fields: ["totalMethods"] },
+    {
+      question: "Did any of the slowest methods touch the database?",
+      columns: ["dmlCount", "soqlCount", "dmlRows", "soqlRows"],
+    },
+    {
+      question: "Where in the code are they, and whose namespace are they in?",
+      columns: ["namespace", "lineNumber"],
+    },
+  ],
+  find_performance_bottlenecks: [
+    {
+      question: "Is anything over or near a limit, and what should I look at?",
+      anyKey: [
+        "cpuBottlenecks",
+        "databaseBottlenecks",
+        "methodBottlenecks",
+        "governorLimitWarnings",
+        "note",
+      ],
+    },
+  ],
+};
+
+/**
+ * On `minimal.log` nothing happened, so these must be reported *as zero* rather
+ * than left out. "How many DML statements ran?" has to be answerable with "none",
+ * and an absent field cannot say that — it cannot be told apart from a log the
+ * parser never got a limit block for.
+ */
+const MINIMAL_ZEROS = {
+  get_apex_log_summary: {
+    fields: [
+      "totalSOQLQueries",
+      "totalDMLOperations",
+      "totalSOQLRows",
+      "totalDMLRows",
+      "parsingErrors",
+    ],
+    limits: [
+      "soqlQueries",
+      "soslQueries",
+      "queryRows",
+      "dmlStatements",
+      "publishImmediateDml",
+      "dmlRows",
+      "cpuTime",
+      "heapSize",
+      "callouts",
+      "emailInvocations",
+      "futureCalls",
+      "queueableJobsAddedToQueue",
+      "mobileApexPushCalls",
+    ],
+  },
+};
+
+/** chars/4 ceilings. Generous enough not to be noise, tight enough to catch bloat. */
+const TOKEN_BUDGET = {
+  "get_apex_log_summary/governor-heavy": 300,
+  "get_apex_log_summary/minimal": 240,
+  "analyze_apex_log_performance/governor-heavy": 360,
+  "analyze_apex_log_performance/minimal": 200,
+  "find_performance_bottlenecks/governor-heavy": 160,
+  "find_performance_bottlenecks/minimal": 80,
+};
+
+const CASES = [
+  "get_apex_log_summary",
+  "analyze_apex_log_performance",
+  "find_performance_bottlenecks",
+].flatMap((tool) =>
+  ["governor-heavy", "minimal"].map((fixture) => ({ tool, fixture })),
+);
+
+/** Minimal MCP stdio client: initialize, then one tools/call per case. */
+function createClient() {
+  const child = spawn("node", ["--max-old-space-size=8192", SERVER], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const pending = new Map();
+  let buffer = "";
+  let nextId = 1;
+
+  child.stdout.on("data", (chunk) => {
+    buffer += chunk.toString();
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const resolve = pending.get(message.id);
+      if (resolve) {
+        pending.delete(message.id);
+        resolve(message);
+      }
+    }
+  });
+
+  const request = (method, params) =>
+    new Promise((resolve) => {
+      const id = nextId++;
+      pending.set(id, resolve);
+      child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+    });
+
+  return {
+    async start() {
+      await request("initialize", {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "apex-log-mcp-eval", version: "0" },
+      });
+      child.stdin.write(
+        `${JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" })}\n`,
+      );
+    },
+    async callTool(name, args) {
+      const response = await request("tools/call", { name, arguments: args });
+      const text = response.result?.content?.[0]?.text;
+      if (typeof text !== "string") {
+        throw new Error(`${name}: no text content in ${JSON.stringify(response)}`);
+      }
+      return text;
+    },
+    stop() {
+      child.kill();
+    },
+  };
+}
+
+/**
+ * Read the payload's top-level scalars, table headers and keys out of its TOON
+ * text. Deliberately shallow — enough to assert what is present and what is
+ * repeated, without reimplementing the decoder.
+ */
+function inspect(toon) {
+  const scalars = new Map();
+  const keys = [];
+  const columns = new Set();
+  const rows = new Map();
+  const strings = [];
+
+  for (const line of toon.split("\n")) {
+    if (!line.trim()) continue;
+    const topLevel = /^([A-Za-z][\w]*)(\[\d+\])?(\{([^}]*)\})?:\s*(.*)$/.exec(line);
+    if (topLevel) {
+      const [, key, , , header, value] = topLevel;
+      keys.push(key);
+      if (header) {
+        header.split(",").forEach((column) => columns.add(column.trim()));
+      } else if (value !== "" && !line.endsWith(":")) {
+        const numeric = Number(value);
+        if (Number.isFinite(numeric) && /^-?[\d.]+$/.test(value)) {
+          scalars.set(key, numeric);
+        } else {
+          // Prose at the top level — a `note`, a `recommendations` list, or a
+          // reintroduced `summary`. Scanned for restated figures below.
+          strings.push(value);
+        }
+      }
+      continue;
+    }
+    const indented = line.trim();
+    const cells = indented.split(",");
+    rows.set(cells[0], cells);
+    strings.push(indented);
+  }
+
+  return { scalars, keys, columns, rows, strings };
+}
+
+function checkAnswerability({ tool, fixture }, toon, failures) {
+  const { scalars, keys, columns, rows } = inspect(toon);
+
+  for (const check of ANSWERABILITY[tool]) {
+    const missing = [];
+    for (const field of check.fields ?? []) {
+      if (!scalars.has(field)) missing.push(field);
+    }
+    for (const key of check.keys ?? []) {
+      if (!keys.includes(key)) missing.push(key);
+    }
+    for (const column of check.columns ?? []) {
+      if (!columns.has(column)) missing.push(column);
+    }
+    for (const limit of check.limits ?? []) {
+      if (!rows.has(limit)) missing.push(`governorLimits.${limit}`);
+    }
+    if (check.anyKey && !check.anyKey.some((key) => keys.includes(key))) {
+      missing.push(`one of ${check.anyKey.join(", ")}`);
+    }
+    if (missing.length) {
+      failures.push(
+        `${tool}/${fixture}: cannot answer "${check.question}" — missing ${missing.join(", ")}`,
+      );
+    }
+  }
+
+  if (fixture !== "minimal") {
+    return;
+  }
+  const expectZero = MINIMAL_ZEROS[tool];
+  if (!expectZero) {
+    return;
+  }
+  for (const field of expectZero.fields ?? []) {
+    if (scalars.get(field) !== 0) {
+      failures.push(
+        `${tool}/${fixture}: ${field} should be reported as 0, got ${scalars.get(field) ?? "nothing"}`,
+      );
+    }
+  }
+  for (const limit of expectZero.limits ?? []) {
+    const used = rows.get(limit)?.[1];
+    if (used !== "0") {
+      failures.push(
+        `${tool}/${fixture}: governorLimits.${limit} should be reported with used 0, got ${used ?? "no row"}`,
+      );
+    }
+  }
+}
+
+function checkNoDuplication({ tool, fixture }, toon, failures) {
+  const { scalars, keys, strings } = inspect(toon);
+
+  const duplicateKeys = keys.filter((key, index) => keys.indexOf(key) !== index);
+  if (duplicateKeys.length) {
+    failures.push(`${tool}/${fixture}: key reported twice — ${duplicateKeys.join(", ")}`);
+  }
+
+  // A prose line must not restate a figure that is already a field of its own.
+  // This is what the deleted `summary` paragraph did, and what a well-meaning
+  // future one would do again.
+  for (const [key, value] of scalars) {
+    if (value === 0 || value === 1) continue;
+    const rendered = String(value);
+    const restated = strings.filter(
+      (line) => /[A-Za-z]{4}\s/.test(line) && line.includes(rendered),
+    );
+    if (restated.length) {
+      failures.push(
+        `${tool}/${fixture}: ${key} (${rendered}) is restated in prose — ${restated[0]}`,
+      );
+    }
+  }
+}
+
+function checkTokenBudget({ tool, fixture }, toon, failures) {
+  const budget = TOKEN_BUDGET[`${tool}/${fixture}`];
+  const tokens = Math.round(toon.length / 4);
+  if (budget === undefined) {
+    failures.push(`${tool}/${fixture}: no token budget declared`);
+  } else if (tokens > budget) {
+    failures.push(`${tool}/${fixture}: ~${tokens} tokens exceeds budget of ${budget}`);
+  }
+  return tokens;
+}
+
+async function checkGolden({ tool, fixture }, toon, failures, update) {
+  const file = path.join(GOLDEN, `${tool}.${fixture}.expected.txt`);
+  if (update) {
+    await fs.mkdir(GOLDEN, { recursive: true });
+    await fs.writeFile(file, `${toon}\n`, "utf-8");
+    return;
+  }
+  let expected;
+  try {
+    expected = await fs.readFile(file, "utf-8");
+  } catch {
+    failures.push(
+      `${tool}/${fixture}: no golden file — run \`pnpm run eval:update\` and review the diff`,
+    );
+    return;
+  }
+  if (expected.trimEnd() !== toon.trimEnd()) {
+    failures.push(
+      `${tool}/${fixture}: output differs from ${path.relative(ROOT, file)}. If the change is intended, run \`pnpm run eval:update\`.`,
+    );
+  }
+}
+
+async function report(logFile) {
+  const client = createClient();
+  await client.start();
+  try {
+    for (const tool of Object.keys(ANSWERABILITY)) {
+      const toon = await client.callTool(tool, { logFilePath: logFile });
+      console.log(
+        `${tool}: ${toon.length} chars, ~${Math.round(toon.length / 4)} tokens`,
+      );
+      console.log(toon.replace(/^/gm, "  "));
+    }
+  } finally {
+    client.stop();
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const reportIndex = args.indexOf("--report");
+  if (reportIndex !== -1) {
+    const logFile = args[reportIndex + 1];
+    if (!logFile) {
+      throw new Error("--report needs a path to a log file");
+    }
+    await report(path.resolve(logFile));
+    return;
+  }
+
+  const update = args.includes("--update");
+  const failures = [];
+  const client = createClient();
+  await client.start();
+
+  try {
+    for (const testCase of CASES) {
+      const logFilePath = path.join(FIXTURES, `${testCase.fixture}.log`);
+      const toon = await client.callTool(testCase.tool, { logFilePath });
+      checkAnswerability(testCase, toon, failures);
+      checkNoDuplication(testCase, toon, failures);
+      const tokens = checkTokenBudget(testCase, toon, failures);
+      await checkGolden(testCase, toon, failures, update);
+      console.log(
+        `${update ? "updated" : "checked"} ${testCase.tool}/${testCase.fixture} — ~${tokens} tokens`,
+      );
+    }
+  } finally {
+    client.stop();
+  }
+
+  if (failures.length) {
+    console.error(`\n${failures.length} eval failure(s):`);
+    failures.forEach((failure) => console.error(`  ✗ ${failure}`));
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`\n${CASES.length} eval case(s) passed.`);
+}
+
+await main();

--- a/src/tools/analyzeLogPerformance.ts
+++ b/src/tools/analyzeLogPerformance.ts
@@ -6,6 +6,7 @@ import { promises as fs } from "fs";
 import { z } from "zod";
 import { parse, ApexLog, LogLine } from "../ApexLogParser.js";
 import { encode } from "@toon-format/toon";
+import { omitEmpty, roundMs, roundPercent } from "./responseShaping.js";
 
 export const analyzeLogPerformanceInputSchema = {
   logFilePath: z
@@ -31,7 +32,7 @@ export type AnalyzeLogArgs = z.infer<
 export const analyzeLogPerformanceToolConfig = {
   title: "Analyze Apex Log Performance",
   description:
-    "Rank methods in an Apex debug log by self-execution time. Returns method names, durations (in ms), SOQL/DML counts, and optimization recommendations. Best for finding which specific methods to optimize.",
+    "Rank methods in an Apex debug log by self-execution time. Returns method names, durations (in ms), SOQL/DML counts, the share of total runtime the ranked methods account for, and optimization recommendations. Best for finding which specific methods to optimize. Every method row carries the full column set; only `recommendations` is omitted, and only when nothing stood out.",
   inputSchema: analyzeLogPerformanceInputSchema,
   annotations: {
     title: "Analyze Apex Log Performance",
@@ -61,9 +62,16 @@ export interface SlowMethod {
 export interface LogAnalysisResult {
   totalMethods: number;
   totalExecutionTime: number;
+  /**
+   * Share of total execution time the returned methods account for between them.
+   * A low figure says the cost is spread across the rest of the transaction
+   * rather than concentrated in these methods — the one thing the table itself
+   * does not say.
+   */
+  topMethodsSelfPercentage: number;
   slowestMethods: SlowMethod[];
-  summary: string;
-  recommendations: string[];
+  /** Omitted when nothing stands out; an empty list says the same thing. */
+  recommendations?: string[];
 }
 
 const NS_TO_MS = 1_000_000;
@@ -96,19 +104,35 @@ export async function analyzeLogPerformance(args: AnalyzeLogArgs) {
 
   const msMethods = slowestMethods.map((m) => ({
     ...m,
-    duration: m.duration / NS_TO_MS,
-    selfDuration: m.selfDuration / NS_TO_MS,
+    duration: roundMs(m.duration / NS_TO_MS),
+    selfDuration: roundMs(m.selfDuration / NS_TO_MS),
+    selfPercentage: roundPercent(m.selfPercentage),
   }));
 
+  // The column set is fixed so that every call returns the same shape, and so
+  // that a zero SOQL count reads as "none" rather than "not measured".
   const result: LogAnalysisResult = {
     totalMethods: methods.length,
-    totalExecutionTime: apexLog.duration.total / NS_TO_MS,
-    slowestMethods: msMethods,
-    summary: generatePerformanceSummary(
-      msMethods,
-      apexLog.duration.total / NS_TO_MS,
+    totalExecutionTime: roundMs(apexLog.duration.total / NS_TO_MS),
+    topMethodsSelfPercentage: roundPercent(
+      slowestMethods.reduce((total, m) => total + m.selfPercentage, 0),
     ),
-    recommendations: generateRecommendations(msMethods),
+    slowestMethods: msMethods.map((m) => ({
+      name: m.name,
+      duration: m.duration,
+      selfDuration: m.selfDuration,
+      selfPercentage: m.selfPercentage,
+      namespace: m.namespace,
+      lineNumber: m.lineNumber,
+      dmlCount: m.dmlCount,
+      soqlCount: m.soqlCount,
+      dmlRows: m.dmlRows,
+      soqlRows: m.soqlRows,
+      thrownCount: m.thrownCount,
+      soslCount: m.soslCount,
+      soslRows: m.soslRows,
+    })),
+    ...omitEmpty({ recommendations: generateRecommendations(msMethods) }),
   };
 
   return {
@@ -166,61 +190,35 @@ export function extractMethods(
   return methods;
 }
 
-function generatePerformanceSummary(
-  methods: SlowMethod[],
-  totalTimeMs: number,
-): string {
-  if (methods.length === 0) {
-    return "No methods found matching the criteria.";
-  }
-
-  const slowestMethod = methods[0]!;
-  const totalSlowMethodsTime = methods.reduce(
-    (sum, method) => sum + method.selfDuration,
-    0,
-  );
-  const percentageOfTotal =
-    totalTimeMs > 0 ? (totalSlowMethodsTime / totalTimeMs) * 100 : 0;
-
-  return `Analysis found ${methods.length} methods. The slowest method "${slowestMethod.name}" took ${slowestMethod.selfDuration.toFixed(2)}ms (${slowestMethod.selfPercentage.toFixed(1)}% of total execution time). The top ${methods.length} methods account for ${percentageOfTotal.toFixed(1)}% of total execution time.`;
-}
-
+/**
+ * Advice for the worst few methods, in the form the caller cannot derive from the
+ * table: which lever to pull. The figure that triggered each one is already a
+ * column on the method's row, so it is not repeated here.
+ *
+ * An empty list means nothing stood out, which is what omitting the field says.
+ */
 function generateRecommendations(methods: SlowMethod[]): string[] {
-  const recommendations: string[] = [];
-
-  for (const method of methods.slice(0, 3)) {
-    const recommendation = getRecommendation(method);
-    if (recommendation) {
-      recommendations.push(recommendation);
-    }
-  }
-
-  if (recommendations.length === 0) {
-    recommendations.push(
-      "Performance looks good! No obvious bottlenecks detected in the analyzed methods.",
-    );
-  }
-
-  return recommendations;
+  return methods
+    .slice(0, 3)
+    .map(getRecommendation)
+    .filter((recommendation): recommendation is string => recommendation !== null);
 }
 
 function getRecommendation(method: SlowMethod): string | null {
   if (method.selfPercentage > 10 && method.selfDuration > 0.1) {
-    return `Method "${method.name}" consumes ${method.selfPercentage.toFixed(
-      1,
-    )}% self execution time. Consider if it can be optimized to make it faster, check how many times it is called and if that can be reduced.`;
+    return `${method.name}: dominates self time. Check whether it can be made faster, and how often it is called.`;
   }
   if (method.soqlRows > 1000) {
-    return `Method "${method.name}" processes ${method.soqlRows} SOQL rows. Consider adding WHERE clauses or using pagination.`;
+    return `${method.name}: high SOQL row count. Add WHERE clauses or paginate.`;
   }
   if (method.soqlCount > 5) {
-    return `Method "${method.name}" executes ${method.soqlCount} SOQL queries. Consider reducing query count through bulkification or caching.`;
+    return `${method.name}: many SOQL queries. Bulkify or cache.`;
   }
   if (method.dmlCount > 3) {
-    return `Method "${method.name}" performs ${method.dmlCount} DML operations. Consider bulkifying DML operations.`;
+    return `${method.name}: many DML operations. Bulkify them.`;
   }
   if (method.soslCount > 3) {
-    return `Method "${method.name}" executes ${method.soslCount} SOSL searches. Consider reducing search count or caching results.`;
+    return `${method.name}: many SOSL searches. Reduce or cache them.`;
   }
 
   return null;

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -226,7 +226,9 @@ export async function executeAnonymous(
 
   const outputDir =
     args.outputDir ?? path.join(projectPath ?? process.cwd(), ".apex-log-mcp");
-  await fs.mkdir(outputDir, { recursive: true });
+  // Resolves to the first directory created, or undefined when it already existed,
+  // which is exactly when the .gitignore tip below is worth its tokens.
+  const createdDir = await fs.mkdir(outputDir, { recursive: true });
 
   const filePath = path.join(outputDir, `${logId}.log`);
   await fs.writeFile(filePath, logBody as string, "utf-8");
@@ -246,7 +248,9 @@ export async function executeAnonymous(
             exceptionMessage: apexResult.exceptionMessage,
           }),
           durationMs: logRecord.DurationMilliseconds,
-          tip: "Add .apex-log-mcp/ to your .gitignore to avoid committing debug logs.",
+          ...(createdDir && {
+            tip: "Add .apex-log-mcp/ to your .gitignore to avoid committing debug logs.",
+          }),
         }),
       },
     ],

--- a/src/tools/findPerformanceBottlenecks.ts
+++ b/src/tools/findPerformanceBottlenecks.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { parse, ApexLog } from "../ApexLogParser.js";
 import { type SlowMethod, extractMethods } from "./analyzeLogPerformance.js";
 import { encode } from "@toon-format/toon";
+import { roundMs, roundPercent } from "./responseShaping.js";
 
 export const findPerformanceBottlenecksInputSchema = {
   logFilePath: z
@@ -66,10 +67,15 @@ export async function findPerformanceBottlenecks(args: BottleneckArgs) {
 
   const bottlenecks: BottleneckResult = {};
 
+  // Limits already spelled out by a dedicated section, so the generic warning
+  // block does not report them a second time.
+  const reportedLimits = new Set<string>();
+
   if (hasCpuSection) {
     const cpu = analyzeCPUBottlenecks(apexLog);
     if (Object.keys(cpu).length > 0) {
       bottlenecks.cpuBottlenecks = cpu;
+      reportedLimits.add("cpuTime");
     }
   }
 
@@ -77,6 +83,7 @@ export async function findPerformanceBottlenecks(args: BottleneckArgs) {
     const db = analyzeDatabaseBottlenecks(apexLog);
     if (Object.keys(db).length > 0) {
       bottlenecks.databaseBottlenecks = db;
+      Object.keys(db).forEach((limit) => reportedLimits.add(limit));
     }
   }
 
@@ -87,17 +94,13 @@ export async function findPerformanceBottlenecks(args: BottleneckArgs) {
     }
   }
 
-  const governorWarnings = analyzeGovernorLimits(
-    apexLog,
-    hasCpuSection && bottlenecks.cpuBottlenecks !== undefined,
-  );
+  const governorWarnings = analyzeGovernorLimits(apexLog, reportedLimits);
   if (Object.keys(governorWarnings).length > 0) {
     bottlenecks.governorLimitWarnings = governorWarnings;
   }
 
   if (Object.keys(bottlenecks).length === 0) {
-    bottlenecks.note =
-      "No performance bottlenecks or governor limit warnings found.";
+    bottlenecks.note = "No bottlenecks or governor limit warnings found.";
   }
 
   return {
@@ -118,8 +121,8 @@ function analyzeCPUBottlenecks(apexLog: ApexLog): Record<string, unknown> {
     return {
       cpuTimeUsed: used,
       cpuTimeLimit: limit,
-      cpuUsagePercentage: cpuUsagePercent,
-      warning: "High CPU usage detected - consider optimizing algorithms",
+      cpuUsagePercentage: roundPercent(cpuUsagePercent),
+      warning: "High CPU usage - consider optimizing algorithms",
     };
   }
 
@@ -140,7 +143,7 @@ function analyzeDatabaseBottlenecks(apexLog: ApexLog): Record<string, unknown> {
     bottlenecks.soqlQueries = {
       used: governorLimits.soqlQueries.used,
       limit: governorLimits.soqlQueries.limit,
-      percentage: soqlPercentage,
+      percentage: roundPercent(soqlPercentage),
     };
   }
 
@@ -155,7 +158,7 @@ function analyzeDatabaseBottlenecks(apexLog: ApexLog): Record<string, unknown> {
     bottlenecks.dmlStatements = {
       used: governorLimits.dmlStatements.used,
       limit: governorLimits.dmlStatements.limit,
-      percentage: dmlPercentage,
+      percentage: roundPercent(dmlPercentage),
     };
   }
 
@@ -168,7 +171,7 @@ function analyzeDatabaseBottlenecks(apexLog: ApexLog): Record<string, unknown> {
     bottlenecks.queryRows = {
       used: governorLimits.queryRows.used,
       limit: governorLimits.queryRows.limit,
-      percentage: queryRowsPercentage,
+      percentage: roundPercent(queryRowsPercentage),
     };
   }
 
@@ -190,16 +193,17 @@ function analyzeMethodBottlenecks(apexLog: ApexLog): Record<string, unknown> {
     methodsByNamespace: Object.entries(methodsByNamespace).map(([ns, group]) => ({
       namespace: ns,
       methodCount: group.length,
-      totalDuration:
+      totalDuration: roundMs(
         group.reduce((sum: number, m: SlowMethod) => sum + m.duration, 0) /
-        NS_TO_MS,
+          NS_TO_MS,
+      ),
     })),
   };
 }
 
 function analyzeGovernorLimits(
   apexLog: ApexLog,
-  excludeCpuTime: boolean,
+  reportedLimits: Set<string>,
 ): Record<string, unknown> {
   const limits = apexLog.governorLimits;
 
@@ -207,7 +211,7 @@ function analyzeGovernorLimits(
 
   Object.entries(limits).forEach(([key, value]: [string, any]) => {
     if (key === "byNamespace") return;
-    if (excludeCpuTime && key === "cpuTime") return;
+    if (reportedLimits.has(key)) return;
     if (value.limit > 0) {
       const percentage = (value.used / value.limit) * 100;
       if (percentage > WARNING_THRESHOLD) {

--- a/src/tools/getLogSummary.ts
+++ b/src/tools/getLogSummary.ts
@@ -3,10 +3,10 @@
  */
 
 import { promises as fs } from "fs";
-import path from "path";
 import { z } from "zod";
 import { parse, ApexLog, LogLine } from "../ApexLogParser.js";
 import { encode } from "@toon-format/toon";
+import { omitEmpty, roundMs, toLimitRows } from "./responseShaping.js";
 
 export const getLogSummaryInputSchema = {
   logFilePath: z
@@ -21,7 +21,7 @@ export type LogSummaryArgs = z.infer<
 export const getLogSummaryToolConfig = {
   title: "Get Apex Log Summary",
   description:
-    "Get a high-level summary of an Apex debug log including total execution time (in ms), method count, SOQL/DML totals, governor limits, and active namespaces. Best for a quick overview before deeper analysis.",
+    "Get a high-level summary of an Apex debug log including total execution time (in ms), method count, SOQL/DML totals, governor limits, debug levels and active namespaces. Best for a quick overview before deeper analysis. Every governor limit and debug category is listed, including limits with zero usage. Only `logIssues` is omitted, and only when the log contained none.",
   inputSchema: getLogSummaryInputSchema,
   annotations: {
     title: "Get Apex Log Summary",
@@ -46,37 +46,30 @@ export async function getLogSummary(args: LogSummaryArgs) {
   const logContent = await fs.readFile(logFilePath, "utf-8");
   const apexLog = parse(logContent);
 
-  const governorLimits: Record<string, { used: number; limit: number }> = {};
-  Object.entries(apexLog.governorLimits).forEach(
-    ([key, value]: [string, any]) => {
-      if (key !== "byNamespace" && (value.used > 0 || value.limit > 0)) {
-        governorLimits[key] = { used: value.used, limit: value.limit };
-      }
-    },
-  );
-
   const logIssues = apexLog.logIssues.map((issue) => ({
     type: issue.type,
     summary: issue.summary,
   }));
 
+  // Every limit and every category is reported, at zero or NONE included: the
+  // caller has to be able to say "no DML statements ran" and "DB logging was
+  // off, so that detail is missing" without guessing from what is absent.
   const summary = {
-    file: path.basename(logFilePath),
     size: apexLog.size,
-    totalExecutionTime: apexLog.duration.total / NS_TO_MS,
+    totalExecutionTime: roundMs(apexLog.duration.total / NS_TO_MS),
     totalMethods: countMethods(apexLog),
     totalSOQLQueries: apexLog.soqlCount.total,
     totalDMLOperations: apexLog.dmlCount.total,
     totalSOQLRows: apexLog.soqlRowCount.total,
     totalDMLRows: apexLog.dmlRowCount.total,
-    governorLimits,
+    governorLimits: toLimitRows(apexLog.governorLimits),
     namespaces: apexLog.namespaces,
-    debugLevels: apexLog.debugLevels.map((d) => ({
-      category: d.logCategory,
-      level: d.logLevel,
+    debugLevels: apexLog.debugLevels.map((level) => ({
+      category: level.logCategory,
+      level: level.logLevel,
     })),
-    logIssues,
     parsingErrors: apexLog.parsingErrors.length,
+    ...omitEmpty({ logIssues }),
   };
 
   return {

--- a/src/tools/responseShaping.ts
+++ b/src/tools/responseShaping.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * Helpers for keeping tool responses small.
+ *
+ * Every token in a response is a token the calling model pays for on every turn
+ * it stays in context. The saving comes from structure and from not saying the
+ * same thing twice — never from dropping a fact. A field with a fixed schema is
+ * always reported, even at zero: an agent asked "how many DML statements ran?"
+ * must be able to answer from the payload.
+ */
+
+import type { GovernorLimits, Limits } from "../ApexLogParser.js";
+
+/** Durations are reported in ms; 3dp keeps microsecond resolution without float noise. */
+export function roundMs(ms: number): number {
+  return Math.round(ms * 1000) / 1000;
+}
+
+/** Percentages are only ever read as a magnitude, so 1dp is plenty. */
+export function roundPercent(percent: number): number {
+  return Math.round(percent * 10) / 10;
+}
+
+/**
+ * A value that tells the reader nothing the omission wouldn't.
+ *
+ * `false` is deliberately not empty: it is an answer.
+ */
+export function isEmptyValue(value: unknown): boolean {
+  if (value === null || value === undefined || value === 0 || value === "") {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+  if (typeof value === "object") {
+    return Object.keys(value).length === 0;
+  }
+  return false;
+}
+
+/**
+ * Drop the keys that carry no information.
+ *
+ * For occurrence lists and optional sections only — issues found,
+ * recommendations made, errors encountered — where an absent key unambiguously
+ * means "nothing occurred". Never pass fixed-schema scalars through this: an
+ * absent count cannot be told apart from a count that was never parsed, so a
+ * zero is reported as a zero.
+ */
+export function omitEmpty<T extends Record<string, unknown>>(
+  obj: T,
+): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, value]) => !isEmptyValue(value)),
+  ) as Partial<T>;
+}
+
+export interface LimitRow {
+  name: string;
+  used: number;
+  limit: number;
+}
+
+/**
+ * Flatten the parser's governor limits into rows.
+ *
+ * All limits are kept, including those at zero — the set is fixed and known, so
+ * a missing row would be a question the caller cannot answer. The saving comes
+ * from the shape: as rows sharing three keys, TOON emits one header plus one
+ * line per limit, which on a real log is a little over half the cost of the same
+ * data as thirteen nested objects.
+ */
+export function toLimitRows(governorLimits: GovernorLimits): LimitRow[] {
+  return Object.entries(governorLimits)
+    .filter(([name]) => name !== "byNamespace")
+    .map(([name, value]) => {
+      const { used, limit } = value as Limits[keyof Limits];
+      return { name, used, limit };
+    });
+}

--- a/tests/analyzeLogPerformance.test.ts
+++ b/tests/analyzeLogPerformance.test.ts
@@ -271,8 +271,9 @@ describe("analyzeLogPerformance", () => {
       const result = await analyzeLogPerformance(args);
       const parsedResult = toonDecode(result);
 
+      // "No methods were found" is a result, not an absence of one.
       expect(parsedResult.totalMethods).toBe(0);
-      expect(parsedResult.slowestMethods).toHaveLength(0);
+      expect(parsedResult.slowestMethods).toEqual([]);
     });
 
     it("should handle log with no matching methods after filtering", async () => {
@@ -287,8 +288,10 @@ describe("analyzeLogPerformance", () => {
       const result = await analyzeLogPerformance(args);
       const parsedResult = toonDecode(result);
 
+      // The namespace matched nothing, and the empty table is how the caller
+      // learns that rather than guessing at a missing key.
       expect(parsedResult.totalMethods).toBe(0);
-      expect(parsedResult.slowestMethods).toHaveLength(0);
+      expect(parsedResult.slowestMethods).toEqual([]);
     });
 
     it("should handle parsing errors gracefully", async () => {
@@ -331,7 +334,6 @@ describe("analyzeLogPerformance", () => {
       expect(typeof method.name).toBe("string");
       expect(typeof method.duration).toBe("number");
       expect(typeof method.selfDuration).toBe("number");
-      expect(typeof method.namespace).toBe("string");
       expect(typeof method.dmlCount).toBe("number");
       expect(typeof method.soqlCount).toBe("number");
       expect(typeof method.dmlRows).toBe("number");
@@ -340,6 +342,25 @@ describe("analyzeLogPerformance", () => {
       expect(["number", "string", "object"]).toContain(
         typeof method.lineNumber,
       );
+      // The column set is fixed, so a zero SOSL count reads as "none ran" rather
+      // than "not measured", and the shape is the same on every call.
+      expect(typeof method.namespace).toBe("string");
+      expect(typeof method.thrownCount).toBe("number");
+      expect(typeof method.soslCount).toBe("number");
+      expect(typeof method.soslRows).toBe("number");
+    });
+
+    it("should report the namespace of every method", async () => {
+      const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
+
+      setupMocksForSuccess(createMockApexLogWithNamespaces());
+
+      const result = await analyzeLogPerformance(args);
+      const parsedResult = toonDecode(result);
+
+      expect(
+        parsedResult.slowestMethods.map((method) => method.namespace),
+      ).toEqual(["default", "CustomNamespace"]);
     });
 
     it("should return LogAnalysisResult with correct structure", async () => {
@@ -353,11 +374,31 @@ describe("analyzeLogPerformance", () => {
 
       expect(typeof parsedResult.totalMethods).toBe("number");
       expect(typeof parsedResult.totalExecutionTime).toBe("number");
+      expect(typeof parsedResult.topMethodsSelfPercentage).toBe("number");
       expect(Array.isArray(parsedResult.slowestMethods)).toBe(true);
       expect(Array.isArray(parsedResult.recommendations)).toBe(true);
     });
 
-    it("should return LogAnalysisResult with summary string", async () => {
+    it("should report what share of the run the returned methods account for", async () => {
+      const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
+
+      setupMocksForSuccess(createMockApexLog());
+
+      const result = await analyzeLogPerformance(args);
+      const parsedResult = toonDecode(result);
+
+      // The one thing the table cannot say for itself: whether the cost is
+      // concentrated in these methods or spread across the rest of the run.
+      expect(parsedResult.topMethodsSelfPercentage).toBe(
+        parsedResult.slowestMethods.reduce(
+          (total: number, method: { selfPercentage: number }) =>
+            total + method.selfPercentage,
+          0,
+        ),
+      );
+    });
+
+    it("should not restate the table as a prose summary", async () => {
       const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
       const mockApexLog = createMockApexLog();
 
@@ -366,10 +407,9 @@ describe("analyzeLogPerformance", () => {
       const result = await analyzeLogPerformance(args);
       const parsedResult = toonDecode(result);
 
-      expect(typeof parsedResult.summary).toBe("string");
-      expect(parsedResult.summary).toContain("Analysis found 3 methods");
-      expect(parsedResult.summary).toContain("SlowMethod");
-      expect(parsedResult.summary).toContain("500.00ms");
+      // The counts, the worst method and its duration are all already columns, so
+      // a sentence repeating them is pure duplication.
+      expect(parsedResult.summary).toBeUndefined();
     });
   });
 
@@ -383,11 +423,9 @@ describe("analyzeLogPerformance", () => {
       const result = await analyzeLogPerformance(args);
       const parsedResult = toonDecode(result);
 
-      const soqlRecommendation = parsedResult.recommendations.find(
-        (rec) =>
-          rec.includes("SOQL queries") && rec.includes("reducing query count"),
-      );
-      expect(soqlRecommendation).toBeDefined();
+      expect(parsedResult.recommendations).toEqual([
+        "HighSOQLMethod: many SOQL queries. Bulkify or cache.",
+      ]);
     });
 
     it("should generate DML recommendations", async () => {
@@ -399,10 +437,9 @@ describe("analyzeLogPerformance", () => {
       const result = await analyzeLogPerformance(args);
       const parsedResult = toonDecode(result);
 
-      const dmlRecommendation = parsedResult.recommendations.find(
-        (rec) => rec.includes("DML operations") && rec.includes("bulkifying"),
-      );
-      expect(dmlRecommendation).toBeDefined();
+      expect(parsedResult.recommendations).toEqual([
+        "HighDMLMethod: many DML operations. Bulkify them.",
+      ]);
     });
 
     it("should generate SOQL rows recommendations", async () => {
@@ -414,10 +451,9 @@ describe("analyzeLogPerformance", () => {
       const result = await analyzeLogPerformance(args);
       const parsedResult = toonDecode(result);
 
-      const rowsRecommendation = parsedResult.recommendations.find(
-        (rec) => rec.includes("SOQL rows") && rec.includes("WHERE clauses"),
-      );
-      expect(rowsRecommendation).toBeDefined();
+      expect(parsedResult.recommendations).toEqual([
+        "HighRowsMethod: high SOQL row count. Add WHERE clauses or paginate.",
+      ]);
     });
 
     it("should generate high percentage recommendations", async () => {
@@ -429,12 +465,11 @@ describe("analyzeLogPerformance", () => {
       const result = await analyzeLogPerformance(args);
       const parsedResult = toonDecode(result);
 
-      const percentageRecommendation = parsedResult.recommendations.find(
-        (rec) =>
-          rec.includes("% self execution time") &&
-          rec.includes("can be optimized"),
-      );
-      expect(percentageRecommendation).toBeDefined();
+      // The percentage that triggered this is already a column on the method's row,
+      // so the advice names the lever and leaves the figure out.
+      expect(parsedResult.recommendations).toEqual([
+        "HighPercentageMethod: dominates self time. Check whether it can be made faster, and how often it is called.",
+      ]);
     });
 
     it("should generate SOSL search recommendations", async () => {
@@ -446,15 +481,12 @@ describe("analyzeLogPerformance", () => {
       const result = await analyzeLogPerformance(args);
       const parsedResult = toonDecode(result);
 
-      const soslRecommendation = parsedResult.recommendations.find(
-        (rec) =>
-          rec.includes("SOSL searches") &&
-          rec.includes("reducing search count"),
-      );
-      expect(soslRecommendation).toBeDefined();
+      expect(parsedResult.recommendations).toEqual([
+        "HighSOSLMethod: many SOSL searches. Reduce or cache them.",
+      ]);
     });
 
-    it("should generate positive message when no issues found", async () => {
+    it("should omit recommendations entirely when nothing stands out", async () => {
       const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
       const mockApexLog = createMockApexLogWithGoodPerformance();
 
@@ -463,9 +495,8 @@ describe("analyzeLogPerformance", () => {
       const result = await analyzeLogPerformance(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.recommendations).toContain(
-        "Performance looks good! No obvious bottlenecks detected in the analyzed methods.",
-      );
+      // An "all good" sentence costs tokens to say what an absent field already says.
+      expect(parsedResult.recommendations).toBeUndefined();
     });
 
     it("should only analyze top 3 methods for recommendations", async () => {

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -1,0 +1,30 @@
+# Eval fixtures and golden files
+
+`pnpm run eval` drives the **built** server over stdio against the logs in `fixtures/` and asserts
+four things per (tool, fixture) pair: that realistic questions are still answerable, that no figure
+is reported twice, that the payload is under a token budget, and that it matches the committed
+golden file. See [`scripts/eval.mjs`](../../scripts/eval.mjs).
+
+## Fixtures
+
+| File | Provenance | What it pins |
+| --- | --- | --- |
+| `governor-heavy.log` | Slices of the [Apex Log Analyzer sample log](https://github.com/certinia/debug-log-analyzer) (`sample-app/debug-logs/sample-log.log`): the transaction start, a DML insert, a managed-package section for `core_pkg` and `srm_pkg` with a SOQL query, and the closing limit block. | CPU over its limit, SOQL/DML consumed, three namespaces, a `FATAL_ERROR`, and — because it is a trimmed slice — a non-zero `parsingErrors`. |
+| `minimal.log` | A `System.debug('')` run: the smallest transaction that still emits a limit block. | Everything is zero. This is the fixture that fails if a zero is ever omitted instead of reported, because "no DML statements ran" has to be answerable from the payload. |
+
+`governor-heavy.log` is deliberately fragmentary — the whole sample log is 19 MB, and the slices keep
+the fixture at ~40 KB while retaining every fact the tools report. Its `parsingErrors` count is an
+artefact of that slicing, and is useful: it exercises the "did the log parse cleanly?" question with
+a non-zero answer, where `minimal.log` answers it with zero.
+
+## Golden files
+
+`golden/<tool>.<fixture>.expected.txt` is the exact TOON payload an agent receives. When an output
+shape changes on purpose:
+
+```zsh
+pnpm run build && pnpm run eval:update
+```
+
+Then read the diff — it is the review of the change, and the token counts printed alongside it are
+the cost.

--- a/tests/eval/fixtures/governor-heavy.log
+++ b/tests/eval/fixtures/governor-heavy.log
@@ -1,0 +1,727 @@
+64.0 APEX_CODE,FINE;APEX_PROFILING,FINE;CALLOUT,FINEST;DATA_ACCESS,INFO;DB,FINEST;NBA,FINE;SYSTEM,FINE;VALIDATION,INFO;VISUALFORCE,FINE;WAVE,FINE;WORKFLOW,FINE
+Execute Anonymous: AccountService.createAccountsAndContacts();
+10:29:24.6 (6297619)|USER_INFO|[EXTERNAL]|005Ea00000R6orz|first-last@example.com|(GMT-07:00) Pacific Daylight Time (America/Los_Angeles)|GMT-07:00
+10:29:24.6 (6329577)|EXECUTION_STARTED
+10:29:24.6 (6337821)|CODE_UNIT_STARTED|[EXTERNAL]|execute_anonymous_apex
+10:29:24.6 (6957638)|SYSTEM_MODE_ENTER|false
+10:29:24.6 (84434204)|METHOD_ENTRY|[5]|01pEa00000CgcGT|AccountService.AccountService()
+10:29:24.6 (84539933)|SYSTEM_METHOD_ENTRY|[7]|com.salesforce.api.interop.apex.bcl.DateMethods.newInstance(Integer, Integer, Integer)
+10:29:24.6 (84645761)|SYSTEM_METHOD_EXIT|[7]|com.salesforce.api.interop.apex.bcl.DateMethods.newInstance(Integer, Integer, Integer)
+10:29:24.6 (84669076)|METHOD_EXIT|[5]|AccountService
+10:29:24.6 (84707278)|METHOD_ENTRY|[1]|01pEa00000CgcGT|AccountService.createAccountsAndContacts()
+10:29:24.6 (84756747)|METHOD_ENTRY|[11]|01pEa00000CgcGT|AccountService.getRevenue()
+10:29:24.6 (84822141)|SYSTEM_METHOD_ENTRY|[120]|com.salesforce.api.interop.apex.bcl.DateMethods.today()
+10:29:24.6 (84859046)|SYSTEM_METHOD_EXIT|[120]|com.salesforce.api.interop.apex.bcl.DateMethods.today()
+10:29:24.6 (84869926)|METHOD_ENTRY|[120]|01pEa00000CgcGT|AccountService.getDayValue(Date)
+10:29:24.6 (84890620)|SYSTEM_METHOD_ENTRY|[142]|com.salesforce.api.interop.apex.bcl.DateMethods.daysBetween(Date)
+10:29:24.6 (84904980)|SYSTEM_METHOD_EXIT|[142]|com.salesforce.api.interop.apex.bcl.DateMethods.daysBetween(Date)
+10:29:24.6 (84949994)|SYSTEM_METHOD_ENTRY|[1]|Math.Math()
+10:29:24.6 (84998791)|SYSTEM_METHOD_EXIT|[1]|Math
+10:29:24.6 (85010745)|METHOD_ENTRY|[143]||System.Math.mod(Integer, Integer)
+10:29:24.6 (86075910)|METHOD_EXIT|[143]||System.Math.mod(Integer, Integer)
+10:29:24.6 (86151658)|METHOD_EXIT|[120]|01pEa00000CgcGT|AccountService.getDayValue(Date)
+10:29:24.6 (86198738)|SYSTEM_METHOD_ENTRY|[120]|Decimal.multiply(Decimal)
+10:29:24.6 (86225666)|SYSTEM_METHOD_EXIT|[120]|Decimal.multiply(Decimal)
+10:29:24.6 (86232986)|METHOD_EXIT|[11]|01pEa00000CgcGT|AccountService.getRevenue()
+10:29:24.6 (86477829)|SYSTEM_CONSTRUCTOR_ENTRY|[13]|<init>()
+10:29:24.6 (86505921)|SYSTEM_CONSTRUCTOR_EXIT|[13]|<init>()
+10:29:24.6 (86754887)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (86795087)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (86951731)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (86968604)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (87079014)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (87097338)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (87174461)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (87184902)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (87225943)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (87236086)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (87276422)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (87284026)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (87304589)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (87314369)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (87339226)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (87348726)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (87404336)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (87437315)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (87460222)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (87470288)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (87504853)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (87514333)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (87553097)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (87560941)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (87579552)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (87589197)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (87613484)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (87623384)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (87663356)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (87670624)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (87687964)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (87696970)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (87719794)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (87729363)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (87762248)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (87769298)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (87805213)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (87815748)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (87842667)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (87869118)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (87907942)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (87915385)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (87933899)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (87943489)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (87967708)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (87976926)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (88016307)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (88024870)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (88044293)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (88053463)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (88076857)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (88086187)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (88119518)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (88142642)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (88162653)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (88191074)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (88249203)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (88262432)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (88311769)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (88320502)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (88343670)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (88355327)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (88408271)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (88435637)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (88475264)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (88487395)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (88506754)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (88516205)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (88539890)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (88549422)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (88583261)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (88590787)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (88608114)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (88617461)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (88640695)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (88650083)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (88683242)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (88690241)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (88714782)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (88724592)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (88788947)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (88815826)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (88855645)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (88862866)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (88885520)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (88895447)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (88933847)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (88943559)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (88980267)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (88987353)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (89005971)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (89015843)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (89039406)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (89048810)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (89081656)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (89089062)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (89106626)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (89115798)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (89138918)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (89148140)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (89181807)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (89189582)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (89210646)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (89220281)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (89243466)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (89252318)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (89326613)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (89334466)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (89354152)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (89364329)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (89389051)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (89398351)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (89432248)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (89439681)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (89457859)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (89467518)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (89489767)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (89498916)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (89531362)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (89538941)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (89598753)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (89618376)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (89647385)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (89656766)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (89690569)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (89697762)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (89716716)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (89725806)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (89748641)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (89757346)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (89789601)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (89796364)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (89813941)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (89823226)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (89846110)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (89855374)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (89889156)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (89896468)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (89932529)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (89942110)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (89972440)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (89981782)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (90137135)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (90146409)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (90168862)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (90178524)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (90204853)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (90214324)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (90249240)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (90256511)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (90272950)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (90282272)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (90328799)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (90338599)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (90373001)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (90380438)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (90398067)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (90407408)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (90450187)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (90464231)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (90499240)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (90506621)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (90541535)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (90550941)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (90576177)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (90585992)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (90639644)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (90647322)|SYSTEM_METHOD_EXIT|[19]|List<Account>.add(Object)
+10:29:24.6 (90666200)|SYSTEM_METHOD_ENTRY|[16]|String.valueOf(Object)
+10:29:24.6 (90675321)|SYSTEM_METHOD_EXIT|[16]|String.valueOf(Object)
+10:29:24.6 (90698875)|SYSTEM_METHOD_ENTRY|[17]|String.valueOf(Object)
+10:29:24.6 (90708090)|SYSTEM_METHOD_EXIT|[17]|String.valueOf(Object)
+10:29:24.6 (90741126)|SYSTEM_METHOD_ENTRY|[19]|List<Account>.add(Object)
+10:29:24.6 (143822324)|SYSTEM_METHOD_EXIT|[25]|system.ListIterator.hasNext()
+10:29:24.6 (143832776)|SYSTEM_METHOD_ENTRY|[26]|String.isBlank(String)
+10:29:24.6 (143839643)|SYSTEM_METHOD_EXIT|[26]|String.isBlank(String)
+10:29:24.6 (143854221)|SYSTEM_METHOD_ENTRY|[29]|Decimal.compareTo(Decimal)
+10:29:24.6 (143862262)|SYSTEM_METHOD_EXIT|[29]|Decimal.compareTo(Decimal)
+10:29:24.6 (143866974)|SYSTEM_METHOD_ENTRY|[25]|system.ListIterator.hasNext()
+10:29:24.6 (143872509)|SYSTEM_METHOD_EXIT|[25]|system.ListIterator.hasNext()
+10:29:24.6 (144082082)|DML_BEGIN|[36]|Op:Insert|Type:Account|Rows:300
+10:29:24.6 (888486920)|CODE_UNIT_STARTED|[EXTERNAL]|Flow:Account
+10:29:24.953 (953433278)|FLOW_CREATE_INTERVIEW_BEGIN|00DEa00000KOnB0|300Ea00000dqZhh|301Ea000012e1Jw
+10:29:24.953 (953999197)|FLOW_CREATE_INTERVIEW_END|4665a721c57d72783b101ffd513f197d6718885-6a01|Update Account Field (Fast)
+10:29:24.953 (954005384)|FLOW_CREATE_INTERVIEW_END|4666a721c57d72783b101ffd513f197d6718885-6a00|Update Account Field (Fast)
+10:29:24.953 (954009744)|FLOW_CREATE_INTERVIEW_END|4667a721c57d72783b101ffd513f197d6718885-69ff|Update Account Field (Fast)
+10:29:24.953 (954011938)|FLOW_CREATE_INTERVIEW_END|4668a721c57d72783b101ffd513f197d6718885-69fe|Update Account Field (Fast)
+10:29:24.953 (954013948)|FLOW_CREATE_INTERVIEW_END|4669a721c57d72783b101ffd513f197d6718885-69fd|Update Account Field (Fast)
+10:29:24.953 (954015997)|FLOW_CREATE_INTERVIEW_END|4670a721c57d72783b101ffd513f197d6718885-69fc|Update Account Field (Fast)
+10:29:24.953 (954018754)|FLOW_CREATE_INTERVIEW_END|4671a721c57d72783b101ffd513f197d6718885-69fb|Update Account Field (Fast)
+10:29:24.953 (954020862)|FLOW_CREATE_INTERVIEW_END|4672a721c57d72783b101ffd513f197d6718885-69fa|Update Account Field (Fast)
+10:29:24.953 (954022900)|FLOW_CREATE_INTERVIEW_END|4673a721c57d72783b101ffd513f197d6718885-69f9|Update Account Field (Fast)
+10:29:24.953 (954025002)|FLOW_CREATE_INTERVIEW_END|4674a721c57d72783b101ffd513f197d6718885-69f8|Update Account Field (Fast)
+10:29:24.953 (954026981)|FLOW_CREATE_INTERVIEW_END|4675a721c57d72783b101ffd513f197d6718885-69f7|Update Account Field (Fast)
+10:29:24.953 (954028963)|FLOW_CREATE_INTERVIEW_END|4676a721c57d72783b101ffd513f197d6718885-69f6|Update Account Field (Fast)
+10:29:24.953 (954031091)|FLOW_CREATE_INTERVIEW_END|4677a721c57d72783b101ffd513f197d6718885-69f5|Update Account Field (Fast)
+10:29:24.953 (954033159)|FLOW_CREATE_INTERVIEW_END|4678a721c57d72783b101ffd513f197d6718885-69f4|Update Account Field (Fast)
+10:29:24.953 (954035604)|FLOW_CREATE_INTERVIEW_END|4679a721c57d72783b101ffd513f197d6718885-69f3|Update Account Field (Fast)
+10:29:24.953 (954037700)|FLOW_CREATE_INTERVIEW_END|4680a721c57d72783b101ffd513f197d6718885-69f2|Update Account Field (Fast)
+10:29:24.953 (954039899)|FLOW_CREATE_INTERVIEW_END|4681a721c57d72783b101ffd513f197d6718885-69f1|Update Account Field (Fast)
+10:29:24.953 (954041961)|FLOW_CREATE_INTERVIEW_END|4682a721c57d72783b101ffd513f197d6718885-69f0|Update Account Field (Fast)
+10:29:24.953 (954043994)|FLOW_CREATE_INTERVIEW_END|4683a721c57d72783b101ffd513f197d6718885-69ef|Update Account Field (Fast)
+10:29:24.953 (954045985)|FLOW_CREATE_INTERVIEW_END|4684a721c57d72783b101ffd513f197d6718885-69ee|Update Account Field (Fast)
+10:29:24.953 (954047948)|FLOW_CREATE_INTERVIEW_END|4685a721c57d72783b101ffd513f197d6718885-69ed|Update Account Field (Fast)
+  int[]:sizeTable:0
+
+10:29:27.928 (3928196166)|CUMULATIVE_LIMIT_USAGE_END
+
+10:29:27.872 (3928523501)|CODE_UNIT_FINISHED|AccountTrigger on Account trigger event BeforeInsert|__sfdc_trigger/AccountTrigger
+10:29:27.934 (3934728586)|ENTERING_MANAGED_PKG|core_pkg
+10:29:27.934 (3948516510)|ENTERING_MANAGED_PKG|core_pkg
+10:29:27.934 (3948573855)|ENTERING_MANAGED_PKG|core_pkg
+10:29:27.934 (3949347190)|ENTERING_MANAGED_PKG|core_pkg
+10:29:27.934 (3949624822)|ENTERING_MANAGED_PKG|core_pkg
+10:29:27.934 (3949870521)|ENTERING_MANAGED_PKG|core_pkg
+10:29:27.934 (3950035641)|ENTERING_MANAGED_PKG|core_pkg
+10:29:27.934 (3950082265)|ENTERING_MANAGED_PKG|core_pkg
+10:29:27.934 (3950107428)|ENTERING_MANAGED_PKG|core_pkg
+10:29:27.934 (3950118030)|ENTERING_MANAGED_PKG|core_pkg
+10:29:27.934 (3970918970)|ENTERING_MANAGED_PKG|core_pkg
+10:29:27.934 (3970974539)|ENTERING_MANAGED_PKG|core_pkg
+10:29:27.934 (3971390480)|ENTERING_MANAGED_PKG|core_pkg
+10:29:27.934 (3971402571)|ENTERING_MANAGED_PKG|core_pkg
+10:29:27.934 (3971616630)|ENTERING_MANAGED_PKG|core_pkg
+10:29:27.934 (3971623600)|ENTERING_MANAGED_PKG|core_pkg
+  Number of DML statements: 1 out of 150
+  Number of Publish Immediate DML: 0 out of 150
+  Number of DML rows: 300 out of 10000
+  Maximum CPU time: 172 out of 10000
+  Maximum heap size: 0 out of 6000000
+  Number of callouts: 0 out of 100
+  Number of Email Invocations: 0 out of 10
+  Number of future calls: 0 out of 50
+  Number of queueable jobs added to the queue: 0 out of 50
+  Number of Mobile Apex push calls: 0 out of 10
+
+10:29:28.66 (4066151244)|CUMULATIVE_LIMIT_USAGE_END
+
+10:29:28.80 (4080646459)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4090678024)|ENTERING_MANAGED_PKG|core_pkg
+10:29:28.80 (4090743817)|ENTERING_MANAGED_PKG|core_pkg
+10:29:28.80 (4090782221)|ENTERING_MANAGED_PKG|core_pkg
+10:29:28.80 (4090801909)|ENTERING_MANAGED_PKG|core_pkg
+10:29:28.80 (4090811491)|ENTERING_MANAGED_PKG|core_pkg
+10:29:28.80 (4090848719)|ENTERING_MANAGED_PKG|core_pkg
+10:29:28.80 (4101205649)|SOQL_EXECUTE_BEGIN|[19]|Aggregations:1|SELECT Name, Id, core_pkg__group_key__c, (SELECT core_pkg__Value__c FROM core_pkg__Values__r ORDER BY core_pkg__Sort__c ASC NULLS FIRST) FROM core_pkg__Config_Option__c
+10:29:28.80 (4125807536)|SOQL_EXECUTE_EXPLAIN|[19]|TableScan on core_pkg__Config_Option__c : [], cardinality: 1, sobjectCardinality: 1, relativeCost 0.65
+10:29:28.80 (4125822651)|SOQL_EXECUTE_END|[19]|Rows:0
+10:29:28.80 (4126432512)|ENTERING_MANAGED_PKG|core_pkg
+10:29:28.80 (4126469614)|ENTERING_MANAGED_PKG|core_pkg
+10:29:28.80 (4126483379)|ENTERING_MANAGED_PKG|core_pkg
+10:29:28.80 (4126490888)|ENTERING_MANAGED_PKG|core_pkg
+10:29:28.80 (4133100752)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4144605120)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4145156777)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4153316109)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4153388854)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4153434764)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4153865773)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4153898799)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4164486411)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4164596557)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4164643599)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4165316985)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4165488019)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4165523826)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4165580133)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4165594168)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4165642082)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4165658786)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4235793267)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4235858648)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4235892226)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4235983842)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4235994428)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:28.80 (4236129278)|ENTERING_MANAGED_PKG|srm_pkg
+10:29:47.859 (24612488832)|METHOD_EXIT|[23]|01pEa00000CfN9K|RecursiveSearcher.search(RecursiveSearcher.SimTree)
+10:29:47.859 (24612492534)|METHOD_EXIT|[23]|01pEa00000CfN9K|RecursiveSearcher.search(RecursiveSearcher.SimTree)
+10:29:47.859 (24612495796)|METHOD_EXIT|[23]|01pEa00000CfN9K|RecursiveSearcher.search(RecursiveSearcher.SimTree)
+10:29:47.859 (24612499330)|METHOD_EXIT|[50]|01pEa00000CfN9K|RecursiveSearcher.search(RecursiveSearcher.SimTree)
+10:29:47.859 (24612505174)|METHOD_EXIT|[102]|01pEa00000CfN9K|RecursiveSearcher.search(Integer, Integer, Integer)
+10:29:47.859 (24612523000)|METHOD_EXIT|[1]|01pEa00000CgcGT|AccountService.createAccountsAndContacts()
+10:29:47.859 (24612576524)|SYSTEM_MODE_EXIT|false
+10:29:47.859 (24612680061)|FATAL_ERROR|System.LimitException: Apex CPU time limit exceeded
+
+Class.RecursiveSearcher.search: line 31, column 1
+Class.RecursiveSearcher.search: line 23, column 1
+Class.RecursiveSearcher.search: line 23, column 1
+Class.RecursiveSearcher.search: line 23, column 1
+Class.RecursiveSearcher.search: line 23, column 1
+Class.RecursiveSearcher.search: line 23, column 1
+Class.RecursiveSearcher.search: line 23, column 1
+Class.RecursiveSearcher.search: line 50, column 1
+Class.AccountService.createAccountsAndContacts: line 102, column 1
+AnonymousBlock: line 1, column 1
+AnonymousBlock: line 1, column 1
+10:29:48.612 (24612836992)|CUMULATIVE_LIMIT_USAGE
+10:29:48.612 (24612836992)|LIMIT_USAGE_FOR_NS|(default)|
+  Number of SOQL queries: 5 out of 100
+  Number of query rows: 600 out of 50000
+  Number of SOSL queries: 0 out of 20
+  Number of DML statements: 6 out of 150
+  Number of Publish Immediate DML: 0 out of 150
+  Number of DML rows: 1200 out of 10000
+  Maximum CPU time: 15163 out of 10000 ******* CLOSE TO LIMIT
+  Maximum heap size: 219591 out of 6000000
+  Number of callouts: 0 out of 100
+  Number of Email Invocations: 0 out of 10
+  Number of future calls: 0 out of 50
+  Number of queueable jobs added to the queue: 0 out of 50
+  Number of Mobile Apex push calls: 0 out of 10
+
+10:29:48.612 (24612836992)|LIMIT_USAGE_FOR_NS|core_pkg|
+  Number of SOQL queries: 1 out of 100
+  Number of query rows: 0 out of 50000
+  Number of SOSL queries: 0 out of 20
+  Number of DML statements: 0 out of 150
+  Number of Publish Immediate DML: 0 out of 150
+  Number of DML rows: 0 out of 10000
+  Maximum CPU time: 0 out of 10000
+  Maximum heap size: 0 out of 6000000
+  Number of callouts: 0 out of 100
+  Number of Email Invocations: 0 out of 10
+  Number of future calls: 0 out of 50
+  Number of queueable jobs added to the queue: 0 out of 50
+  Number of Mobile Apex push calls: 0 out of 10
+
+10:29:48.612 (24612836992)|LIMIT_USAGE_FOR_NS|core_pkg|
+  Number of SOQL queries: 0 out of 100
+  Number of query rows: 2 out of 50000
+  Number of SOSL queries: 0 out of 20
+  Number of DML statements: 0 out of 150
+  Number of Publish Immediate DML: 0 out of 150
+  Number of DML rows: 0 out of 10000
+  Maximum CPU time: 0 out of 10000
+  Maximum heap size: 0 out of 6000000
+  Number of callouts: 0 out of 100
+  Number of Email Invocations: 0 out of 10
+  Number of future calls: 0 out of 50
+  Number of queueable jobs added to the queue: 0 out of 50
+  Number of Mobile Apex push calls: 0 out of 10
+
+10:29:48.612 (24612836992)|LIMIT_USAGE_FOR_NS|srm_pkg|
+  Number of SOQL queries: 0 out of 100
+  Number of query rows: 0 out of 50000
+  Number of SOSL queries: 0 out of 20
+  Number of DML statements: 0 out of 150
+  Number of Publish Immediate DML: 0 out of 150
+  Number of DML rows: 0 out of 10000
+  Maximum CPU time: 0 out of 10000
+  Maximum heap size: 0 out of 6000000
+  Number of callouts: 0 out of 100
+  Number of Email Invocations: 0 out of 10
+  Number of future calls: 0 out of 50
+  Number of queueable jobs added to the queue: 0 out of 50
+  Number of Mobile Apex push calls: 0 out of 10
+
+10:29:48.612 (24612836992)|TOTAL_EMAIL_RECIPIENTS_QUEUED|0
+10:29:48.612 (24612836992)|STATIC_VARIABLE_LIST|
+  boolean:$assertionsDisabled:0
+  int:BINARYSEARCH_THRESHOLD:0
+  int:BYTES:0
+  int:BYTES:0
+  int:BYTES:0
+  String:CAUSE_CAPTION:0
+  int:COPY_THRESHOLD:0
+  byte[]:DigitOnes:0
+  byte[]:DigitTens:0
+  Boolean:FALSE:0
+  int:FILL_THRESHOLD:0
+  int:INDEXOFSUBLIST_THRESHOLD:0
+  int:MAX_EXPONENT:0
+  double:MAX_VALUE:0
+  int:MAX_VALUE:0
+  long:MAX_VALUE:0
+  int:MIN_EXPONENT:0
+  double:MIN_NORMAL:0
+  double:MIN_VALUE:0
+  int:MIN_VALUE:0
+  long:MIN_VALUE:0
+  double:NEGATIVE_INFINITY:0
+  String:NULL_CAUSE_MESSAGE:0
+  double:NaN:0
+  double:POSITIVE_INFINITY:0
+  int:REPLACEALL_THRESHOLD:0
+  int:REVERSE_THRESHOLD:0
+  int:ROTATE_THRESHOLD:0
+  String:SELF_SUPPRESSION_MESSAGE:0
+  int:SHUFFLE_THRESHOLD:0
+  int:SIZE:0
+  int:SIZE:0
+  int:SIZE:0
+  String:SUPPRESSED_CAPTION:0
+  Boolean:TRUE:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcInnerTypes:0
+  String:__sfdcProperties:0
+  String:__sfdcProperties:0
+  String:__sfdcProperties:0
+  String:__sfdcProperties:0
+  String:__sfdcProperties:0
+  String:__sfdcProperties:0
+  String:__sfdcProperties:0
+  String:__sfdcProperties:0
+  String:__sfdcProperties:0
+  String:__sfdcProperties:0
+  String:__sfdcProperties:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcAdditionalCodeLocations:0
+  String:_sfdcSuppressedCodeLocations:0
+  String:_sfdcSuppressedCodeLocations:0
+  String:_sfdcSuppressedCodeLocations:0
+  String:_sfdcSuppressedCodeLocations:0
+  String:_sfdcSuppressedCodeLocations:0
+  String:_sfdcSuppressedCodeLocations:0
+  String:_sfdcSuppressedCodeLocations:0
+  String:_static_API_SECRET:0
+  String:_static_APPLOG_ORIGIN:0
+  String:_static_ASSIGNMENT:0
+  String:_static_ASSIGNMENTS:0
+  String:_static_AUTH_STATUS_COMPLETED:0
+  String:_static_AUTH_STATUS_NOT_COMPLETED:0
+  Set<String>:_static_AccountFields:0
+  String:_static_CODE:0
+  String:_static_CONFIGURATION_KEY:0
+  Set<Schema.SObjectField>:_static_CONTACT_FIELDS:0
+  String:_static_CONTENT_TYPE_HEADER:0
+  String:_static_CONTENT_TYPE_HEADER_VALUE:0
+  String:_static_CREATE_INSTANCE:0
+  Integer:_static_DEFAULT_HOUR_SCALE:0
+  Boolean:_static_DEFAULT_USE_IS_RESOURCE_FLAG:0
+  String:_static_DELETED:0
+  String:_static_DELETE_INSTANCE:0
+  String:_static_DELETE_WF_INSTANCE:0
+  String:_static_DEVELOPER_ORG_URL:0
+  Double:_static_E:0
+  String:_static_EMPTY:0
+  String:_static_EMPTY_JSON_BODY:0
+  String:_static_ERROR:0
+  String:_static_ERROR_DESCRIPTION:0
+  String:_static_ERROR_MESSAGE:0
+  String:_static_FEATURE_NAME:0
+  String:_static_FIELDS:0
+  String:_static_FORMULA_KEY:0
+  String:_static_FORMULA_NAME:0
+  String:_static_GRP:0
+  Map<Schema.SObjectType,srm_pkg.ICustomSettingUtil>:_static_HIERARCHY_SETTINGS_CACHE:0
+  String:_static_HTTP_METHOD_TYPE_DELETE:0
+  String:_static_HTTP_METHOD_TYPE_GET:0
+  String:_static_HTTP_METHOD_TYPE_POST:0
+  String:_static_HTTP_METHOD_TYPE_PUT:0
+  String:_static_IDField:0
+  String:_static_ID_KEY:0
+  String:_static_INITIAL_SYNC_WF_INSTANCE:0
+  String:_static_INSTANCES:0
+  Boolean:_static_IS_RUNNING_TEST:0
+  Date:_static_KNOWN_MONDAY:0
+  Map<Schema.SObjectType,srm_pkg.ICustomSettingListUtil>:_static_LIST_SETTINGS_CACHE:0
+  Integer:_static_MAX_BINDINGS:0
+  String:_static_MESSAGE:0
+  Map<Schema.SObjectType,srm_pkg.ICustomSettingUtil>:_static_MOCK_HIERARCHY_SETTINGS_CACHE:0
+  Map<Schema.SObjectType,srm_pkg.ICustomSettingListUtil>:_static_MOCK_LIST_SETTINGS_CACHE:0
+  String:_static_MSG_SEPARATOR:0
+  String:_static_NAME:0
+  String:_static_NAMESPACE:0
+  String:_static_NAMESPACE_SEPARATOR_CLASS:0
+  String:_static_NAMESPACE_SEPARATOR_OBJECT:0
+  String:_static_NAMESPACE_SEPARATOR_OBJECT:0
+  String:_static_NILL:0
+  Boolean:_static_NO_CACHE_DEFAULT:0
+  String:_static_Namespace:0
+  String:_static_OAUTH_PARAMETER:0
+  String:_static_OAUTH_PROXY_NAME:0
+  String:_static_OAUTH_URL:0
+  String:_static_PAGE_URL:0
+  String:_static_PARAMETERS_KEY:0
+  String:_static_PATH:0
+  String:_static_PERFORM_INITIAL_SYNC_STEP_NAME:0
+  Set<Schema.SObjectField>:_static_PE_SUPPORTED_FIELDS:0
+  Double:_static_PI:0
+  String:_static_PRACTICE:0
+  String:_static_PREFIX:0
+  String:_static_PROJECT:0
+  String:_static_PROJECTMANAGER:0
+  String:_static_PROJECTS:0
+  Integer:_static_PROJECT_TASK_APP_LOG_LEVEL:0
+  String:_static_PROJECT_TASK_CREATE:0
+  String:_static_PROJECT_TASK_DELETE:0
+  String:_static_PROJECT_TASK_PARENT_TASK:0
+  String:_static_PROJECT_TASK_UPDATE:0
+  String:_static_PROJECT_UPDATED:0
+  String:_static_PROJECT_WF_INSTANCE:0
+  String:_static_PUSH_MAPPINGS_FEATURE_STEP_NAME:0
+  String:_static_REGION:0
+  String:_static_RESOURCES:0
+  String:_static_RESOURCES_WITHOUT_ASSIGNMENTS:0
+  String:_static_RESOURCE_CURRENT_ACTUAL_DEFAULT_TYPE:0
+  String:_static_RESOURCE_FORMULA_INSTANCE_FEATURE_STEP_NAME:0
+  String:_static_RESOURCE_ID:0
+  String:_static_RESOURCE_NAME:0
+  String:_static_RESOURCE_UPDATED:0
+  String:_static_RESOURCE_WF_INSTANCE:0
+  String:_static_RES_AND_ASSIGNMENT:0
+  String:_static_RETRY_CREATE_SUCCESS:0
+  String:_static_RETRY_DELETE_SUCCESS:0
+  String:_static_RETRY_UPDATE_SUCCESS:0
+  String:_static_SANDBOX_URL:0
+  String:_static_SELF_KEY:0
+  String:_static_SENDTOTHIRDPARTY:0
+  String:_static_SEND_TO_THIRD_PARTY_EXPENSES_APPLICATION:0
+  core_pkg__ErpCommonObjectSettings__c:_static_SETTINGS:0
+  String:_static_SFDC:0
+  String:_static_SF_KEY:0
+  String:_static_SF_SECRET:0
+  String:_static_SLASH:0
+  String:_static_SORT_ORDER_ASCENDING:0
+  String:_static_SORT_ORDER_DESCENDING:0
+  String:_static_STATE:0
+  String:_static_STR_TRUE:0
+  String:_static_SUBTRACT_HOLIDAYS_FROM_TOTAL_HOURS:0
+  Set<String>:_static_SYSTEM_FIELDS:0
+  String:_static_TOKEN_KEY:0
+  String:_static_TPA_APP:0
+  Map<System.Type,List<core_pkg.SObjDomain>>:_static_TriggerStateByClass:0
+  String:_static_UPDATED:0
+  String:_static_UPDATE_INSTANCE:0
+  String:_static_URL_CONST:0
+  Boolean:_static_USE_IS_RESOURCE_FLAG:0
+  String:_static_USE_RESOURCE_LAST_DATE:0
+  String:_static_USE_RESOURCE_START_DATE:0
+  String:_static_VENDOR_NAME:0
+  String:_static_VENDOR_PATH:0
+  Integer:_static_VFPAGE_LIST_LIMIT:0
+  Decimal:_static_ZERO:0
+  String:_static_allFormulaInstancesEndpoint:0
+  String:_static_authAccAdmin:0
+  String:_static_authElementInstance:0
+  String:_static_deactivateFormulaInstanceEndpoint:0
+  String:_static_disableFormulaInstanceEndpoint:0
+  String:_static_endPoint:0
+  String:_static_formulaExecutionEndpoint:0
+  String:_static_formulaIDEndpoint:0
+  String:_static_formulaInstanceEndpoint:0
+  String:_static_getElementResourceQueryEndpoint:0
+  Map<String,Map<String,List<String>>>:_static_groupMap:0
+  Map<String,core_pkg.SObjDescribe>:_static_instanceCache:0
+  Map<String,srm_pkg.SObjDescribe>:_static_instanceCache:0
+  String:_static_instanceID:0
+  String:_static_instanceLevelVDREndpoint:0
+  String:_static_instanceName:0
+  Set<String>:_static_invalidSObjNames:0
+  Set<String>:_static_invalidSObjNames:0
+  Integer:_static_m_VFPAGE_LIST_LIMIT:0
+  Boolean:_static_m_canExecuteOppTrigger:0
+  Map<String,ANY>:_static_mockInstanceByTypeName:0
+  String:_static_modifyElementResourceEndpoint:0
+  String:_static_namespace:0
+  String:_static_namespace:0
+  String:_static_namespaceSObject:0
+  Map<Schema.SObjectType,List<core_pkg.PluggableTriggerApi.PluginConstructor>>:_static_pluggableTriggerCache:0
+  Map<Id,Boolean>:_static_projectTaskIdsMapToSync:0
+  String:_static_transformationFetchEndpoint:0
+  String:_static_transformationPostPutEndpoint:0
+  String:_static_updateformulaInstanceEndpoint:0
+  char[]:digits:0
+  long:serialVersionUID:0
+  long:serialVersionUID:0
+  long:serialVersionUID:0
+  long:serialVersionUID:0
+  long:serialVersionUID:0
+  long:serialVersionUID:0
+  long:serialVersionUID:0
+  long:serialVersionUID:0
+  long:serialVersionUID:0
+  int[]:sizeTable:0
+
+10:29:48.612 (24612836992)|CUMULATIVE_LIMIT_USAGE_END
+
+10:29:47.859 (24613530919)|CODE_UNIT_FINISHED|execute_anonymous_apex
+10:29:47.859 (24613548462)|EXECUTION_FINISHED
+10:29:48.614 (24614437147)|CUMULATIVE_PROFILING_BEGIN
+10:29:48.614 (24614437147)|CUMULATIVE_PROFILING|SOQL operations|
+(core_pkg): [
+			SELECT
+				Name,
+				Id,
+				core_pkg__group_key__c,
+				(SELECT core_pkg__Value__c FROM core_pkg__Values__r ORDER BY core_pkg__Sort__c)
+			FROM core_pkg__Config_Option__c
+		]: executed 1 time in 35 ms
+(core_pkg): com.salesforce.api.Database.query(String): executed 1 time in 28 ms
+(core_pkg): com.salesforce.api.Database.query(String): executed 1 time in 28 ms
+Class.ContactTriggerHandler.handleBeforeInsert: line 17, column 1: [SELECT Id, Name, AnnualRevenue FROM Account WHERE Id IN :accountIds]: executed 2 times in 17 ms
+Class.AccountService.createAccountsAndContacts: line 79, column 1: [SELECT Id, Name, AnnualRevenue FROM Account WHERE Id IN :accountIds]: executed 1 time in 16 ms
+(core_pkg): com.salesforce.api.Database.query(String): executed 1 time in 5 ms
+(core_pkg): com.salesforce.api.Database.query(String): executed 1 time in 5 ms
+
+10:29:48.614 (24614437147)|CUMULATIVE_PROFILING|No profiling information for SOSL operations
+10:29:48.614 (24614437147)|CUMULATIVE_PROFILING|DML operations|
+Class.AccountService.createAccountsAndContacts: line 94, column 1: Insert: List<Contact>: executed 1 time in 9433 ms
+Class.AccountService.createAccountsAndContacts: line 36, column 1: Insert: List<Account>: executed 1 time in 7315 ms
+Class.ContactTriggerHandler.handleAfterInsert: line 65, column 1: Insert: List<Task>: executed 2 times in 578 ms
+
+10:29:48.614 (24614437147)|CUMULATIVE_PROFILING|method invocations|
+Class.RecursiveSearcher.search: line 23, column 1: public void search(RecursiveSearcher.SimTree): executed 1964 times in 76857 ms
+External entry point: public static void execute(): executed 1 time in 24606 ms
+AnonymousBlock: line 1, column 1: public static void createAccountsAndContacts(): executed 1 time in 24528 ms
+Class.RecursiveSearcher.search: line 50, column 1: public void search(RecursiveSearcher.SimTree): executed 34 times in 11582 ms
+Class.AccountService.createAccountsAndContacts: line 90, column 1: public RecursiveSearcher(): executed 2 times in 6904 ms
+Trigger.ContactTrigger: line 13, column 1: public static void handleAfterInsert(List<Contact>): executed 2 times in 3265 ms
+Class.RecursiveSearcher.CallTreeGenerator.buildNode: line 164, column 1: public static String valueOf(Object): executed 3934 times in 3072 ms
+Class.RecursiveSearcher.CallTreeGenerator.buildNode: line 164, column 1: public static String valueOf(Object): executed 3934 times in 3072 ms
+Class.ContactTriggerHandler.handleAfterInsert: line 67, column 1: public RecursiveSearcher(): executed 4 times in 2643 ms
+Trigger.AccountTrigger: line 14, column 1: public void handleAfterInsert(List<Account>): executed 2 times in 1938 ms
+Class.AccountTriggerHandler.handleAfterInsert: line 34, column 1: public RecursiveSearcher(): executed 4 times in 1908 ms
+
+10:29:48.614 (24614437147)|CUMULATIVE_PROFILING_END

--- a/tests/eval/fixtures/minimal.log
+++ b/tests/eval/fixtures/minimal.log
@@ -1,0 +1,26 @@
+64.0 APEX_CODE,FINE;APEX_PROFILING,NONE;CALLOUT,NONE;DATA_ACCESS,NONE;DB,NONE;NBA,NONE;SYSTEM,DEBUG;VALIDATION,NONE;VISUALFORCE,NONE;WAVE,NONE;WORKFLOW,NONE
+Execute Anonymous: System.debug('');
+09:00:00.1 (1213412)|USER_INFO|[EXTERNAL]|005Ea00000R6orz|first-last@example.com|(GMT+00:00) Greenwich Mean Time (Europe/London)|GMT+00:00
+09:00:00.1 (1249981)|EXECUTION_STARTED
+09:00:00.1 (1256604)|CODE_UNIT_STARTED|[EXTERNAL]|execute_anonymous_apex
+09:00:00.1 (1731239)|USER_DEBUG|[1]|DEBUG|
+09:00:00.1 (1782103)|CUMULATIVE_LIMIT_USAGE
+09:00:00.1 (1782103)|LIMIT_USAGE_FOR_NS|(default)|
+  Number of SOQL queries: 0 out of 100
+  Number of query rows: 0 out of 50000
+  Number of SOSL queries: 0 out of 20
+  Number of DML statements: 0 out of 150
+  Number of Publish Immediate DML: 0 out of 150
+  Number of DML rows: 0 out of 10000
+  Maximum CPU time: 0 out of 10000
+  Maximum heap size: 0 out of 6000000
+  Number of callouts: 0 out of 100
+  Number of Email Invocations: 0 out of 10
+  Number of future calls: 0 out of 50
+  Number of queueable jobs added to the queue: 0 out of 50
+  Number of Mobile Apex push calls: 0 out of 10
+
+09:00:00.1 (1782103)|CUMULATIVE_LIMIT_USAGE_END
+
+09:00:00.1 (1802547)|CODE_UNIT_FINISHED|execute_anonymous_apex
+09:00:00.1 (1810992)|EXECUTION_FINISHED

--- a/tests/eval/golden/analyze_apex_log_performance.governor-heavy.expected.txt
+++ b/tests/eval/golden/analyze_apex_log_performance.governor-heavy.expected.txt
@@ -1,0 +1,15 @@
+totalMethods: 13
+totalExecutionTime: 24608.108
+topMethodsSelfPercentage: 96.6
+slowestMethods[10]{name,duration,selfDuration,selfPercentage,namespace,lineNumber,dmlCount,soqlCount,dmlRows,soqlRows,thrownCount,soslCount,soslRows}:
+  srm_pkg,20479.388,20479.388,83.2,srm_pkg,null,0,0,0,0,0,0,0
+  "Flow:Account",3040.037,3040.037,12.4,default,null,0,0,0,0,0,0,0
+  core_pkg,131.423,131.423,0.5,core_pkg,null,0,0,0,0,0,0,0
+  execute_anonymous_apex,24607.193,79.143,0.3,default,null,1,1,300,0,0,0,0
+  core_pkg,10.528,10.528,0,core_pkg,null,0,0,0,0,0,0,0
+  srm_pkg,10.032,10.032,0,srm_pkg,null,0,0,0,0,0,0,0
+  core_pkg,6.668,6.668,0,core_pkg,null,0,0,0,0,0,0,0
+  AccountService.createAccountsAndContacts(),24527.816,3.58,0,default,1,1,1,300,0,0,0,0
+  "System.Math.mod(Integer, Integer)",1.065,1.065,0,default,143,0,0,0,0,0,0,0
+  AccountService.getDayValue(Date),1.282,0.153,0,default,120,0,0,0,0,0,0,0
+recommendations[2]: "srm_pkg: dominates self time. Check whether it can be made faster, and how often it is called.","Flow:Account: dominates self time. Check whether it can be made faster, and how often it is called."

--- a/tests/eval/golden/analyze_apex_log_performance.minimal.expected.txt
+++ b/tests/eval/golden/analyze_apex_log_performance.minimal.expected.txt
@@ -1,0 +1,7 @@
+totalMethods: 2
+totalExecutionTime: 0.561
+topMethodsSelfPercentage: 100
+slowestMethods[2]{name,duration,selfDuration,selfPercentage,namespace,lineNumber,dmlCount,soqlCount,dmlRows,soqlRows,thrownCount,soslCount,soslRows}:
+  execute_anonymous_apex,0.546,0.546,97.3,default,null,0,0,0,0,0,0,0
+  EXECUTION_STARTED,0.561,0.015,2.7,default,null,0,0,0,0,0,0,0
+recommendations[1]: "execute_anonymous_apex: dominates self time. Check whether it can be made faster, and how often it is called."

--- a/tests/eval/golden/find_performance_bottlenecks.governor-heavy.expected.txt
+++ b/tests/eval/golden/find_performance_bottlenecks.governor-heavy.expected.txt
@@ -1,0 +1,11 @@
+cpuBottlenecks:
+  cpuTimeUsed: 15163
+  cpuTimeLimit: 10000
+  cpuUsagePercentage: 151.6
+  warning: High CPU usage - consider optimizing algorithms
+methodBottlenecks:
+  totalMethods: 13
+  methodsByNamespace[3]{namespace,methodCount,totalDuration}:
+    default,8,76786.322
+    core_pkg,3,148.619
+    srm_pkg,2,20489.42

--- a/tests/eval/golden/find_performance_bottlenecks.minimal.expected.txt
+++ b/tests/eval/golden/find_performance_bottlenecks.minimal.expected.txt
@@ -1,0 +1,4 @@
+methodBottlenecks:
+  totalMethods: 2
+  methodsByNamespace[1]{namespace,methodCount,totalDuration}:
+    default,2,1.107

--- a/tests/eval/golden/get_apex_log_summary.governor-heavy.expected.txt
+++ b/tests/eval/golden/get_apex_log_summary.governor-heavy.expected.txt
@@ -1,0 +1,38 @@
+size: 39532
+totalExecutionTime: 24608.108
+totalMethods: 11
+totalSOQLQueries: 1
+totalDMLOperations: 1
+totalSOQLRows: 0
+totalDMLRows: 300
+governorLimits[13]{name,used,limit}:
+  soqlQueries,5,100
+  soslQueries,0,20
+  queryRows,602,50000
+  dmlStatements,6,150
+  publishImmediateDml,0,150
+  dmlRows,1200,10000
+  cpuTime,15163,10000
+  heapSize,219591,6000000
+  callouts,0,100
+  emailInvocations,0,10
+  futureCalls,0,50
+  queueableJobsAddedToQueue,0,50
+  mobileApexPushCalls,0,10
+namespaces[3]: default,core_pkg,srm_pkg
+debugLevels[11]{category,level}:
+  APEX_CODE,FINE
+  APEX_PROFILING,FINE
+  CALLOUT,FINEST
+  DATA_ACCESS,INFO
+  DB,FINEST
+  NBA,FINE
+  SYSTEM,FINE
+  VALIDATION,INFO
+  VISUALFORCE,FINE
+  WAVE,FINE
+  WORKFLOW,FINE
+parsingErrors: 11
+logIssues[2]{type,summary}:
+  unexpected,Unexpected-Exit
+  error,"FATAL ERROR! cause=System.LimitException: Apex CPU time limit exceeded\n"

--- a/tests/eval/golden/get_apex_log_summary.minimal.expected.txt
+++ b/tests/eval/golden/get_apex_log_summary.minimal.expected.txt
@@ -1,0 +1,35 @@
+size: 1274
+totalExecutionTime: 0.561
+totalMethods: 1
+totalSOQLQueries: 0
+totalDMLOperations: 0
+totalSOQLRows: 0
+totalDMLRows: 0
+governorLimits[13]{name,used,limit}:
+  soqlQueries,0,100
+  soslQueries,0,20
+  queryRows,0,50000
+  dmlStatements,0,150
+  publishImmediateDml,0,150
+  dmlRows,0,10000
+  cpuTime,0,10000
+  heapSize,0,6000000
+  callouts,0,100
+  emailInvocations,0,10
+  futureCalls,0,50
+  queueableJobsAddedToQueue,0,50
+  mobileApexPushCalls,0,10
+namespaces[1]: default
+debugLevels[11]{category,level}:
+  APEX_CODE,FINE
+  APEX_PROFILING,NONE
+  CALLOUT,NONE
+  DATA_ACCESS,NONE
+  DB,NONE
+  NBA,NONE
+  SYSTEM,DEBUG
+  VALIDATION,NONE
+  VISUALFORCE,NONE
+  WAVE,NONE
+  WORKFLOW,NONE
+parsingErrors: 0

--- a/tests/executeAnonymous.test.ts
+++ b/tests/executeAnonymous.test.ts
@@ -227,7 +227,6 @@ describe("Execute Anonymous", () => {
       expect(decoded.success).toBe(true);
       expect(decoded.exceptionMessage).toBeUndefined();
       expect(decoded.durationMs).toBe(150);
-      expect(decoded.tip).toContain(".gitignore");
     });
 
     it("should throw error when connection username cannot be determined", async () => {
@@ -891,14 +890,29 @@ describe("Execute Anonymous", () => {
       expect(decoded.filePath).toContain(`${testLogId}.log`);
     });
 
-    it("should include gitignore tip in response", async () => {
+    it("should include the gitignore tip only when it created the output dir", async () => {
       const args: ExecuteAnonymousArgs = { apex: testApexCode };
 
-      const result = await executeAnonymous(mockServer, args, policy());
+      // mkdir resolves to the first directory it created, so a value here means the
+      // caller has a brand new directory that is not yet ignored by git.
+      mockMkdir.mockResolvedValueOnce("/project/.apex-log-mcp");
 
-      expect(toonDecode(result).tip).toBe(
-        "Add .apex-log-mcp/ to your .gitignore to avoid committing debug logs.",
-      );
+      expect(toonDecode(await executeAnonymous(mockServer, args, policy())).tip)
+        .toBe(
+          "Add .apex-log-mcp/ to your .gitignore to avoid committing debug logs.",
+        );
+    });
+
+    it("should omit the gitignore tip when the output dir already existed", async () => {
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+
+      // An existing directory has already been dealt with once, so repeating the
+      // advice on every run is noise the caller pays for.
+      mockMkdir.mockResolvedValueOnce(undefined);
+
+      expect(
+        toonDecode(await executeAnonymous(mockServer, args, policy())).tip,
+      ).toBeUndefined();
     });
   });
 

--- a/tests/findPerformanceBottlenecks.test.ts
+++ b/tests/findPerformanceBottlenecks.test.ts
@@ -229,7 +229,7 @@ describe("findPerformanceBottlenecks", () => {
         cpuTimeUsed: 8500,
         cpuTimeLimit: 10000,
         cpuUsagePercentage: 85,
-        warning: "High CPU usage detected - consider optimizing algorithms",
+        warning: "High CPU usage - consider optimizing algorithms",
       });
 
       // Verify database analysis - only soqlQueries should be present (>80%)
@@ -257,10 +257,9 @@ describe("findPerformanceBottlenecks", () => {
         ]),
       });
 
-      // Verify governor limit warnings exclude cpuTime (deduplicated with cpuBottlenecks)
-      expect(parsedResult.governorLimitWarnings).toBeDefined();
-      expect(parsedResult.governorLimitWarnings!.cpuTime).toBeUndefined();
-      expect(parsedResult.governorLimitWarnings!.soqlQueries).toBeDefined();
+      // cpuTime and soqlQueries are the only limits over threshold and both already
+      // have a dedicated section, so there is nothing left to warn about.
+      expect(parsedResult.governorLimitWarnings).toBeUndefined();
     });
 
     it('should use "all" as default when analysisType is not specified', async () => {
@@ -305,7 +304,7 @@ describe("findPerformanceBottlenecks", () => {
         cpuTimeUsed: 9000,
         cpuTimeLimit: 10000,
         cpuUsagePercentage: 90,
-        warning: "High CPU usage detected - consider optimizing algorithms",
+        warning: "High CPU usage - consider optimizing algorithms",
       });
     });
 
@@ -530,24 +529,22 @@ describe("findPerformanceBottlenecks", () => {
       const result = await findPerformanceBottlenecks(args);
       const parsedResult = toonDecode(result);
 
-      // cpuTime excluded from governorLimitWarnings (deduplicated with cpuBottlenecks)
+      // Every limit a dedicated section already spelled out is left out here rather
+      // than reported a second time: cpuTime by cpuBottlenecks, the rest by
+      // databaseBottlenecks.
       expect(parsedResult.governorLimitWarnings!.cpuTime).toBeUndefined();
-      // Other limits should be present as structured data
-      expect(parsedResult.governorLimitWarnings!.soqlQueries).toMatchObject({
-        used: 90,
-        limit: 100,
-      });
-      expect(parsedResult.governorLimitWarnings!.dmlStatements).toMatchObject({
-        used: 135,
-        limit: 150,
-      });
-      expect(parsedResult.governorLimitWarnings!.queryRows).toMatchObject({
-        used: 45000,
-        limit: 50000,
-      });
+      expect(parsedResult.governorLimitWarnings!.soqlQueries).toBeUndefined();
+      expect(parsedResult.governorLimitWarnings!.dmlStatements).toBeUndefined();
+      expect(parsedResult.governorLimitWarnings!.queryRows).toBeUndefined();
+      // heapSize has no dedicated section, so it is only reported here.
       expect(parsedResult.governorLimitWarnings!.heapSize).toMatchObject({
         used: 5100000,
         limit: 6000000,
+      });
+      expect(parsedResult.databaseBottlenecks).toMatchObject({
+        soqlQueries: { used: 90, limit: 100, percentage: 90 },
+        dmlStatements: { used: 135, limit: 150, percentage: 90 },
+        queryRows: { used: 45000, limit: 50000, percentage: 90 },
       });
     });
 
@@ -706,7 +703,7 @@ describe("findPerformanceBottlenecks", () => {
 
       // Should identify all bottleneck types
       expect(parsedResult.cpuBottlenecks!.warning).toBe(
-        "High CPU usage detected - consider optimizing algorithms",
+        "High CPU usage - consider optimizing algorithms",
       );
       expect(parsedResult.cpuBottlenecks!.cpuUsagePercentage).toBe(95);
 
@@ -722,14 +719,11 @@ describe("findPerformanceBottlenecks", () => {
       expect(methodBottlenecks.totalMethods).toBe(2);
       expect(methodBottlenecks.methodsByNamespace).toHaveLength(2);
 
-      // Governor warnings should have non-CPU limits as structured data
-      expect(parsedResult.governorLimitWarnings).toBeDefined();
-      expect(parsedResult.governorLimitWarnings!.soqlQueries).toMatchObject({
-        used: 95,
-        limit: 100,
+      // Only heapSize is left to warn about: every other limit over threshold was
+      // already detailed by the CPU or database section.
+      expect(parsedResult.governorLimitWarnings).toEqual({
+        heapSize: { used: 5500000, limit: 6000000 },
       });
-      // cpuTime excluded from governorLimitWarnings (deduplicated)
-      expect(parsedResult.governorLimitWarnings!.cpuTime).toBeUndefined();
     });
 
     it("should handle optimal performance scenario", async () => {

--- a/tests/getLogSummary.test.ts
+++ b/tests/getLogSummary.test.ts
@@ -3,7 +3,6 @@
  */
 
 import { promises as fs } from "fs";
-import path from "path";
 
 import { getLogSummary, LogSummaryArgs } from "../src/tools/getLogSummary";
 import {
@@ -25,16 +24,11 @@ jest.mock("fs", () => ({
   },
 }));
 
-jest.mock("path", () => ({
-  basename: jest.fn(),
-}));
-
 jest.mock("../src/ApexLogParser", () => ({
   parse: jest.fn(),
 }));
 
 const mockFs = fs as jest.Mocked<typeof fs>;
-const mockPath = path as jest.Mocked<typeof path>;
 const mockParse = parse as jest.MockedFunction<typeof parse>;
 
 // Helper function to create a mock LogLine
@@ -177,7 +171,6 @@ describe("getLogSummary", () => {
 
       mockFs.access.mockResolvedValue(undefined);
       mockFs.readFile.mockResolvedValue(mockLogContent);
-      mockPath.basename.mockReturnValue("test-log.log");
       mockParse.mockReturnValue(mockApexLog);
 
       const args: LogSummaryArgs = {
@@ -191,14 +184,11 @@ describe("getLogSummary", () => {
         "/path/to/test-log.log",
         "utf-8",
       );
-      expect(mockPath.basename).toHaveBeenCalledWith("/path/to/test-log.log");
       expect(mockParse).toHaveBeenCalledWith(mockLogContent);
 
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.file).toBe("test-log.log");
       expect(parsedResult.size).toBe(15000);
-      expect(parsedResult.debugLevels).toEqual([]);
       expect(parsedResult.totalExecutionTime).toBe(12500); // ms
       expect(parsedResult.totalMethods).toBe(3); // 2 METHOD_ENTRY + 1 with subCategory 'Method'
       expect(parsedResult.totalSOQLQueries).toBe(5);
@@ -206,35 +196,41 @@ describe("getLogSummary", () => {
       expect(parsedResult.totalSOQLRows).toBe(150);
       expect(parsedResult.totalDMLRows).toBe(25);
       expect(parsedResult.namespaces).toEqual(["default", "MyNamespace"]);
-      expect(parsedResult.logIssues).toEqual([]);
+      // The only omission: the log contained no issues, and an absent list says so.
+      expect(parsedResult.logIssues).toBeUndefined();
       expect(parsedResult.parsingErrors).toBe(0);
 
-      // Governor limits: only those with used > 0 or limit > 0
-      expect(parsedResult.governorLimits.cpuTime).toEqual({
+      // Every limit is a row, whether or not anything was spent against it.
+      expect(parsedResult.governorLimits).toHaveLength(13);
+      expect(parsedResult.governorLimits).toContainEqual({
+        name: "cpuTime",
         used: 1500,
         limit: 10000,
       });
-      expect(parsedResult.governorLimits.soqlQueries).toEqual({
-        used: 5,
-        limit: 100,
-      });
-      expect(parsedResult.governorLimits.dmlStatements).toEqual({
+      expect(parsedResult.governorLimits).toContainEqual({
+        name: "dmlStatements",
         used: 3,
         limit: 150,
       });
+      expect(parsedResult.governorLimits).toContainEqual({
+        name: "callouts",
+        used: 0,
+        limit: 100,
+      });
     });
 
-    it("should map debugLevels to compact category/level objects", async () => {
+    it("should report every log category and its level", async () => {
       const mockApexLog = createMockApexLog({
         debugLevels: [
           { logCategory: "Apex_code", logLevel: "DEBUG" },
           { logCategory: "System", logLevel: "INFO" },
+          { logCategory: "Callout", logLevel: "NONE" },
+          { logCategory: "Workflow", logLevel: "NONE" },
         ] as any,
       });
 
       mockFs.access.mockResolvedValue(undefined);
       mockFs.readFile.mockResolvedValue("mock log content");
-      mockPath.basename.mockReturnValue("debug-levels.log");
       mockParse.mockReturnValue(mockApexLog);
 
       const args: LogSummaryArgs = {
@@ -244,9 +240,13 @@ describe("getLogSummary", () => {
       const result = await getLogSummary(args);
       const parsedResult = toonDecode(result);
 
+      // The levels tie log content to log configuration: what was captured, and
+      // what is missing because a category was switched off.
       expect(parsedResult.debugLevels).toEqual([
         { category: "Apex_code", level: "DEBUG" },
         { category: "System", level: "INFO" },
+        { category: "Callout", level: "NONE" },
+        { category: "Workflow", level: "NONE" },
       ]);
     });
 
@@ -257,7 +257,6 @@ describe("getLogSummary", () => {
 
       mockFs.access.mockResolvedValue(undefined);
       mockFs.readFile.mockResolvedValue("mock log content");
-      mockPath.basename.mockReturnValue("namespace-test.log");
       mockParse.mockReturnValue(mockApexLog);
 
       const args: LogSummaryArgs = {
@@ -272,7 +271,6 @@ describe("getLogSummary", () => {
         "CustomApp",
         "ThirdParty",
       ]);
-      expect(parsedResult.file).toBe("namespace-test.log");
     });
 
     it("should include log issues as array of {type, summary} objects", async () => {
@@ -292,7 +290,6 @@ describe("getLogSummary", () => {
 
       mockFs.access.mockResolvedValue(undefined);
       mockFs.readFile.mockResolvedValue("mock log content");
-      mockPath.basename.mockReturnValue("error-log.log");
       mockParse.mockReturnValue(mockApexLog);
 
       const args: LogSummaryArgs = {
@@ -327,7 +324,6 @@ describe("getLogSummary", () => {
 
       mockFs.access.mockResolvedValue(undefined);
       mockFs.readFile.mockResolvedValue("mock log content");
-      mockPath.basename.mockReturnValue("nested-methods.log");
       mockParse.mockReturnValue(mockApexLog);
 
       const args: LogSummaryArgs = {
@@ -372,7 +368,6 @@ describe("getLogSummary", () => {
 
       mockFs.access.mockResolvedValue(undefined);
       mockFs.readFile.mockResolvedValue("mock log content");
-      mockPath.basename.mockReturnValue("empty-log.log");
       mockParse.mockReturnValue(mockApexLog);
 
       const args: LogSummaryArgs = {
@@ -382,44 +377,41 @@ describe("getLogSummary", () => {
       const result = await getLogSummary(args);
       const parsedResult = toonDecode(result);
 
+      // "Nothing ran" is an answer, and only a reported zero gives it. An absent
+      // counter cannot be told apart from one the parser never populated.
       expect(parsedResult.totalExecutionTime).toBe(0);
       expect(parsedResult.totalMethods).toBe(0);
       expect(parsedResult.totalSOQLQueries).toBe(0);
       expect(parsedResult.totalDMLOperations).toBe(0);
       expect(parsedResult.totalSOQLRows).toBe(0);
       expect(parsedResult.totalDMLRows).toBe(0);
-      // All limits are 0/0, so governorLimits should be empty
-      expect(parsedResult.governorLimits).toEqual({});
+      expect(parsedResult.governorLimits).toHaveLength(13);
+      expect(parsedResult.governorLimits).toContainEqual({
+        name: "dmlStatements",
+        used: 0,
+        limit: 0,
+      });
     });
 
-    it("should handle different file paths and extensions", async () => {
-      const testCases = [
-        {
-          path: "/Users/test/apex-debug-123.log",
-          expected: "apex-debug-123.log",
-        },
-        { path: "C:\\Logs\\production.log", expected: "production.log" },
-        { path: "/var/logs/debug-output.txt", expected: "debug-output.txt" },
-        { path: "simple.log", expected: "simple.log" },
+    it("should not echo the log file path back to the caller", async () => {
+      const paths = [
+        "/Users/test/apex-debug-123.log",
+        "C:\\Logs\\production.log",
+        "/var/logs/debug-output.txt",
+        "simple.log",
       ];
 
-      for (const testCase of testCases) {
-        const mockApexLog = createMockApexLog();
-
+      for (const logFilePath of paths) {
         mockFs.access.mockResolvedValue(undefined);
         mockFs.readFile.mockResolvedValue("mock log content");
-        mockPath.basename.mockReturnValue(testCase.expected);
-        mockParse.mockReturnValue(mockApexLog);
+        mockParse.mockReturnValue(createMockApexLog());
 
-        const args: LogSummaryArgs = {
-          logFilePath: testCase.path,
-        };
-
-        const result = await getLogSummary(args);
+        const result = await getLogSummary({ logFilePath });
         const parsedResult = toonDecode(result);
 
-        expect(parsedResult.file).toBe(testCase.expected);
-        expect(mockPath.basename).toHaveBeenCalledWith(testCase.path);
+        // The caller supplied the path, so repeating it back only costs tokens.
+        expect(parsedResult.file).toBeUndefined();
+        expect(mockFs.readFile).toHaveBeenCalledWith(logFilePath, "utf-8");
       }
     });
   });
@@ -506,7 +498,6 @@ describe("getLogSummary", () => {
 
       mockFs.access.mockResolvedValue(undefined);
       mockFs.readFile.mockResolvedValue("mock log content");
-      mockPath.basename.mockReturnValue("edge-case.log");
       mockParse.mockReturnValue(mockApexLog);
 
       const args: LogSummaryArgs = {
@@ -516,10 +507,11 @@ describe("getLogSummary", () => {
       const result = await getLogSummary(args);
       const parsedResult = toonDecode(result);
 
+      // `logIssues` is the one occurrence list, so it is the one key that goes
+      // away. The rest are part of the fixed schema and report their emptiness.
+      expect(parsedResult.logIssues).toBeUndefined();
       expect(parsedResult.namespaces).toEqual([]);
-      expect(parsedResult.logIssues).toEqual([]);
       expect(parsedResult.parsingErrors).toBe(0);
-      expect(parsedResult.file).toBe("edge-case.log");
     });
   });
 
@@ -540,7 +532,6 @@ describe("getLogSummary", () => {
 
       mockFs.access.mockResolvedValue(undefined);
       mockFs.readFile.mockResolvedValue("mock log content");
-      mockPath.basename.mockReturnValue("method-counting.log");
       mockParse.mockReturnValue(mockApexLog);
 
       const args: LogSummaryArgs = {
@@ -577,7 +568,6 @@ describe("getLogSummary", () => {
 
       mockFs.access.mockResolvedValue(undefined);
       mockFs.readFile.mockResolvedValue("mock log content");
-      mockPath.basename.mockReturnValue("deep-nested.log");
       mockParse.mockReturnValue(mockApexLog);
 
       const args: LogSummaryArgs = {
@@ -606,7 +596,6 @@ describe("getLogSummary", () => {
 
       mockFs.access.mockResolvedValue(undefined);
       mockFs.readFile.mockResolvedValue("mock log content");
-      mockPath.basename.mockReturnValue("non-methods.log");
       mockParse.mockReturnValue(mockApexLog);
 
       const args: LogSummaryArgs = {
@@ -621,7 +610,7 @@ describe("getLogSummary", () => {
   });
 
   describe("governor limits handling", () => {
-    it("should include all governor limits with used > 0 or limit > 0", async () => {
+    it("should report every governor limit as a row", async () => {
       const customGovernorLimits: GovernorLimits = {
         soqlQueries: { used: 50, limit: 100 },
         soslQueries: { used: 5, limit: 20 },
@@ -645,7 +634,6 @@ describe("getLogSummary", () => {
 
       mockFs.access.mockResolvedValue(undefined);
       mockFs.readFile.mockResolvedValue("mock log content");
-      mockPath.basename.mockReturnValue("governor-limits.log");
       mockParse.mockReturnValue(mockApexLog);
 
       const args: LogSummaryArgs = {
@@ -655,40 +643,24 @@ describe("getLogSummary", () => {
       const result = await getLogSummary(args);
       const parsedResult = toonDecode(result);
 
-      // All limits with used > 0 or limit > 0 should be included
-      expect(parsedResult.governorLimits.cpuTime).toEqual({
-        used: 8000,
-        limit: 10000,
-      });
-      expect(parsedResult.governorLimits.heapSize).toEqual({
-        used: 5000000,
-        limit: 6000000,
-      });
-      expect(parsedResult.governorLimits.soqlQueries).toEqual({
-        used: 50,
-        limit: 100,
-      });
-      expect(parsedResult.governorLimits.dmlStatements).toEqual({
-        used: 25,
-        limit: 150,
-      });
-      expect(parsedResult.governorLimits.queryRows).toEqual({
-        used: 2500,
-        limit: 50000,
-      });
-      expect(parsedResult.governorLimits.callouts).toEqual({
-        used: 3,
-        limit: 100,
-      });
-      expect(parsedResult.governorLimits.dmlRows).toEqual({
-        used: 500,
-        limit: 10000,
-      });
-      // mobileApexPushCalls has used: 0, limit: 10 — included since limit > 0
-      expect(parsedResult.governorLimits.mobileApexPushCalls).toEqual({
-        used: 0,
-        limit: 10,
-      });
+      // The whole fixed set, flattened to rows that share three keys so TOON can
+      // emit one header and one line per limit.
+      expect(parsedResult.governorLimits).toEqual([
+        { name: "soqlQueries", used: 50, limit: 100 },
+        { name: "soslQueries", used: 5, limit: 20 },
+        { name: "queryRows", used: 2500, limit: 50000 },
+        { name: "dmlStatements", used: 25, limit: 150 },
+        { name: "publishImmediateDml", used: 2, limit: 10 },
+        { name: "dmlRows", used: 500, limit: 10000 },
+        { name: "cpuTime", used: 8000, limit: 10000 },
+        { name: "heapSize", used: 5000000, limit: 6000000 },
+        { name: "callouts", used: 3, limit: 100 },
+        { name: "emailInvocations", used: 1, limit: 10 },
+        { name: "futureCalls", used: 2, limit: 50 },
+        { name: "queueableJobsAddedToQueue", used: 1, limit: 50 },
+        // Nothing was spent against this one, and the row says exactly that.
+        { name: "mobileApexPushCalls", used: 0, limit: 10 },
+      ]);
     });
 
     it("should handle maximum governor limit values", async () => {
@@ -715,7 +687,6 @@ describe("getLogSummary", () => {
 
       mockFs.access.mockResolvedValue(undefined);
       mockFs.readFile.mockResolvedValue("mock log content");
-      mockPath.basename.mockReturnValue("max-limits.log");
       mockParse.mockReturnValue(mockApexLog);
 
       const args: LogSummaryArgs = {
@@ -725,14 +696,21 @@ describe("getLogSummary", () => {
       const result = await getLogSummary(args);
       const parsedResult = toonDecode(result);
 
-      expect(parsedResult.governorLimits.cpuTime.used).toBe(10000);
-      expect(parsedResult.governorLimits.cpuTime.limit).toBe(10000);
-      expect(parsedResult.governorLimits.heapSize.used).toBe(6000000);
-      expect(parsedResult.governorLimits.heapSize.limit).toBe(6000000);
-      expect(parsedResult.governorLimits.soqlQueries.used).toBe(100);
-      expect(parsedResult.governorLimits.soqlQueries.limit).toBe(100);
-      expect(parsedResult.governorLimits.dmlStatements.used).toBe(150);
-      expect(parsedResult.governorLimits.dmlStatements.limit).toBe(150);
+      // Every limit is at its ceiling, so `used` and `limit` match on every row.
+      expect(parsedResult.governorLimits).toHaveLength(13);
+      for (const row of parsedResult.governorLimits) {
+        expect(row.used).toBe(row.limit);
+      }
+      expect(parsedResult.governorLimits).toContainEqual({
+        name: "cpuTime",
+        used: 10000,
+        limit: 10000,
+      });
+      expect(parsedResult.governorLimits).toContainEqual({
+        name: "heapSize",
+        used: 6000000,
+        limit: 6000000,
+      });
     });
   });
 });

--- a/tests/responseShaping.test.ts
+++ b/tests/responseShaping.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+import {
+  isEmptyValue,
+  omitEmpty,
+  roundMs,
+  roundPercent,
+  toLimitRows,
+} from "../src/tools/responseShaping";
+import type { GovernorLimits, Limits } from "../src/ApexLogParser";
+
+describe("responseShaping", () => {
+  describe("roundMs", () => {
+    it("should keep microsecond resolution", () => {
+      expect(roundMs(1.2345678)).toBe(1.235);
+      expect(roundMs(0.0004)).toBe(0);
+    });
+
+    it("should drop the float noise that division introduces", () => {
+      expect(roundMs(1234567 / 1_000_000)).toBe(1.235);
+      expect(roundMs(0.1 + 0.2)).toBe(0.3);
+    });
+
+    it("should leave whole numbers alone", () => {
+      expect(roundMs(500)).toBe(500);
+      expect(roundMs(0)).toBe(0);
+    });
+  });
+
+  describe("roundPercent", () => {
+    it("should round to one decimal place", () => {
+      expect(roundPercent(93.333333)).toBe(93.3);
+      expect(roundPercent(85)).toBe(85);
+      expect(roundPercent(0.04)).toBe(0);
+    });
+  });
+
+  describe("isEmptyValue", () => {
+    it.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["zero", 0],
+      ["the empty string", ""],
+      ["an empty array", []],
+      ["an empty object", {}],
+    ])("should treat %s as empty", (_label, value) => {
+      expect(isEmptyValue(value)).toBe(true);
+    });
+
+    it.each([
+      ["a non-zero number", 1],
+      ["a negative number", -1],
+      ["a non-empty string", "default"],
+      ["a populated array", [0]],
+      ["a populated object", { used: 0 }],
+    ])("should treat %s as carrying information", (_label, value) => {
+      expect(isEmptyValue(value)).toBe(false);
+    });
+
+    it("should treat false as an answer rather than an absence", () => {
+      // A zero count and an absent count mean the same thing; `success: false` and
+      // an absent `success` do not.
+      expect(isEmptyValue(false)).toBe(false);
+    });
+  });
+
+  describe("omitEmpty", () => {
+    it("should drop only the keys that carry no information", () => {
+      expect(
+        omitEmpty({
+          totalMethods: 3,
+          totalSOQLQueries: 0,
+          namespaces: [],
+          governorLimits: {},
+          note: "",
+          parsingErrors: null,
+          success: false,
+        }),
+      ).toEqual({ totalMethods: 3, success: false });
+    });
+
+    it("should return an empty object when nothing survives", () => {
+      expect(omitEmpty({ a: 0, b: [] })).toEqual({});
+    });
+  });
+
+  describe("toLimitRows", () => {
+    const limitNames: (keyof Limits)[] = [
+      "soqlQueries",
+      "soslQueries",
+      "queryRows",
+      "dmlStatements",
+      "publishImmediateDml",
+      "dmlRows",
+      "cpuTime",
+      "heapSize",
+      "callouts",
+      "emailInvocations",
+      "futureCalls",
+      "queueableJobsAddedToQueue",
+      "mobileApexPushCalls",
+    ];
+
+    const buildLimits = (
+      used: Partial<Record<keyof Limits, number>> = {},
+    ): GovernorLimits =>
+      ({
+        ...Object.fromEntries(
+          limitNames.map((name) => [
+            name,
+            { used: used[name] ?? 0, limit: 100 },
+          ]),
+        ),
+        byNamespace: new Map(),
+      }) as GovernorLimits;
+
+    it("should return one row per limit in parser order", () => {
+      const rows = toLimitRows(buildLimits());
+
+      expect(rows).toHaveLength(limitNames.length);
+      expect(rows.map((row) => row.name)).toEqual(limitNames);
+    });
+
+    it("should keep a limit nothing was spent against", () => {
+      // "How many DML statements were consumed?" has to be answerable with
+      // "none". An absent row cannot say that.
+      const rows = toLimitRows(buildLimits({ cpuTime: 15163 }));
+
+      expect(rows).toContainEqual({
+        name: "dmlStatements",
+        used: 0,
+        limit: 100,
+      });
+      expect(rows).toContainEqual({ name: "cpuTime", used: 15163, limit: 100 });
+    });
+
+    it("should skip byNamespace, which is not a limit", () => {
+      expect(toLimitRows(buildLimits()).map((row) => row.name)).not.toContain(
+        "byNamespace",
+      );
+    });
+  });
+});


### PR DESCRIPTION
Stacked on #78. Its head branch lives in the fork, so GitHub cannot use it as a base — this PR targets `main` and therefore shows #78's commit in its diff too. It will be rebased once #78 merges. **Review only the second commit here.**

Shrinks what the analysis tools return, guided by MCP/Anthropic tool-design practice, **without losing a single fact**.

## The rule this follows

**Restructure before you delete.** Measured with the real encoder on the 13 governor limits of a 19 MB log:

| `governorLimits`, 13 entries | tokens | can answer "0 DML statements"? |
| --- | --- | --- |
| Nested objects, all 13 (before) | ~151 | yes |
| Nested objects, `used > 0` only | ~42 | **no** |
| **Flat `{name, used, limit}` table, all 13** | **~84** | yes |

The flat table is 45% cheaper than the nested form *and* complete. Dropping the zero rows buys 42 more tokens and costs the answer, so it doesn't.

Alongside it: a fixed-schema field is always reported, even at zero (an absent count cannot be told apart from one that was never parsed); only occurrence lists are omitted when empty; never state the same figure twice; round to the precision someone acts on.

## Measured result

On `sample-log.log` (19 MB), against this branch's base:

| Tool | before | after | delta |
| --- | --- | --- | --- |
| `get_apex_log_summary` | ~305 tok | ~233 | −24% |
| `analyze_apex_log_performance` | ~420 tok | ~294 | −30% |
| `find_performance_bottlenecks` | ~93 tok | ~87 | −6% |
| **total** | **~818** | **~614** | **−25%** |

## What was removed

Only the redundant:

- `file` — the caller supplied the path.
- The prose `summary` on `analyze_apex_log_performance`, which restated its own table. Its one unique fact — what share of the run the returned methods account for — is now the scalar `topMethodsSelfPercentage` (~8 tokens where the paragraph was ~55).
- A governor limit warned about in two sections at once.
- Float tails: `62.569866677679975` becomes `62.57`.
- `recommendations` when nothing stands out. It no longer says *"Performance looks good! No obvious bottlenecks detected"* on a log that exceeded the CPU limit by 51% and died with a `FATAL_ERROR`.

Everything else is intact: all 13 governor limits, all 11 debug levels, every method column, both `logIssues`.

## The gate

`pnpm run eval` (`scripts/eval.mjs`, wired into CI) drives the **built** server over stdio against committed fixtures and asserts four things per (tool, fixture): realistic user questions are still answerable, no figure is reported twice, the payload is under a token budget, and it matches its golden file.

The jest suite cannot do this — `moduleNameMapper` swaps `@toon-format/toon` for a JSON stand-in, so it never sees the real encoding.

It was verified to fire on real injected regressions: restoring the `used > 0` filter produces *"cannot answer 'How many DML statements and SOQL queries were consumed?'"* plus 13 zero-row failures and a golden diff; reintroducing a prose summary produces *"totalExecutionTime (24608.108) is restated in prose"*.

## Verification

- `pnpm run build` ✅
- `pnpm run lint` ✅
- `pnpm test` — 239 tests, 12 suites ✅ (coverage 97%)
- `pnpm run eval` — 6/6 ✅

Docs updated: CHANGELOG, README Tools Reference, DEVELOPING (the "Shaping Tool Responses" section rewritten around the rule above), CLAUDE.md, and a new `tests/eval/README.md` recording fixture provenance.

## Not in scope

`outputSchema` / `structuredContent` — the MCP spec asks for the payload to also be serialized into a text block, which would send it twice. Tracked separately.
