### PR TITLE
docs(skills): add lean-mcp-tools and changelog-entry

### DIFF
--- a/.claude/skills/changelog-entry/SKILL.md
+++ b/.claude/skills/changelog-entry/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: changelog-entry
+description: Use when writing, editing or reviewing a CHANGELOG.md entry, when a pull request needs a changelog line, when deciding if a change is breaking or needs a migration note, or when a changelog conflict appears while rebasing stacked branches.
+---
+
+# Changelog entry
+
+A changelog is written for the person who upgrades. How the change was made, what it cost, and which
+files moved belong in the issue and the pull request.
+
+## The shape of an entry
+
+```
+- [**Breaking:** ]<present-tense verb> <what the user gets> ([#<issue>])
+```
+
+```markdown
+### Changed
+
+- **Breaking:** drop `file` from `get_apex_log_summary` in favour of the scalar `topMethodsSelfPercentage` ([#86])
+- Reduce every tool response with no fact lost: `execute_anonymous` by 30%, `get_apex_log_summary` by 27% ([#86])
+
+<!-- Unreleased -->
+
+[#86]: https://github.com/owner/repo/issues/86
+```
+
+- **One line, one sentence.** No sub-bullets. No semicolon joining two facts.
+- **Present tense.** "Add", "Reduce", "Refuse" — not "Added", "Reduced".
+- **Breaking entries first** in their section, prefixed `**Breaking:**`.
+- **Sections in this order:** Changed, Added, Removed, Fixed.
+- **A reference link on every substantial entry**, defined under `<!-- Unreleased -->` at the end of
+  the file. Never an inline URL.
+
+## What earns an entry
+
+One entry per user-visible change, not one per commit. If a user of the released package cannot see
+it, it gets no entry: a refactor, a renamed internal helper, a test, the mechanism behind a fix.
+
+Give the result, not the method. A number earns its place when the size **is** the result
+("Reduce ... by 31%"); how it was measured does not.
+
+Already-unreleased work: edit the existing entry. A change nobody has received is not a change.
+
+No issue fits? File one, then reference it.
+
+## Wrong, then right
+
+| Wrong | Right |
+| --- | --- |
+| `- Removed destructiveHint from three tools, since the spec says it is meaningless when readOnlyHint is true` | no entry — the user sees no difference |
+| `- Replaced ten per-category properties with one z.partialRecord, cutting ~844 to ~428 tokens` | fold the result into the one user-facing entry |
+| `- Reduced the cost by 31% ([#87](https://.../87))` | `- Reduce the cost by 31% ([#87])`, plus a reference definition |
+
+## Versions and migration
+
+- A version heading is added when the release is tagged, with an absolute date: `## [1.0.0] - 2026-03-20`.
+  Until then everything sits under `## [Unreleased]`.
+- **Major** is forced by behaviour that changes for someone who upgrades and changes nothing else.
+- When upgrading needs an action, add a migration note under `## [Unreleased]` that points at it.
+
+## Stacked branches
+
+Every branch in a stack writes into the same `## [Unreleased]` section, so a rebase conflicts there.
+Keep both sides. Losing the other branch's entry is silent, and review will not catch it.

