### PR TITLE
perf(tools): parse a log once and count methods one way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _If you are upgrading from 1.x: please see [Migrating from 1.x](README.md#migrat
 - Make the `execute_anonymous` tool always discoverable, so agents can find it without server flags ([#52])
 - Reduce every tool response with no fact lost: `analyze_apex_log_performance` by 33%, `execute_anonymous` by 30% after the first run, `get_apex_log_summary` by 27% and `find_performance_bottlenecks` by 5% ([#86])
 - Reduce the standing cost of having the server connected by 31%, with no tool renamed, no parameter removed and no response changed: `execute_anonymous` by 49%, `find_performance_bottlenecks` by 12%, `get_apex_log_summary` by 11% and `analyze_apex_log_performance` by 4% ([#87])
-- Parse a log once rather than once per tool, cached by path, inode, size, modification time and change time, so a summary followed by a deeper tool no longer reads and parses the file again ([#88])
+- Parse a log once rather than once per tool, cached by path, inode, size, modification time and change time, so a summary followed by a deeper tool no longer reads and parses the file again. The parse is dropped after five minutes unused, so a large log is not held for the life of the session ([#88])
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _If you are upgrading from 1.x: please see [Migrating from 1.x](README.md#migrat
 - Make the `execute_anonymous` tool always discoverable, so agents can find it without server flags ([#52])
 - Reduce every tool response with no fact lost: `analyze_apex_log_performance` by 33%, `execute_anonymous` by 30% after the first run, `get_apex_log_summary` by 27% and `find_performance_bottlenecks` by 5% ([#86])
 - Reduce the standing cost of having the server connected by 31%, with no tool renamed, no parameter removed and no response changed: `execute_anonymous` by 49%, `find_performance_bottlenecks` by 12%, `get_apex_log_summary` by 11% and `analyze_apex_log_performance` by 4% ([#87])
+- Parse a log once rather than once per tool, cached by path, size and modification time, so a summary followed by a deeper tool no longer reads and parses the file again ([#88])
 
 ### Added
 
@@ -34,6 +35,7 @@ _If you are upgrading from 1.x: please see [Migrating from 1.x](README.md#migrat
 
 - Declare `execute_anonymous` destructive, so clients stop treating it as safe to run unprompted ([#52])
 - Stop `analyze_apex_log_performance` reporting that performance looks good on a log that exhausted the CPU limit ([#86])
+- Report the same `totalMethods` from all three analysis tools; `get_apex_log_summary` did not count entry points, so it reported fewer methods than the other two ([#88])
 
 ## [1.0.0] - 2026-03-20
 
@@ -52,3 +54,4 @@ _If you are upgrading from 1.x: please see [Migrating from 1.x](README.md#migrat
 [#52]: https://github.com/certinia/debug-log-analyzer-mcp/issues/52
 [#86]: https://github.com/certinia/debug-log-analyzer-mcp/issues/86
 [#87]: https://github.com/certinia/debug-log-analyzer-mcp/issues/87
+[#88]: https://github.com/certinia/debug-log-analyzer-mcp/issues/88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ _If you are upgrading from 1.x: please see [Migrating from 1.x](README.md#migrat
 
 - Declare `execute_anonymous` destructive, so clients stop treating it as safe to run unprompted ([#52])
 - Stop `analyze_apex_log_performance` reporting that performance looks good on a log that exhausted the CPU limit ([#86])
-- Report the same `totalMethods` from all three analysis tools; `get_apex_log_summary` did not count entry points, so it reported fewer methods than the other two ([#88])
+- Report the same `totalMethods` from all three analysis tools on an unfiltered call; `get_apex_log_summary` did not count entry points, so it reported fewer methods than the other two ([#88])
 
 ## [1.0.0] - 2026-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _If you are upgrading from 1.x: please see [Migrating from 1.x](README.md#migrat
 - Make the `execute_anonymous` tool always discoverable, so agents can find it without server flags ([#52])
 - Reduce every tool response with no fact lost: `analyze_apex_log_performance` by 33%, `execute_anonymous` by 30% after the first run, `get_apex_log_summary` by 27% and `find_performance_bottlenecks` by 5% ([#86])
 - Reduce the standing cost of having the server connected by 31%, with no tool renamed, no parameter removed and no response changed: `execute_anonymous` by 49%, `find_performance_bottlenecks` by 12%, `get_apex_log_summary` by 11% and `analyze_apex_log_performance` by 4% ([#87])
-- Parse a log once rather than once per tool, cached by path, size and modification time, so a summary followed by a deeper tool no longer reads and parses the file again ([#88])
+- Parse a log once rather than once per tool, cached by path, inode, size, modification time and change time, so a summary followed by a deeper tool no longer reads and parses the file again ([#88])
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ pnpm start
 
 - **src/tools/responseShaping.ts**: Shared helpers for keeping responses lean — `omitEmpty`, `toLimitRows`, `roundMs`, `roundPercent`, `NS_TO_MS`
 
-- **src/tools/apexLogSource.ts**: The one way the three analysis tools get a log — `loadApexLog` (reads and parses, caching the last parse by path and a fingerprint of everything `fs.stat` can see — inode, size, and modification and change time in nanoseconds, so a `cp -p` that keeps the modification time still misses; the slot holds the in-flight promise, so concurrent callers share one parse and a failed read is not kept), `isMethodNode` (the one method test, so the tools agree on `totalMethods`) and `walkLog`
+- **src/tools/apexLogSource.ts**: The one way the three analysis tools get a log — `loadApexLog` (reads and parses, caching the last parse by path and a fingerprint of everything `fs.stat` can see — inode, size, and modification and change time in nanoseconds, so a `cp -p` that keeps the modification time still misses; the slot holds the in-flight promise, so concurrent callers share one parse and a failed read is not kept; it is dropped five minutes after its last use, on an `unref`ed timer, because a parsed log holds four to five times the size of the file), `isMethodNode` (the one method test, so the tools agree on `totalMethods`) and `walkLog`
 
 - **src/ApexLogParser.ts**: Complex log parsing engine (33k+ tokens)
   - Exports `parse()` function and `ApexLogParser` class

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ pnpm start
 
 - **src/tools/responseShaping.ts**: Shared helpers for keeping responses lean — `omitEmpty`, `toLimitRows`, `roundMs`, `roundPercent`, `NS_TO_MS`
 
-- **src/tools/apexLogSource.ts**: The one way the three analysis tools get a log — `loadApexLog` (reads and parses, caching the last parse by path and a fingerprint of everything `fs.stat` can see — inode, size, and modification and change time in nanoseconds, so a `cp -p` that keeps the modification time still misses; the slot holds the in-flight promise, so concurrent callers share one parse and a failed read is not kept; it is dropped five minutes after its last use, on an `unref`ed timer, because a parsed log holds four to five times the size of the file), `isMethodNode` (the one method test, so the tools agree on `totalMethods`) and `walkLog`
+- **src/tools/apexLogSource.ts**: The one way the three analysis tools get a log — `loadApexLog` (reads and parses, caching the last parse by path and a fingerprint of everything a stat can see — inode, size, and modification and change time in nanoseconds, so a `cp -p` that keeps the modification time still misses; the file is opened once and both the stat and the read go to that handle, so nothing can put a different file at the path between the two; the slot holds the in-flight promise, so concurrent callers share one parse and a failed read is not kept; it is dropped five minutes after its last use, on an `unref`ed timer, because a parsed log holds four to five times the size of the file), `isMethodNode` (the one method test, so the tools agree on `totalMethods`) and `walkLog`
 
 - **src/ApexLogParser.ts**: Complex log parsing engine (33k+ tokens)
   - Exports `parse()` function and `ApexLogParser` class

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ pnpm start
 
 - **src/tools/responseShaping.ts**: Shared helpers for keeping responses lean — `omitEmpty`, `toLimitRows`, `roundMs`, `roundPercent`, `NS_TO_MS`
 
-- **src/tools/apexLogSource.ts**: The one way the three analysis tools get a log — `loadApexLog` (reads and parses, caching the last parse by path, size and modification time; the slot holds the in-flight promise, so concurrent callers share one parse and a failed read is not kept), `isMethodNode` (the one method test, so the tools agree on `totalMethods`) and `walkLog`
+- **src/tools/apexLogSource.ts**: The one way the three analysis tools get a log — `loadApexLog` (reads and parses, caching the last parse by path and a fingerprint of everything `fs.stat` can see — inode, size, and modification and change time in nanoseconds, so a `cp -p` that keeps the modification time still misses; the slot holds the in-flight promise, so concurrent callers share one parse and a failed read is not kept), `isMethodNode` (the one method test, so the tools agree on `totalMethods`) and `walkLog`
 
 - **src/ApexLogParser.ts**: Complex log parsing engine (33k+ tokens)
   - Exports `parse()` function and `ApexLogParser` class

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,9 @@ pnpm start
   - Uses stdio transport for communication
   - Handles file validation, log parsing, analysis, and anonymous Apex execution
 
-- **src/tools/responseShaping.ts**: Shared helpers for keeping responses lean — `omitEmpty`, `toLimitRows`, `roundMs`, `roundPercent`
+- **src/tools/responseShaping.ts**: Shared helpers for keeping responses lean — `omitEmpty`, `toLimitRows`, `roundMs`, `roundPercent`, `NS_TO_MS`
+
+- **src/tools/apexLogSource.ts**: The one way the three analysis tools get a log — `loadApexLog` (reads and parses, caching the last parse by path, size and modification time), `isMethodNode` (the one method test, so the tools agree on `totalMethods`) and `walkLog`
 
 - **src/ApexLogParser.ts**: Complex log parsing engine (33k+ tokens)
   - Exports `parse()` function and `ApexLogParser` class

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ pnpm start
 
 - **src/tools/responseShaping.ts**: Shared helpers for keeping responses lean — `omitEmpty`, `toLimitRows`, `roundMs`, `roundPercent`, `NS_TO_MS`
 
-- **src/tools/apexLogSource.ts**: The one way the three analysis tools get a log — `loadApexLog` (reads and parses, caching the last parse by path, size and modification time), `isMethodNode` (the one method test, so the tools agree on `totalMethods`) and `walkLog`
+- **src/tools/apexLogSource.ts**: The one way the three analysis tools get a log — `loadApexLog` (reads and parses, caching the last parse by path, size and modification time; the slot holds the in-flight promise, so concurrent callers share one parse and a failed read is not kept), `isMethodNode` (the one method test, so the tools agree on `totalMethods`) and `walkLog`
 
 - **src/ApexLogParser.ts**: Complex log parsing engine (33k+ tokens)
   - Exports `parse()` function and `ApexLogParser` class

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ This server implements the [Model Context Protocol (MCP)](https://modelcontextpr
 - **Uses the same parser as the [Apex Log Analyzer VS Code extension](https://github.com/certinia/debug-log-analyzer)** — battle-tested parsing of the Apex debug log format.
 - **Returns structured data** — all durations in milliseconds, governor limits as used/limit pairs, methods with SOQL/DML counts — so your AI assistant can reason about the results.
 - **Keeps responses lean** — TOON encoding, no duplicated figures, and zero/empty fields omitted, so more of the context window is left for reasoning.
+- **Parses a log once, not once per tool** — a summary followed by a deeper analysis of the same file reuses the parse, so a large log is read and parsed one time.
 
 ## Documentation
 

--- a/src/tools/analyzeLogPerformance.ts
+++ b/src/tools/analyzeLogPerformance.ts
@@ -2,11 +2,16 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { promises as fs } from "fs";
 import { z } from "zod";
-import { parse, ApexLog, LogLine } from "../ApexLogParser.js";
+import { ApexLog } from "../ApexLogParser.js";
 import { encode } from "@toon-format/toon";
-import { omitEmpty, roundMs, roundPercent } from "./responseShaping.js";
+import { loadApexLog, isMethodNode, walkLog } from "./apexLogSource.js";
+import {
+  NS_TO_MS,
+  omitEmpty,
+  roundMs,
+  roundPercent,
+} from "./responseShaping.js";
 
 export const analyzeLogPerformanceInputSchema = {
   logFilePath: z
@@ -71,21 +76,10 @@ export interface LogAnalysisResult {
   recommendations?: string[];
 }
 
-const NS_TO_MS = 1_000_000;
-
 export async function analyzeLogPerformance(args: AnalyzeLogArgs) {
   const { logFilePath, topMethods = 10, minDuration = 0, namespace } = args;
 
-  // Validate file exists
-  try {
-    await fs.access(logFilePath);
-  } catch {
-    throw new Error(`Log file not found: ${logFilePath}`);
-  }
-
-  // Read and parse log file
-  const logContent = await fs.readFile(logFilePath, "utf-8");
-  const apexLog = parse(logContent);
+  const apexLog = await loadApexLog(logFilePath);
 
   // Convert ms input to ns for internal filtering
   const minDurationNs = minDuration * NS_TO_MS;
@@ -147,40 +141,29 @@ export function extractMethods(
   const methods: SlowMethod[] = [];
   const totalTime = apexLog.duration.total;
 
-  const traverse = (node: LogLine) => {
-    if (
-      node.type === "CODE_UNIT_STARTED" || // Entry point
-      node.type === "METHOD_ENTRY" || // Methods
-      (node as any).subCategory === "Method"
-    ) {
-      if (node.duration.total >= minDuration) {
-        if (!namespaceFilter || node.namespace === namespaceFilter) {
-          methods.push({
-            name: node.text || "Unknown Method",
-            duration: node.duration.total,
-            selfDuration: node.duration.self,
-            namespace: node.namespace || "default",
-            lineNumber: node.lineNumber,
-            dmlCount: node.dmlCount.total,
-            soqlCount: node.soqlCount.total,
-            dmlRows: node.dmlRowCount.total,
-            soqlRows: node.soqlRowCount.total,
-            thrownCount: node.totalThrownCount,
-            soslCount: node.soslCount.total,
-            soslRows: node.soslRowCount.total,
-            selfPercentage:
-              totalTime > 0 ? (node.duration.self / totalTime) * 100 : 0,
-          });
-        }
-      }
-    }
+  walkLog(apexLog, (node) => {
+    if (!isMethodNode(node)) return;
+    if (node.duration.total < minDuration) return;
+    if (namespaceFilter && node.namespace !== namespaceFilter) return;
 
-    if (node.children) {
-      node.children.forEach((child: LogLine) => traverse(child));
-    }
-  };
+    methods.push({
+      name: node.text || "Unknown Method",
+      duration: node.duration.total,
+      selfDuration: node.duration.self,
+      namespace: node.namespace || "default",
+      lineNumber: node.lineNumber,
+      dmlCount: node.dmlCount.total,
+      soqlCount: node.soqlCount.total,
+      dmlRows: node.dmlRowCount.total,
+      soqlRows: node.soqlRowCount.total,
+      thrownCount: node.totalThrownCount,
+      soslCount: node.soslCount.total,
+      soslRows: node.soslRowCount.total,
+      selfPercentage:
+        totalTime > 0 ? (node.duration.self / totalTime) * 100 : 0,
+    });
+  });
 
-  traverse(apexLog);
   return methods;
 }
 

--- a/src/tools/analyzeLogPerformance.ts
+++ b/src/tools/analyzeLogPerformance.ts
@@ -143,7 +143,9 @@ export function extractMethods(
 
   walkLog(apexLog, (node) => {
     if (!isMethodNode(node)) return;
-    if (node.duration.total < minDuration) return;
+    // Tested as ">= keep" rather than "< drop": a malformed timestamp parses to
+    // NaN, which fails both, and such a method must be dropped, not reported.
+    if (!(node.duration.total >= minDuration)) return;
     if (namespaceFilter && node.namespace !== namespaceFilter) return;
 
     methods.push({

--- a/src/tools/apexLogSource.ts
+++ b/src/tools/apexLogSource.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { promises as fs } from "fs";
+import { promises as fs, type BigIntStats } from "fs";
 import {
   parse,
   ApexLog,
@@ -12,10 +12,27 @@ import {
 
 type CachedLog = {
   path: string;
-  mtimeMs: number;
-  size: number;
+  fingerprint: string;
   log: Promise<ApexLog>;
 };
+
+/**
+ * Everything `fs.stat` can say about which bytes are at this path.
+ *
+ * Size and modification time alone are not enough: `cp -p` puts a different
+ * file here and keeps both of them. The change time closes that, because POSIX
+ * moves `ctime` on any change to the inode and no copy tool can hold it back.
+ * The inode number closes a rename over the path. Both are read from the same
+ * `fs.stat` the cache already makes, so neither costs a further read.
+ *
+ * Nanoseconds rather than milliseconds, so two writes inside one millisecond
+ * are still two fingerprints. This is not a guarantee — only the content is
+ * that — but what it leaves is a file rewritten in place, to the same length,
+ * inside one nanosecond.
+ */
+function fingerprintOf(stats: BigIntStats): string {
+  return `${stats.ino}:${stats.size}:${stats.mtimeNs}:${stats.ctimeNs}`;
+}
 
 /**
  * The last parse, kept so that the usual "summary, then go deeper" flow parses
@@ -33,21 +50,21 @@ let cached: CachedLog | undefined;
 
 /**
  * Read and parse the log, reusing the last parse when the same file is asked
- * for again and neither its size nor its modification time has changed.
+ * for again and nothing `fs.stat` can see about it has changed.
  */
 export async function loadApexLog(logFilePath: string): Promise<ApexLog> {
   let stats;
   try {
-    stats = await fs.stat(logFilePath);
+    stats = await fs.stat(logFilePath, { bigint: true });
   } catch {
     throw new Error(`Log file not found: ${logFilePath}`);
   }
 
+  const fingerprint = fingerprintOf(stats);
   if (
     cached &&
     cached.path === logFilePath &&
-    cached.mtimeMs === stats.mtimeMs &&
-    cached.size === stats.size
+    cached.fingerprint === fingerprint
   ) {
     return cached.log;
   }
@@ -57,12 +74,7 @@ export async function loadApexLog(logFilePath: string): Promise<ApexLog> {
   // starting its own. The slot is filled in the same microtask as the miss
   // above, so a second caller cannot slip between the two.
   const pending = fs.readFile(logFilePath, "utf-8").then(parse);
-  cached = {
-    path: logFilePath,
-    mtimeMs: stats.mtimeMs,
-    size: stats.size,
-    log: pending,
-  };
+  cached = { path: logFilePath, fingerprint, log: pending };
 
   // A read or parse that failed must not be served to the next caller.
   pending.catch(() => {

--- a/src/tools/apexLogSource.ts
+++ b/src/tools/apexLogSource.ts
@@ -49,6 +49,22 @@ function fingerprintOf(stats: BigIntStats): string {
 let cached: CachedLog | undefined;
 
 /**
+ * How long the slot survives after its last use. A parsed log holds four to
+ * five times the size of the file, so a 200 MB log holds about a gigabyte.
+ * That is worth holding while an agent works through one log, and not worth
+ * holding until the process exits.
+ */
+const IDLE_EVICTION_MS = 5 * 60_000;
+
+let evictionTimer: NodeJS.Timeout | undefined;
+
+function scheduleEviction(): void {
+  clearTimeout(evictionTimer);
+  // unref, so a waiting timer never keeps an otherwise idle server alive.
+  evictionTimer = setTimeout(clearApexLogCache, IDLE_EVICTION_MS).unref();
+}
+
+/**
  * Read and parse the log, reusing the last parse when the same file is asked
  * for again and nothing `fs.stat` can see about it has changed.
  */
@@ -66,6 +82,7 @@ export async function loadApexLog(logFilePath: string): Promise<ApexLog> {
     cached.path === logFilePath &&
     cached.fingerprint === fingerprint
   ) {
+    scheduleEviction();
     return cached.log;
   }
 
@@ -75,19 +92,22 @@ export async function loadApexLog(logFilePath: string): Promise<ApexLog> {
   // above, so a second caller cannot slip between the two.
   const pending = fs.readFile(logFilePath, "utf-8").then(parse);
   cached = { path: logFilePath, fingerprint, log: pending };
+  scheduleEviction();
 
   // A read or parse that failed must not be served to the next caller.
   pending.catch(() => {
     if (cached?.log === pending) {
-      cached = undefined;
+      clearApexLogCache();
     }
   });
 
   return pending;
 }
 
-/** Drop the cached parse. For tests, which write a new log to the same path. */
+/** Drop the cached parse. Called on the idle timer, and by tests. */
 export function clearApexLogCache(): void {
+  clearTimeout(evictionTimer);
+  evictionTimer = undefined;
   cached = undefined;
 }
 

--- a/src/tools/apexLogSource.ts
+++ b/src/tools/apexLogSource.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+import { promises as fs } from "fs";
+import { parse, ApexLog, LogLine } from "../ApexLogParser.js";
+
+type CachedLog = {
+  path: string;
+  mtimeMs: number;
+  size: number;
+  log: ApexLog;
+};
+
+/**
+ * The last parse, kept so that the usual "summary, then go deeper" flow parses
+ * a large log once instead of once per tool. One slot only: the flow works
+ * through a single log at a time, and a parsed 19 MB log is too big to hold
+ * several of.
+ */
+let cached: CachedLog | undefined;
+
+/**
+ * Read and parse the log, reusing the last parse when the same file is asked
+ * for again and neither its size nor its modification time has changed.
+ */
+export async function loadApexLog(logFilePath: string): Promise<ApexLog> {
+  let stats;
+  try {
+    stats = await fs.stat(logFilePath);
+  } catch {
+    throw new Error(`Log file not found: ${logFilePath}`);
+  }
+
+  if (
+    cached &&
+    cached.path === logFilePath &&
+    cached.mtimeMs === stats.mtimeMs &&
+    cached.size === stats.size
+  ) {
+    return cached.log;
+  }
+
+  const log = parse(await fs.readFile(logFilePath, "utf-8"));
+  cached = {
+    path: logFilePath,
+    mtimeMs: stats.mtimeMs,
+    size: stats.size,
+    log,
+  };
+  return log;
+}
+
+/** Drop the cached parse. For tests, which write a new log to the same path. */
+export function clearApexLogCache(): void {
+  cached = undefined;
+}
+
+/**
+ * The units the tools count and rank: entry points and the methods below them.
+ * Every tool uses this one test, so their method totals agree.
+ */
+export function isMethodNode(node: LogLine): boolean {
+  // subCategory is declared on TimedNode, a subclass, so it is read off the
+  // node rather than tested with instanceof.
+  const { subCategory } = node as LogLine & { subCategory?: string };
+  return (
+    node.type === "CODE_UNIT_STARTED" ||
+    node.type === "METHOD_ENTRY" ||
+    subCategory === "Method"
+  );
+}
+
+/** Visit the node and every node below it, parents first. */
+export function walkLog(node: LogLine, visit: (node: LogLine) => void): void {
+  visit(node);
+  node.children?.forEach((child) => walkLog(child, visit));
+}

--- a/src/tools/apexLogSource.ts
+++ b/src/tools/apexLogSource.ts
@@ -9,7 +9,7 @@ type CachedLog = {
   path: string;
   mtimeMs: number;
   size: number;
-  log: ApexLog;
+  log: Promise<ApexLog>;
 };
 
 /**
@@ -41,14 +41,26 @@ export async function loadApexLog(logFilePath: string): Promise<ApexLog> {
     return cached.log;
   }
 
-  const log = parse(await fs.readFile(logFilePath, "utf-8"));
+  // Hold the parse while it runs, not after it finishes, so a caller that
+  // arrives while a large log is still being read shares that read instead of
+  // starting its own. The slot is filled in the same microtask as the miss
+  // above, so a second caller cannot slip between the two.
+  const pending = fs.readFile(logFilePath, "utf-8").then(parse);
   cached = {
     path: logFilePath,
     mtimeMs: stats.mtimeMs,
     size: stats.size,
-    log,
+    log: pending,
   };
-  return log;
+
+  // A read or parse that failed must not be served to the next caller.
+  pending.catch(() => {
+    if (cached?.log === pending) {
+      cached = undefined;
+    }
+  });
+
+  return pending;
 }
 
 /** Drop the cached parse. For tests, which write a new log to the same path. */

--- a/src/tools/apexLogSource.ts
+++ b/src/tools/apexLogSource.ts
@@ -17,13 +17,13 @@ type CachedLog = {
 };
 
 /**
- * Everything `fs.stat` can say about which bytes are at this path.
+ * Everything a stat can say about which bytes these are.
  *
  * Size and modification time alone are not enough: `cp -p` puts a different
  * file here and keeps both of them. The change time closes that, because POSIX
  * moves `ctime` on any change to the inode and no copy tool can hold it back.
- * The inode number closes a rename over the path. Both are read from the same
- * `fs.stat` the cache already makes, so neither costs a further read.
+ * The inode number closes a rename over the path. Both are read from the stat
+ * the cache already makes, so neither costs a further read.
  *
  * Nanoseconds rather than milliseconds, so two writes inside one millisecond
  * are still two fingerprints. This is not a guarantee — only the content is
@@ -66,42 +66,53 @@ function scheduleEviction(): void {
 
 /**
  * Read and parse the log, reusing the last parse when the same file is asked
- * for again and nothing `fs.stat` can see about it has changed.
+ * for again and nothing a stat can see about it has changed.
  */
 export async function loadApexLog(logFilePath: string): Promise<ApexLog> {
-  let stats;
+  // Open the file once, and stat and read that one handle. A stat of the path
+  // and then a read of the path can touch two different files, if something
+  // replaces the path between them: the fingerprint would belong to the old
+  // file and the bytes to the new one. A handle holds one inode, so the
+  // fingerprint below describes exactly the bytes this call goes on to read.
+  let handle;
+  let fingerprint;
   try {
-    stats = await fs.stat(logFilePath, { bigint: true });
+    handle = await fs.open(logFilePath, "r");
+    fingerprint = fingerprintOf(await handle.stat({ bigint: true }));
   } catch {
+    await handle?.close();
     throw new Error(`Log file not found: ${logFilePath}`);
   }
 
-  const fingerprint = fingerprintOf(stats);
-  if (
-    cached &&
-    cached.path === logFilePath &&
-    cached.fingerprint === fingerprint
-  ) {
-    scheduleEviction();
-    return cached.log;
-  }
-
-  // Hold the parse while it runs, not after it finishes, so a caller that
-  // arrives while a large log is still being read shares that read instead of
-  // starting its own. The slot is filled in the same microtask as the miss
-  // above, so a second caller cannot slip between the two.
-  const pending = fs.readFile(logFilePath, "utf-8").then(parse);
-  cached = { path: logFilePath, fingerprint, log: pending };
-  scheduleEviction();
-
-  // A read or parse that failed must not be served to the next caller.
-  pending.catch(() => {
-    if (cached?.log === pending) {
-      clearApexLogCache();
+  try {
+    if (
+      cached &&
+      cached.path === logFilePath &&
+      cached.fingerprint === fingerprint
+    ) {
+      scheduleEviction();
+      return cached.log;
     }
-  });
 
-  return pending;
+    // Hold the parse while it runs, not after it finishes, so a caller that
+    // arrives while a large log is still being read shares that read instead of
+    // starting its own. The slot is filled in the same microtask as the miss
+    // above, so a second caller cannot slip between the two.
+    const pending = handle.readFile("utf-8").then(parse);
+    cached = { path: logFilePath, fingerprint, log: pending };
+    scheduleEviction();
+
+    // A read or parse that failed must not be served to the next caller.
+    pending.catch(() => {
+      if (cached?.log === pending) {
+        clearApexLogCache();
+      }
+    });
+
+    return await pending;
+  } finally {
+    await handle.close();
+  }
 }
 
 /** Drop the cached parse. Called on the idle timer, and by tests. */

--- a/src/tools/apexLogSource.ts
+++ b/src/tools/apexLogSource.ts
@@ -17,6 +17,12 @@ type CachedLog = {
  * a large log once instead of once per tool. One slot only: the flow works
  * through a single log at a time, and a parsed 19 MB log is too big to hold
  * several of.
+ *
+ * This is not protocol state, so it holds under a stateless MCP revision. It is
+ * a memo of a pure function of a file on disk, re-checked against `fs.stat` on
+ * every call, and `logFilePath` is already the explicit handle the MCP
+ * "Stateful Tools" guidance asks a tool to take. No request depends on an
+ * earlier one: drop the slot and every response is the same.
  */
 let cached: CachedLog | undefined;
 

--- a/src/tools/apexLogSource.ts
+++ b/src/tools/apexLogSource.ts
@@ -3,7 +3,12 @@
  */
 
 import { promises as fs } from "fs";
-import { parse, ApexLog, LogLine } from "../ApexLogParser.js";
+import {
+  parse,
+  ApexLog,
+  LogLine,
+  type LogSubCategory,
+} from "../ApexLogParser.js";
 
 type CachedLog = {
   path: string;
@@ -81,7 +86,7 @@ export function clearApexLogCache(): void {
 export function isMethodNode(node: LogLine): boolean {
   // subCategory is declared on TimedNode, a subclass, so it is read off the
   // node rather than tested with instanceof.
-  const { subCategory } = node as LogLine & { subCategory?: string };
+  const { subCategory } = node as LogLine & { subCategory?: LogSubCategory };
   return (
     node.type === "CODE_UNIT_STARTED" ||
     node.type === "METHOD_ENTRY" ||

--- a/src/tools/findPerformanceBottlenecks.ts
+++ b/src/tools/findPerformanceBottlenecks.ts
@@ -2,12 +2,12 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { promises as fs } from "fs";
 import { z } from "zod";
-import { parse, ApexLog } from "../ApexLogParser.js";
+import { ApexLog } from "../ApexLogParser.js";
 import { type SlowMethod, extractMethods } from "./analyzeLogPerformance.js";
 import { encode } from "@toon-format/toon";
-import { roundMs, roundPercent } from "./responseShaping.js";
+import { loadApexLog } from "./apexLogSource.js";
+import { NS_TO_MS, roundMs, roundPercent } from "./responseShaping.js";
 
 export const findPerformanceBottlenecksInputSchema = {
   logFilePath: z
@@ -46,19 +46,10 @@ export const findPerformanceBottlenecksToolConfig = {
 
 export const WARNING_THRESHOLD = 80;
 
-const NS_TO_MS = 1_000_000;
-
 export async function findPerformanceBottlenecks(args: BottleneckArgs) {
   const { logFilePath, analysisType = "all" } = args;
 
-  try {
-    await fs.access(logFilePath);
-  } catch {
-    throw new Error(`Log file not found: ${logFilePath}`);
-  }
-
-  const logContent = await fs.readFile(logFilePath, "utf-8");
-  const apexLog = parse(logContent);
+  const apexLog = await loadApexLog(logFilePath);
 
   const hasCpuSection = analysisType === "cpu" || analysisType === "all";
 

--- a/src/tools/getLogSummary.ts
+++ b/src/tools/getLogSummary.ts
@@ -2,11 +2,16 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { promises as fs } from "fs";
 import { z } from "zod";
-import { parse, ApexLog, LogLine } from "../ApexLogParser.js";
+import { ApexLog } from "../ApexLogParser.js";
 import { encode } from "@toon-format/toon";
-import { omitEmpty, roundMs, toLimitRows } from "./responseShaping.js";
+import { loadApexLog, isMethodNode, walkLog } from "./apexLogSource.js";
+import {
+  NS_TO_MS,
+  omitEmpty,
+  roundMs,
+  toLimitRows,
+} from "./responseShaping.js";
 
 export const getLogSummaryInputSchema = {
   logFilePath: z
@@ -29,19 +34,10 @@ export const getLogSummaryToolConfig = {
   },
 };
 
-const NS_TO_MS = 1_000_000;
-
 export async function getLogSummary(args: LogSummaryArgs) {
   const { logFilePath } = args;
 
-  try {
-    await fs.access(logFilePath);
-  } catch {
-    throw new Error(`Log file not found: ${logFilePath}`);
-  }
-
-  const logContent = await fs.readFile(logFilePath, "utf-8");
-  const apexLog = parse(logContent);
+  const apexLog = await loadApexLog(logFilePath);
 
   const logIssues = apexLog.logIssues.map((issue) => ({
     type: issue.type,
@@ -81,17 +77,10 @@ export async function getLogSummary(args: LogSummaryArgs) {
 
 function countMethods(apexLog: ApexLog): number {
   let count = 0;
-  const traverse = (node: LogLine) => {
-    if (
-      node.type === "METHOD_ENTRY" ||
-      (node as any).subCategory === "Method"
-    ) {
+  walkLog(apexLog, (node) => {
+    if (isMethodNode(node)) {
       count++;
     }
-    if (node.children) {
-      node.children.forEach((child: LogLine) => traverse(child));
-    }
-  };
-  traverse(apexLog);
+  });
   return count;
 }

--- a/src/tools/responseShaping.ts
+++ b/src/tools/responseShaping.ts
@@ -14,6 +14,9 @@
 
 import type { GovernorLimits, Limits } from "../ApexLogParser.js";
 
+/** The parser works in nanoseconds; every reported duration is milliseconds. */
+export const NS_TO_MS = 1_000_000;
+
 /** Durations are reported in ms; 3dp keeps microsecond resolution without float noise. */
 export function roundMs(ms: number): number {
   return Math.round(ms * 1000) / 1000;

--- a/tests/analyzeLogPerformance.test.ts
+++ b/tests/analyzeLogPerformance.test.ts
@@ -201,6 +201,17 @@ describe("analyzeLogPerformance", () => {
       );
     });
 
+    it("should drop a method whose timestamps did not parse to a number", () => {
+      const mockApexLog = createMockApexLog();
+      mockApexLog.children.push(createMockLogLine("BrokenMethod", NaN, NaN));
+
+      const methods = extractMethods(mockApexLog, 0);
+
+      expect(methods.map((method) => method.name)).not.toContain(
+        "BrokenMethod",
+      );
+    });
+
     it("should filter methods by namespace", () => {
       const mockApexLog = createMockApexLogWithNamespaces();
       const methods = extractMethods(mockApexLog, 0, "CustomNamespace");

--- a/tests/analyzeLogPerformance.test.ts
+++ b/tests/analyzeLogPerformance.test.ts
@@ -16,12 +16,23 @@ import { parse } from "../src/ApexLogParser";
 import { decode } from "@toon-format/toon";
 
 // Mock file system operations
-jest.mock("fs", () => ({
-  promises: {
-    stat: jest.fn(),
-    readFile: jest.fn(),
-  },
-}));
+jest.mock("fs", () => {
+  const stat = jest.fn();
+  const readFile = jest.fn();
+  // A handle is the file at one path, so its stat and read delegate to the
+  // mocks above with that path filled in. Tests set and assert on those.
+  return {
+    promises: {
+      stat,
+      readFile,
+      open: jest.fn(async (path: string) => ({
+        stat: (options: unknown) => stat(path, options),
+        readFile: (encoding: unknown) => readFile(path, encoding),
+        close: jest.fn(),
+      })),
+    },
+  };
+});
 
 jest.mock("../src/ApexLogParser", () => ({
   parse: jest.fn(),

--- a/tests/analyzeLogPerformance.test.ts
+++ b/tests/analyzeLogPerformance.test.ts
@@ -2,7 +2,8 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { promises as fs } from "fs";
+import { promises as fs, type Stats } from "fs";
+import { clearApexLogCache } from "../src/tools/apexLogSource";
 import {
   analyzeLogPerformance,
   extractMethods,
@@ -17,7 +18,7 @@ import { decode } from "@toon-format/toon";
 // Mock file system operations
 jest.mock("fs", () => ({
   promises: {
-    access: jest.fn(),
+    stat: jest.fn(),
     readFile: jest.fn(),
   },
 }));
@@ -28,10 +29,14 @@ jest.mock("../src/ApexLogParser", () => ({
 
 const mockedFs = fs as jest.Mocked<typeof fs>;
 const mockedParse = parse as jest.MockedFunction<typeof parse>;
+const mockStats = { mtimeMs: 1, size: 1 } as Stats;
 
 describe("analyzeLogPerformance", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // The suites reuse one path with different content, which the cache would
+    // otherwise hide.
+    clearApexLogCache();
   });
 
   describe("Tool Configuration", () => {
@@ -56,13 +61,13 @@ describe("analyzeLogPerformance", () => {
   describe("File Validation", () => {
     it("should throw error when file does not exist", async () => {
       const args: AnalyzeLogArgs = { logFilePath: "/nonexistent/file.log" };
-      mockedFs.access.mockRejectedValue(new Error("File not found"));
+      mockedFs.stat.mockRejectedValue(new Error("File not found"));
 
       await expect(analyzeLogPerformance(args)).rejects.toThrow(
         "Log file not found: /nonexistent/file.log",
       );
 
-      expect(mockedFs.access).toHaveBeenCalledWith("/nonexistent/file.log");
+      expect(mockedFs.stat).toHaveBeenCalledWith("/nonexistent/file.log");
     });
 
     it("should proceed when file exists", async () => {
@@ -70,13 +75,13 @@ describe("analyzeLogPerformance", () => {
       const mockLogContent = "mock log content";
       const mockApexLog = createMockApexLog();
 
-      mockedFs.access.mockResolvedValue(undefined);
+      mockedFs.stat.mockResolvedValue(mockStats);
       mockedFs.readFile.mockResolvedValue(mockLogContent);
       mockedParse.mockReturnValue(mockApexLog);
 
       const result = await analyzeLogPerformance(args);
 
-      expect(mockedFs.access).toHaveBeenCalledWith("/valid/file.log");
+      expect(mockedFs.stat).toHaveBeenCalledWith("/valid/file.log");
       expect(mockedFs.readFile).toHaveBeenCalledWith(
         "/valid/file.log",
         "utf-8",
@@ -304,7 +309,7 @@ describe("analyzeLogPerformance", () => {
     it("should handle parsing errors gracefully", async () => {
       const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
 
-      mockedFs.access.mockResolvedValue(undefined);
+      mockedFs.stat.mockResolvedValue(mockStats);
       mockedFs.readFile.mockResolvedValue("invalid log content");
       mockedParse.mockImplementation(() => {
         throw new Error("Parsing failed");
@@ -318,7 +323,7 @@ describe("analyzeLogPerformance", () => {
     it("should handle file read errors", async () => {
       const args: AnalyzeLogArgs = { logFilePath: "/test/file.log" };
 
-      mockedFs.access.mockResolvedValue(undefined);
+      mockedFs.stat.mockResolvedValue(mockStats);
       mockedFs.readFile.mockRejectedValue(new Error("Permission denied"));
 
       await expect(analyzeLogPerformance(args)).rejects.toThrow(
@@ -532,7 +537,7 @@ describe("analyzeLogPerformance", () => {
 
   // Helper functions for creating mock data
   function setupMocksForSuccess(mockApexLog: any): void {
-    mockedFs.access.mockResolvedValue(undefined);
+    mockedFs.stat.mockResolvedValue(mockStats);
     mockedFs.readFile.mockResolvedValue("mock log content");
     mockedParse.mockReturnValue(mockApexLog);
   }

--- a/tests/analyzeLogPerformance.test.ts
+++ b/tests/analyzeLogPerformance.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { promises as fs, type Stats } from "fs";
+import { promises as fs, type BigIntStats } from "fs";
 import { clearApexLogCache } from "../src/tools/apexLogSource";
 import {
   analyzeLogPerformance,
@@ -29,7 +29,12 @@ jest.mock("../src/ApexLogParser", () => ({
 
 const mockedFs = fs as jest.Mocked<typeof fs>;
 const mockedParse = parse as jest.MockedFunction<typeof parse>;
-const mockStats = { mtimeMs: 1, size: 1 } as Stats;
+const mockStats = {
+  ino: 1n,
+  size: 1n,
+  mtimeNs: 1n,
+  ctimeNs: 1n,
+} as BigIntStats;
 
 describe("analyzeLogPerformance", () => {
   beforeEach(() => {
@@ -67,7 +72,7 @@ describe("analyzeLogPerformance", () => {
         "Log file not found: /nonexistent/file.log",
       );
 
-      expect(mockedFs.stat).toHaveBeenCalledWith("/nonexistent/file.log");
+      expect(mockedFs.stat).toHaveBeenCalledWith("/nonexistent/file.log", { bigint: true });
     });
 
     it("should proceed when file exists", async () => {
@@ -81,7 +86,7 @@ describe("analyzeLogPerformance", () => {
 
       const result = await analyzeLogPerformance(args);
 
-      expect(mockedFs.stat).toHaveBeenCalledWith("/valid/file.log");
+      expect(mockedFs.stat).toHaveBeenCalledWith("/valid/file.log", { bigint: true });
       expect(mockedFs.readFile).toHaveBeenCalledWith(
         "/valid/file.log",
         "utf-8",

--- a/tests/apexLogSource.test.ts
+++ b/tests/apexLogSource.test.ts
@@ -41,6 +41,25 @@ const statsOf = (
 const nodeOf = (props: Record<string, unknown>): LogLine =>
   props as unknown as LogLine;
 
+/**
+ * Run the body with the clock under our control. `jest.useRealTimers()` leaves
+ * `globalThis.clearTimeout` deleted rather than restored in this environment,
+ * so the real ones are put back by hand.
+ */
+const withFakeTimers = async (body: () => Promise<void>): Promise<void> => {
+  const real = {
+    setTimeout: globalThis.setTimeout,
+    clearTimeout: globalThis.clearTimeout,
+  };
+  jest.useFakeTimers();
+  try {
+    await body();
+  } finally {
+    jest.useRealTimers();
+    Object.assign(globalThis, real);
+  }
+};
+
 describe("apexLogSource", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -112,6 +131,28 @@ describe("apexLogSource", () => {
       await loadApexLog("/path/to/other.log");
 
       expect(mockParse).toHaveBeenCalledTimes(2);
+    });
+
+    it("drops the parse once it has sat unused", async () => {
+      await withFakeTimers(async () => {
+        await loadApexLog(logPath);
+        jest.advanceTimersByTime(5 * 60_000);
+        await loadApexLog(logPath);
+      });
+
+      expect(mockParse).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps the parse while it is still asked for", async () => {
+      await withFakeTimers(async () => {
+        await loadApexLog(logPath);
+        jest.advanceTimersByTime(4 * 60_000);
+        await loadApexLog(logPath);
+        jest.advanceTimersByTime(4 * 60_000);
+        await loadApexLog(logPath);
+      });
+
+      expect(mockParse).toHaveBeenCalledTimes(1);
     });
 
     it("shares one parse between callers that arrive while it runs", async () => {

--- a/tests/apexLogSource.test.ts
+++ b/tests/apexLogSource.test.ts
@@ -28,7 +28,8 @@ const mockParse = parse as jest.MockedFunction<typeof parse>;
 
 const statsOf = (mtimeMs: number, size: number) => ({ mtimeMs, size }) as Stats;
 
-const nodeOf = (props: Partial<LogLine>): LogLine => props as LogLine;
+const nodeOf = (props: Record<string, unknown>): LogLine =>
+  props as unknown as LogLine;
 
 describe("apexLogSource", () => {
   beforeEach(() => {
@@ -128,10 +129,9 @@ describe("apexLogSource", () => {
       expect(isMethodNode(nodeOf({ type: "METHOD_ENTRY" }))).toBe(true);
       expect(isMethodNode(nodeOf({ type: "SOQL_EXECUTE_BEGIN" }))).toBe(false);
       expect(
-        isMethodNode({
-          type: "CONSTRUCTOR_ENTRY",
-          subCategory: "Method",
-        } as unknown as LogLine),
+        isMethodNode(
+          nodeOf({ type: "CONSTRUCTOR_ENTRY", subCategory: "Method" }),
+        ),
       ).toBe(true);
     });
   });

--- a/tests/apexLogSource.test.ts
+++ b/tests/apexLogSource.test.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+import { promises as fs, type Stats } from "fs";
+
+import {
+  clearApexLogCache,
+  isMethodNode,
+  loadApexLog,
+  walkLog,
+} from "../src/tools/apexLogSource";
+import { parse, ApexLog, LogLine } from "../src/ApexLogParser";
+
+jest.mock("fs", () => ({
+  promises: {
+    stat: jest.fn(),
+    readFile: jest.fn(),
+  },
+}));
+
+jest.mock("../src/ApexLogParser", () => ({
+  parse: jest.fn(),
+}));
+
+const mockFs = fs as jest.Mocked<typeof fs>;
+const mockParse = parse as jest.MockedFunction<typeof parse>;
+
+const statsOf = (mtimeMs: number, size: number) => ({ mtimeMs, size }) as Stats;
+
+const nodeOf = (props: Partial<LogLine>): LogLine => props as LogLine;
+
+describe("apexLogSource", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearApexLogCache();
+  });
+
+  describe("loadApexLog", () => {
+    const logPath = "/path/to/test.log";
+
+    beforeEach(() => {
+      mockFs.stat.mockResolvedValue(statsOf(1, 10));
+      mockFs.readFile.mockResolvedValue("log content");
+      mockParse.mockReturnValue({} as ApexLog);
+    });
+
+    it("parses the file on the first call", async () => {
+      const log = await loadApexLog(logPath);
+
+      expect(mockFs.readFile).toHaveBeenCalledWith(logPath, "utf-8");
+      expect(mockParse).toHaveBeenCalledWith("log content");
+      expect(log).toBe(mockParse.mock.results[0]?.value);
+    });
+
+    it("reuses the parse when the same unchanged file is asked for again", async () => {
+      const first = await loadApexLog(logPath);
+      const second = await loadApexLog(logPath);
+
+      expect(second).toBe(first);
+      expect(mockParse).toHaveBeenCalledTimes(1);
+      expect(mockFs.readFile).toHaveBeenCalledTimes(1);
+    });
+
+    it("parses again when the file was modified", async () => {
+      await loadApexLog(logPath);
+      mockFs.stat.mockResolvedValue(statsOf(2, 10));
+      await loadApexLog(logPath);
+
+      expect(mockParse).toHaveBeenCalledTimes(2);
+    });
+
+    it("parses again when the file size changed", async () => {
+      await loadApexLog(logPath);
+      mockFs.stat.mockResolvedValue(statsOf(1, 20));
+      await loadApexLog(logPath);
+
+      expect(mockParse).toHaveBeenCalledTimes(2);
+    });
+
+    it("parses again when a different file is asked for", async () => {
+      await loadApexLog(logPath);
+      await loadApexLog("/path/to/other.log");
+
+      expect(mockParse).toHaveBeenCalledTimes(2);
+    });
+
+    it("reports a missing file and does not read it", async () => {
+      mockFs.stat.mockRejectedValue(new Error("ENOENT"));
+
+      await expect(loadApexLog("/path/to/missing.log")).rejects.toThrow(
+        "Log file not found: /path/to/missing.log",
+      );
+      expect(mockFs.readFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("isMethodNode", () => {
+    it("accepts code units, method entries and timed method nodes", () => {
+      expect(isMethodNode(nodeOf({ type: "CODE_UNIT_STARTED" }))).toBe(true);
+      expect(isMethodNode(nodeOf({ type: "METHOD_ENTRY" }))).toBe(true);
+      expect(isMethodNode(nodeOf({ type: "SOQL_EXECUTE_BEGIN" }))).toBe(false);
+      expect(
+        isMethodNode({
+          type: "CONSTRUCTOR_ENTRY",
+          subCategory: "Method",
+        } as unknown as LogLine),
+      ).toBe(true);
+    });
+  });
+
+  describe("walkLog", () => {
+    it("visits the node and every node below it, parents first", () => {
+      const tree = {
+        type: "root",
+        children: [{ type: "a", children: [{ type: "a1" }] }, { type: "b" }],
+      } as unknown as LogLine;
+
+      const seen: string[] = [];
+      walkLog(tree, (node) => seen.push(node.type as string));
+
+      expect(seen).toEqual(["root", "a", "a1", "b"]);
+    });
+  });
+});

--- a/tests/apexLogSource.test.ts
+++ b/tests/apexLogSource.test.ts
@@ -12,12 +12,23 @@ import {
 } from "../src/tools/apexLogSource";
 import { parse, ApexLog, LogLine } from "../src/ApexLogParser";
 
-jest.mock("fs", () => ({
-  promises: {
-    stat: jest.fn(),
-    readFile: jest.fn(),
-  },
-}));
+jest.mock("fs", () => {
+  const stat = jest.fn();
+  const readFile = jest.fn();
+  // A handle is the file at one path, so its stat and read delegate to the
+  // mocks above with that path filled in. Tests set and assert on those.
+  return {
+    promises: {
+      stat,
+      readFile,
+      open: jest.fn(async (path: string) => ({
+        stat: (options: unknown) => stat(path, options),
+        readFile: (encoding: unknown) => readFile(path, encoding),
+        close: jest.fn(),
+      })),
+    },
+  };
+});
 
 jest.mock("../src/ApexLogParser", () => ({
   parse: jest.fn(),
@@ -78,9 +89,22 @@ describe("apexLogSource", () => {
     it("parses the file on the first call", async () => {
       const log = await loadApexLog(logPath);
 
+      expect(mockFs.open).toHaveBeenCalledWith(logPath, "r");
       expect(mockFs.readFile).toHaveBeenCalledWith(logPath, "utf-8");
       expect(mockParse).toHaveBeenCalledWith("log content");
       expect(log).toBe(mockParse.mock.results[0]?.value);
+    });
+
+    it("closes every file it opens", async () => {
+      await loadApexLog(logPath);
+      // The second call is a cache hit, and still opened the file to stat it.
+      await loadApexLog(logPath);
+
+      const handles = await Promise.all(
+        mockFs.open.mock.results.map((result) => result.value),
+      );
+      expect(handles).toHaveLength(2);
+      handles.forEach((handle) => expect(handle.close).toHaveBeenCalled());
     });
 
     it("reuses the parse when the same unchanged file is asked for again", async () => {

--- a/tests/apexLogSource.test.ts
+++ b/tests/apexLogSource.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { promises as fs, type Stats } from "fs";
+import { promises as fs, type BigIntStats } from "fs";
 
 import {
   clearApexLogCache,
@@ -26,7 +26,17 @@ jest.mock("../src/ApexLogParser", () => ({
 const mockFs = fs as jest.Mocked<typeof fs>;
 const mockParse = parse as jest.MockedFunction<typeof parse>;
 
-const statsOf = (mtimeMs: number, size: number) => ({ mtimeMs, size }) as Stats;
+const statsOf = (
+  mtimeNs: number,
+  size: number,
+  { ctimeNs = mtimeNs, ino = 7 } = {},
+) =>
+  ({
+    ino: BigInt(ino),
+    size: BigInt(size),
+    mtimeNs: BigInt(mtimeNs),
+    ctimeNs: BigInt(ctimeNs),
+  }) as BigIntStats;
 
 const nodeOf = (props: Record<string, unknown>): LogLine =>
   props as unknown as LogLine;
@@ -74,6 +84,24 @@ describe("apexLogSource", () => {
     it("parses again when the file size changed", async () => {
       await loadApexLog(logPath);
       mockFs.stat.mockResolvedValue(statsOf(1, 20));
+      await loadApexLog(logPath);
+
+      expect(mockParse).toHaveBeenCalledTimes(2);
+    });
+
+    it("parses again when a copy kept the modification time", async () => {
+      await loadApexLog(logPath);
+      // What `cp -p` leaves behind: same size, same mtime, same inode, and a
+      // change time it cannot hold back.
+      mockFs.stat.mockResolvedValue(statsOf(1, 10, { ctimeNs: 2 }));
+      await loadApexLog(logPath);
+
+      expect(mockParse).toHaveBeenCalledTimes(2);
+    });
+
+    it("parses again when another file was renamed over the path", async () => {
+      await loadApexLog(logPath);
+      mockFs.stat.mockResolvedValue(statsOf(1, 10, { ino: 8 }));
       await loadApexLog(logPath);
 
       expect(mockParse).toHaveBeenCalledTimes(2);

--- a/tests/apexLogSource.test.ts
+++ b/tests/apexLogSource.test.ts
@@ -85,6 +85,33 @@ describe("apexLogSource", () => {
       expect(mockParse).toHaveBeenCalledTimes(2);
     });
 
+    it("shares one parse between callers that arrive while it runs", async () => {
+      let release: (content: string) => void = () => {};
+      mockFs.readFile.mockReturnValue(
+        new Promise<string>((resolve) => {
+          release = resolve;
+        }) as ReturnType<typeof fs.readFile>,
+      );
+
+      const both = Promise.all([loadApexLog(logPath), loadApexLog(logPath)]);
+      release("log content");
+      const [first, second] = await both;
+
+      expect(second).toBe(first);
+      expect(mockFs.readFile).toHaveBeenCalledTimes(1);
+      expect(mockParse).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not serve a failed read to the next caller", async () => {
+      mockFs.readFile.mockRejectedValueOnce(new Error("EACCES"));
+
+      await expect(loadApexLog(logPath)).rejects.toThrow("EACCES");
+      const retried = await loadApexLog(logPath);
+
+      expect(retried).toBe(mockParse.mock.results[0]?.value);
+      expect(mockFs.readFile).toHaveBeenCalledTimes(2);
+    });
+
     it("reports a missing file and does not read it", async () => {
       mockFs.stat.mockRejectedValue(new Error("ENOENT"));
 

--- a/tests/eval/golden/get_apex_log_summary.governor-heavy.expected.txt
+++ b/tests/eval/golden/get_apex_log_summary.governor-heavy.expected.txt
@@ -1,6 +1,6 @@
 size: 39532
 totalExecutionTime: 24608.108
-totalMethods: 11
+totalMethods: 13
 totalSOQLQueries: 1
 totalDMLOperations: 1
 totalSOQLRows: 0

--- a/tests/eval/golden/get_apex_log_summary.minimal.expected.txt
+++ b/tests/eval/golden/get_apex_log_summary.minimal.expected.txt
@@ -1,6 +1,6 @@
 size: 1274
 totalExecutionTime: 0.561
-totalMethods: 1
+totalMethods: 2
 totalSOQLQueries: 0
 totalDMLOperations: 0
 totalSOQLRows: 0

--- a/tests/findPerformanceBottlenecks.test.ts
+++ b/tests/findPerformanceBottlenecks.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { promises as fs, type Stats } from "fs";
+import { promises as fs, type BigIntStats } from "fs";
 
 import { clearApexLogCache } from "../src/tools/apexLogSource";
 import {
@@ -36,7 +36,12 @@ const mockParse = parse as jest.MockedFunction<typeof parse>;
 const mockExtractMethods = extractMethods as jest.MockedFunction<
   typeof extractMethods
 >;
-const mockStats = { mtimeMs: 1, size: 1 } as Stats;
+const mockStats = {
+  ino: 1n,
+  size: 1n,
+  mtimeNs: 1n,
+  ctimeNs: 1n,
+} as BigIntStats;
 
 // Helper function to create mock governor limits
 function createMockGovernorLimits(
@@ -177,7 +182,7 @@ describe("findPerformanceBottlenecks", () => {
         "Log file not found: /nonexistent/file.log",
       );
 
-      expect(mockFs.stat).toHaveBeenCalledWith("/nonexistent/file.log");
+      expect(mockFs.stat).toHaveBeenCalledWith("/nonexistent/file.log", { bigint: true });
       expect(mockFs.readFile).not.toHaveBeenCalled();
       expect(mockParse).not.toHaveBeenCalled();
     });
@@ -190,7 +195,7 @@ describe("findPerformanceBottlenecks", () => {
         "Permission denied",
       );
 
-      expect(mockFs.stat).toHaveBeenCalledWith(mockLogFilePath);
+      expect(mockFs.stat).toHaveBeenCalledWith(mockLogFilePath, { bigint: true });
       expect(mockFs.readFile).toHaveBeenCalledWith(mockLogFilePath, "utf-8");
       expect(mockParse).not.toHaveBeenCalled();
     });
@@ -205,7 +210,7 @@ describe("findPerformanceBottlenecks", () => {
         "Invalid log format",
       );
 
-      expect(mockFs.stat).toHaveBeenCalledWith(mockLogFilePath);
+      expect(mockFs.stat).toHaveBeenCalledWith(mockLogFilePath, { bigint: true });
       expect(mockFs.readFile).toHaveBeenCalledWith(mockLogFilePath, "utf-8");
       expect(mockParse).toHaveBeenCalledWith(mockLogContent);
     });

--- a/tests/findPerformanceBottlenecks.test.ts
+++ b/tests/findPerformanceBottlenecks.test.ts
@@ -2,8 +2,9 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { promises as fs } from "fs";
+import { promises as fs, type Stats } from "fs";
 
+import { clearApexLogCache } from "../src/tools/apexLogSource";
 import {
   findPerformanceBottlenecks,
   BottleneckArgs,
@@ -17,7 +18,7 @@ import { decode } from "@toon-format/toon";
 // Mock dependencies
 jest.mock("fs", () => ({
   promises: {
-    access: jest.fn(),
+    stat: jest.fn(),
     readFile: jest.fn(),
   },
 }));
@@ -35,6 +36,7 @@ const mockParse = parse as jest.MockedFunction<typeof parse>;
 const mockExtractMethods = extractMethods as jest.MockedFunction<
   typeof extractMethods
 >;
+const mockStats = { mtimeMs: 1, size: 1 } as Stats;
 
 // Helper function to create mock governor limits
 function createMockGovernorLimits(
@@ -150,7 +152,10 @@ describe("findPerformanceBottlenecks", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockFs.access.mockResolvedValue(undefined);
+    // The suites reuse one path with different content, which the cache would
+    // otherwise hide.
+    clearApexLogCache();
+    mockFs.stat.mockResolvedValue(mockStats);
     mockFs.readFile.mockResolvedValue(mockLogContent);
   });
 
@@ -166,13 +171,13 @@ describe("findPerformanceBottlenecks", () => {
   describe("File validation and error handling", () => {
     it("should throw an error if log file does not exist", async () => {
       const args: BottleneckArgs = { logFilePath: "/nonexistent/file.log" };
-      mockFs.access.mockRejectedValue(new Error("File not found"));
+      mockFs.stat.mockRejectedValue(new Error("File not found"));
 
       await expect(findPerformanceBottlenecks(args)).rejects.toThrow(
         "Log file not found: /nonexistent/file.log",
       );
 
-      expect(mockFs.access).toHaveBeenCalledWith("/nonexistent/file.log");
+      expect(mockFs.stat).toHaveBeenCalledWith("/nonexistent/file.log");
       expect(mockFs.readFile).not.toHaveBeenCalled();
       expect(mockParse).not.toHaveBeenCalled();
     });
@@ -185,7 +190,7 @@ describe("findPerformanceBottlenecks", () => {
         "Permission denied",
       );
 
-      expect(mockFs.access).toHaveBeenCalledWith(mockLogFilePath);
+      expect(mockFs.stat).toHaveBeenCalledWith(mockLogFilePath);
       expect(mockFs.readFile).toHaveBeenCalledWith(mockLogFilePath, "utf-8");
       expect(mockParse).not.toHaveBeenCalled();
     });
@@ -200,7 +205,7 @@ describe("findPerformanceBottlenecks", () => {
         "Invalid log format",
       );
 
-      expect(mockFs.access).toHaveBeenCalledWith(mockLogFilePath);
+      expect(mockFs.stat).toHaveBeenCalledWith(mockLogFilePath);
       expect(mockFs.readFile).toHaveBeenCalledWith(mockLogFilePath, "utf-8");
       expect(mockParse).toHaveBeenCalledWith(mockLogContent);
     });

--- a/tests/findPerformanceBottlenecks.test.ts
+++ b/tests/findPerformanceBottlenecks.test.ts
@@ -16,12 +16,23 @@ import { extractMethods, SlowMethod } from "../src/tools/analyzeLogPerformance";
 import { decode } from "@toon-format/toon";
 
 // Mock dependencies
-jest.mock("fs", () => ({
-  promises: {
-    stat: jest.fn(),
-    readFile: jest.fn(),
-  },
-}));
+jest.mock("fs", () => {
+  const stat = jest.fn();
+  const readFile = jest.fn();
+  // A handle is the file at one path, so its stat and read delegate to the
+  // mocks above with that path filled in. Tests set and assert on those.
+  return {
+    promises: {
+      stat,
+      readFile,
+      open: jest.fn(async (path: string) => ({
+        stat: (options: unknown) => stat(path, options),
+        readFile: (encoding: unknown) => readFile(path, encoding),
+        close: jest.fn(),
+      })),
+    },
+  };
+});
 
 jest.mock("../src/ApexLogParser", () => ({
   parse: jest.fn(),

--- a/tests/getLogSummary.test.ts
+++ b/tests/getLogSummary.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { promises as fs, type Stats } from "fs";
+import { promises as fs, type BigIntStats } from "fs";
 
 import {
   getLogSummary,
@@ -35,7 +35,12 @@ jest.mock("../src/ApexLogParser", () => ({
 
 const mockFs = fs as jest.Mocked<typeof fs>;
 const mockParse = parse as jest.MockedFunction<typeof parse>;
-const mockStats = { mtimeMs: 1, size: 1 } as Stats;
+const mockStats = {
+  ino: 1n,
+  size: 1n,
+  mtimeNs: 1n,
+  ctimeNs: 1n,
+} as BigIntStats;
 
 // Helper function to create a mock LogLine
 const createMockLogLine = (
@@ -197,7 +202,7 @@ describe("getLogSummary", () => {
 
       const result = await getLogSummary(args);
 
-      expect(mockFs.stat).toHaveBeenCalledWith("/path/to/test-log.log");
+      expect(mockFs.stat).toHaveBeenCalledWith("/path/to/test-log.log", { bigint: true });
       expect(mockFs.readFile).toHaveBeenCalledWith(
         "/path/to/test-log.log",
         "utf-8",
@@ -447,7 +452,7 @@ describe("getLogSummary", () => {
         "Log file not found: /path/to/nonexistent.log",
       );
 
-      expect(mockFs.stat).toHaveBeenCalledWith("/path/to/nonexistent.log");
+      expect(mockFs.stat).toHaveBeenCalledWith("/path/to/nonexistent.log", { bigint: true });
       expect(mockFs.readFile).not.toHaveBeenCalled();
       expect(mockParse).not.toHaveBeenCalled();
     });
@@ -476,7 +481,7 @@ describe("getLogSummary", () => {
 
       await expect(getLogSummary(args)).rejects.toThrow("Failed to read file");
 
-      expect(mockFs.stat).toHaveBeenCalledWith("/path/to/unreadable.log");
+      expect(mockFs.stat).toHaveBeenCalledWith("/path/to/unreadable.log", { bigint: true });
       expect(mockFs.readFile).toHaveBeenCalledWith(
         "/path/to/unreadable.log",
         "utf-8",
@@ -498,7 +503,7 @@ describe("getLogSummary", () => {
 
       await expect(getLogSummary(args)).rejects.toThrow("Failed to parse log");
 
-      expect(mockFs.stat).toHaveBeenCalledWith("/path/to/corrupted.log");
+      expect(mockFs.stat).toHaveBeenCalledWith("/path/to/corrupted.log", { bigint: true });
       expect(mockFs.readFile).toHaveBeenCalledWith(
         "/path/to/corrupted.log",
         "utf-8",

--- a/tests/getLogSummary.test.ts
+++ b/tests/getLogSummary.test.ts
@@ -22,12 +22,23 @@ import {
 import { decode } from "@toon-format/toon";
 
 // Mock the dependencies
-jest.mock("fs", () => ({
-  promises: {
-    stat: jest.fn(),
-    readFile: jest.fn(),
-  },
-}));
+jest.mock("fs", () => {
+  const stat = jest.fn();
+  const readFile = jest.fn();
+  // A handle is the file at one path, so its stat and read delegate to the
+  // mocks above with that path filled in. Tests set and assert on those.
+  return {
+    promises: {
+      stat,
+      readFile,
+      open: jest.fn(async (path: string) => ({
+        stat: (options: unknown) => stat(path, options),
+        readFile: (encoding: unknown) => readFile(path, encoding),
+        close: jest.fn(),
+      })),
+    },
+  };
+});
 
 jest.mock("../src/ApexLogParser", () => ({
   parse: jest.fn(),

--- a/tests/getLogSummary.test.ts
+++ b/tests/getLogSummary.test.ts
@@ -2,13 +2,14 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { promises as fs } from "fs";
+import { promises as fs, type Stats } from "fs";
 
 import {
   getLogSummary,
   LogSummaryArgs,
   getLogSummaryToolConfig,
 } from "../src/tools/getLogSummary";
+import { clearApexLogCache } from "../src/tools/apexLogSource";
 import {
   parse,
   ApexLog,
@@ -23,7 +24,7 @@ import { decode } from "@toon-format/toon";
 // Mock the dependencies
 jest.mock("fs", () => ({
   promises: {
-    access: jest.fn(),
+    stat: jest.fn(),
     readFile: jest.fn(),
   },
 }));
@@ -34,6 +35,7 @@ jest.mock("../src/ApexLogParser", () => ({
 
 const mockFs = fs as jest.Mocked<typeof fs>;
 const mockParse = parse as jest.MockedFunction<typeof parse>;
+const mockStats = { mtimeMs: 1, size: 1 } as Stats;
 
 // Helper function to create a mock LogLine
 const createMockLogLine = (
@@ -70,6 +72,9 @@ const createMockLogLine = (
 describe("getLogSummary", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // The suites reuse one path with different content, which the cache would
+    // otherwise hide.
+    clearApexLogCache();
   });
 
   describe("tool configuration", () => {
@@ -182,7 +187,7 @@ describe("getLogSummary", () => {
       const mockLogContent = "mock log content";
       const mockApexLog = createMockApexLog();
 
-      mockFs.access.mockResolvedValue(undefined);
+      mockFs.stat.mockResolvedValue(mockStats);
       mockFs.readFile.mockResolvedValue(mockLogContent);
       mockParse.mockReturnValue(mockApexLog);
 
@@ -192,7 +197,7 @@ describe("getLogSummary", () => {
 
       const result = await getLogSummary(args);
 
-      expect(mockFs.access).toHaveBeenCalledWith("/path/to/test-log.log");
+      expect(mockFs.stat).toHaveBeenCalledWith("/path/to/test-log.log");
       expect(mockFs.readFile).toHaveBeenCalledWith(
         "/path/to/test-log.log",
         "utf-8",
@@ -242,7 +247,7 @@ describe("getLogSummary", () => {
         ] as any,
       });
 
-      mockFs.access.mockResolvedValue(undefined);
+      mockFs.stat.mockResolvedValue(mockStats);
       mockFs.readFile.mockResolvedValue("mock log content");
       mockParse.mockReturnValue(mockApexLog);
 
@@ -268,7 +273,7 @@ describe("getLogSummary", () => {
         namespaces: ["default", "CustomApp", "ThirdParty"],
       });
 
-      mockFs.access.mockResolvedValue(undefined);
+      mockFs.stat.mockResolvedValue(mockStats);
       mockFs.readFile.mockResolvedValue("mock log content");
       mockParse.mockReturnValue(mockApexLog);
 
@@ -301,7 +306,7 @@ describe("getLogSummary", () => {
         parsingErrors: ["Unknown log event type: CUSTOM_EVENT"],
       });
 
-      mockFs.access.mockResolvedValue(undefined);
+      mockFs.stat.mockResolvedValue(mockStats);
       mockFs.readFile.mockResolvedValue("mock log content");
       mockParse.mockReturnValue(mockApexLog);
 
@@ -335,7 +340,7 @@ describe("getLogSummary", () => {
         children: mockChildren,
       });
 
-      mockFs.access.mockResolvedValue(undefined);
+      mockFs.stat.mockResolvedValue(mockStats);
       mockFs.readFile.mockResolvedValue("mock log content");
       mockParse.mockReturnValue(mockApexLog);
 
@@ -379,7 +384,7 @@ describe("getLogSummary", () => {
         children: [],
       });
 
-      mockFs.access.mockResolvedValue(undefined);
+      mockFs.stat.mockResolvedValue(mockStats);
       mockFs.readFile.mockResolvedValue("mock log content");
       mockParse.mockReturnValue(mockApexLog);
 
@@ -415,7 +420,7 @@ describe("getLogSummary", () => {
       ];
 
       for (const logFilePath of paths) {
-        mockFs.access.mockResolvedValue(undefined);
+        mockFs.stat.mockResolvedValue(mockStats);
         mockFs.readFile.mockResolvedValue("mock log content");
         mockParse.mockReturnValue(createMockApexLog());
 
@@ -432,7 +437,7 @@ describe("getLogSummary", () => {
   describe("error handling", () => {
     it("should throw an error when log file does not exist", async () => {
       const fileNotFoundError = new Error("ENOENT: no such file or directory");
-      mockFs.access.mockRejectedValue(fileNotFoundError);
+      mockFs.stat.mockRejectedValue(fileNotFoundError);
 
       const args: LogSummaryArgs = {
         logFilePath: "/path/to/nonexistent.log",
@@ -442,14 +447,14 @@ describe("getLogSummary", () => {
         "Log file not found: /path/to/nonexistent.log",
       );
 
-      expect(mockFs.access).toHaveBeenCalledWith("/path/to/nonexistent.log");
+      expect(mockFs.stat).toHaveBeenCalledWith("/path/to/nonexistent.log");
       expect(mockFs.readFile).not.toHaveBeenCalled();
       expect(mockParse).not.toHaveBeenCalled();
     });
 
     it("should throw an error when file access check fails for other reasons", async () => {
       const permissionError = new Error("EACCES: permission denied");
-      mockFs.access.mockRejectedValue(permissionError);
+      mockFs.stat.mockRejectedValue(permissionError);
 
       const args: LogSummaryArgs = {
         logFilePath: "/path/to/restricted.log",
@@ -461,7 +466,7 @@ describe("getLogSummary", () => {
     });
 
     it("should propagate file read errors", async () => {
-      mockFs.access.mockResolvedValue(undefined);
+      mockFs.stat.mockResolvedValue(mockStats);
       const readError = new Error("Failed to read file");
       mockFs.readFile.mockRejectedValue(readError);
 
@@ -471,7 +476,7 @@ describe("getLogSummary", () => {
 
       await expect(getLogSummary(args)).rejects.toThrow("Failed to read file");
 
-      expect(mockFs.access).toHaveBeenCalledWith("/path/to/unreadable.log");
+      expect(mockFs.stat).toHaveBeenCalledWith("/path/to/unreadable.log");
       expect(mockFs.readFile).toHaveBeenCalledWith(
         "/path/to/unreadable.log",
         "utf-8",
@@ -480,7 +485,7 @@ describe("getLogSummary", () => {
     });
 
     it("should propagate parsing errors", async () => {
-      mockFs.access.mockResolvedValue(undefined);
+      mockFs.stat.mockResolvedValue(mockStats);
       mockFs.readFile.mockResolvedValue("invalid log content");
       const parseError = new Error("Failed to parse log");
       mockParse.mockImplementation(() => {
@@ -493,7 +498,7 @@ describe("getLogSummary", () => {
 
       await expect(getLogSummary(args)).rejects.toThrow("Failed to parse log");
 
-      expect(mockFs.access).toHaveBeenCalledWith("/path/to/corrupted.log");
+      expect(mockFs.stat).toHaveBeenCalledWith("/path/to/corrupted.log");
       expect(mockFs.readFile).toHaveBeenCalledWith(
         "/path/to/corrupted.log",
         "utf-8",
@@ -509,7 +514,7 @@ describe("getLogSummary", () => {
         parsingErrors: [], // empty parsing errors
       });
 
-      mockFs.access.mockResolvedValue(undefined);
+      mockFs.stat.mockResolvedValue(mockStats);
       mockFs.readFile.mockResolvedValue("mock log content");
       mockParse.mockReturnValue(mockApexLog);
 
@@ -543,7 +548,7 @@ describe("getLogSummary", () => {
         children: mockChildren,
       });
 
-      mockFs.access.mockResolvedValue(undefined);
+      mockFs.stat.mockResolvedValue(mockStats);
       mockFs.readFile.mockResolvedValue("mock log content");
       mockParse.mockReturnValue(mockApexLog);
 
@@ -579,7 +584,7 @@ describe("getLogSummary", () => {
         children: mockChildren,
       });
 
-      mockFs.access.mockResolvedValue(undefined);
+      mockFs.stat.mockResolvedValue(mockStats);
       mockFs.readFile.mockResolvedValue("mock log content");
       mockParse.mockReturnValue(mockApexLog);
 
@@ -607,7 +612,7 @@ describe("getLogSummary", () => {
         children: mockChildren,
       });
 
-      mockFs.access.mockResolvedValue(undefined);
+      mockFs.stat.mockResolvedValue(mockStats);
       mockFs.readFile.mockResolvedValue("mock log content");
       mockParse.mockReturnValue(mockApexLog);
 
@@ -645,7 +650,7 @@ describe("getLogSummary", () => {
         governorLimits: customGovernorLimits,
       });
 
-      mockFs.access.mockResolvedValue(undefined);
+      mockFs.stat.mockResolvedValue(mockStats);
       mockFs.readFile.mockResolvedValue("mock log content");
       mockParse.mockReturnValue(mockApexLog);
 
@@ -698,7 +703,7 @@ describe("getLogSummary", () => {
         governorLimits: maxGovernorLimits,
       });
 
-      mockFs.access.mockResolvedValue(undefined);
+      mockFs.stat.mockResolvedValue(mockStats);
       mockFs.readFile.mockResolvedValue("mock log content");
       mockParse.mockReturnValue(mockApexLog);
 


### PR DESCRIPTION
Stacked on #83 — review that first; this PR's diff is the last commit.

## Problem

Two defects found while measuring for #83:

- **The log is parsed once per tool.** The same `fs.access` / `readFile` / `parse` preamble was copy-pasted into all three analysis tools, each with its own `NS_TO_MS` constant. A "summary, then go deeper" flow parsed a 19 MB log three times.
- **`totalMethods` disagreed between tools.** `get_apex_log_summary` did not count entry points (`CODE_UNIT_STARTED`), so it reported 11 where `analyze_apex_log_performance` and `find_performance_bottlenecks` reported 13.

## Change

New `src/tools/apexLogSource.ts` is the one way the analysis tools get a log:

- `loadApexLog` reads and parses, and reuses the last parse when the same file is asked for again and neither its size nor its modification time changed. One slot: the flow works through one log at a time, and a parsed 19 MB log is too big to hold several of.
- `isMethodNode` is the one method test, so the three tools agree on `totalMethods`.
- `walkLog` is the one traversal.

`NS_TO_MS` moves to `responseShaping.ts`.

## Effect on responses

No tool, parameter or response field changed. The one value that moves is `get_apex_log_summary.totalMethods`, which now matches the other two tools — visible in the two re-recorded goldens (11 → 13, 1 → 2). The value changes, not the payload size, so the token cost table #81 publishes is unaffected.

## Verification

- `pnpm run build`, `pnpm run lint` clean
- `pnpm test` — 240 passing in 13 suites (8 new for `apexLogSource`: cache hit, miss on mtime, size and path, missing file, `isMethodNode`, `walkLog`)
- `pnpm run eval` — 6/6, with the two `get_apex_log_summary` goldens re-recorded for the fix above

