### PR TITLE
ci: run on pull requests onto any base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches: [main, release/**]
+  # No branch filter: a pull request onto any base, including a stacked PR
+  # onto another feature branch, must be checked before it is merged.
   pull_request:
-    branches: [main, release/**]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The `pull_request` trigger was filtered to `main` and `release/**`, so a PR stacked onto another feature branch got **no** lint, build, test or eval run — #81 and #83 both show zero checks today, and would merge unchecked.

Dropping the filter makes every pull request run CI, whatever its base. The `push` trigger keeps its `main` / `release/**` filter, so pushing a feature branch still does not start a second, duplicate run.

One line, no job changed.