--- a/.claude/skills/lean-mcp-tools/SKILL.md
+++ b/.claude/skills/lean-mcp-tools/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: lean-mcp-tools
+description: Use when adding or editing an MCP tool definition — its name, title, description, inputSchema or annotations — when a server's tools/list looks expensive, when deciding whether a fact belongs in a tool description or the server instructions, or when the context cost of an MCP server needs measuring or budgeting.
+---
+
+# Lean MCP tools
+
+A response is paid for when a tool is called. A **definition** is paid for on every request, called
+or not, because the client sends all of them with each one. Server `instructions` sit between: once
+per session. Put each fact where its audience reads it.
+
+| Fact | Goes in |
+| --- | --- |
+| True of every tool ("all durations are in milliseconds") | `instructions` |
+| Why a caller picks this tool over its neighbour | that tool's `description` |
+| A value | the response |
+
+## What a definition holds
+
+- `name`, `title` — the display field. `annotations.title` is a second copy; drop it.
+- `description` — the selection prompt: what it returns, when to pick it, nothing the schema below
+  already says.
+- `inputSchema` — a `describe` only for what the property name and its type cannot say.
+- `annotations` — only spec hints that differ from the default **and** carry meaning.
+  `destructiveHint` and `idempotentHint` are defined as meaningful only when `readOnlyHint` is false,
+  so a read-only tool declares `readOnlyHint: true` and `openWorldHint: false` and stops. There is no
+  `priority` hint.
+
+## Restructure before you delete
+
+Deleting a fact costs the answer and saves less than reshaping it.
+
+- Ten per-category properties, each inlining the same enum, became
+  `z.partialRecord(z.enum(CATEGORIES), z.enum(LEVELS))` — each enum emitted once. ~844 tokens to
+  ~428, wire form unchanged, unknown keys now rejected. (Plain `z.record` is cheaper still, but marks
+  every key required.)
+- Hold the values as an `as const` tuple and build the schema from it, so no description restates them.
+
+## Measure the whole wire object
+
+```js
+estimateTokens(JSON.stringify(tool)); // per tool, from a live tools/list over stdio
+```
+
+A budget over `{name, description, inputSchema}` guards a subset of the cost: it let `title`,
+`annotations` and the SDK's own fields grow ~215 tokens unwatched.
+
+**A definition is not finished until a check covers it.** Three assertions, in the gate that already
+runs the server:
+
+1. A per-tool budget, ~5% headroom, so one careless sentence fails.
+2. A total under the last released figure, held as a constant. This also catches a new tool.
+3. Selection keywords, one or two per tool. Clients match the words in the description, so a trim
+   that saves tokens can cost discovery. Make that trade fail loudly.
+
+Generate every published figure from the run, so a stale number fails too. Pin annotations with unit
+tests; a budget with headroom will not notice a hint coming back.
+
+## Know the floor
+
+`$schema`, from zod's `toJSONSchema`, and `execution`, added by the SDK, cost ~90 tokens across four
+tools and have no public hook. Record the floor; do not reach into SDK internals for it.
+
+## Do not
+
+- Merge tools to save tokens. It breaks callers, tests and clients that register by tool name, and a
+  flattened schema stops saying which parameter belongs to which mode.
+- Add `outputSchema` for economy. The spec asks for the payload in a text block too, so it goes twice.


### PR DESCRIPTION
Two skills, written from what #87 and #86 taught, so the next change to a tool definition or a changelog entry does not have to relearn it. Contributor tooling only: no source file changes, no changelog entry, nothing shipped in the package.

- **`lean-mcp-tools`** — where a fact belongs (a definition costs tokens on every request, `instructions` once per session, a response once per call), what a definition may hold, restructuring instead of deleting, the `z.partialRecord` win, measuring the whole wire object, and the three assertions that gate it.
- **`changelog-entry`** — the shape of one entry, what earns one, versions and migration notes, and why a stacked-branch conflict in `## [Unreleased]` keeps both sides.

Each is one `SKILL.md` under `.claude/skills/`, symlinked from `~/.claude/skills/` so it is available in every project.

## Tested, not asserted

Both were written test-first, following `superpowers:writing-skills`. A subagent got the task with no mention of skills, twice: once before the skill existed, once after.

**`lean-mcp-tools`** — the baseline invented an `annotations: { priority: 6 }` hint, dropped `readOnlyHint` and `openWorldHint`, restated "in milliseconds" in three per-property descriptions, added an `outputSchema`, and listed six pre-ship checks, none of which measured anything. With the skill: no invented hint, no duplicated `title`, "in milliseconds" moved to `instructions`, `outputSchema` declined for the double-send reason, and the checks became the per-tool budget, the total against the last published figure, and the keyword assertion — plus a unit test to pin the annotations.

**`changelog-entry`** — the baseline wrote five past-tense entries for one user-visible change, promoted `z.partialRecord` and the spec reasoning into user-facing lines, referenced the issue on the first entry only, and used an inline URL. With the skill: one present-tense line, a reference definition under `<!-- Unreleased -->`, and the mechanism, the spec detail and the contributor-facing eval check all left out as unobservable to someone upgrading.

Both skills were selected from their description alone, with no prompting.
