### PR TITLE
fix(operations): read the calling namespace off the direct parent

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -260,6 +260,13 @@ asked for the work. `DMLBeginLine` pins `namespace = "default"` however the DML 
 `SOQLExecuteBeginLine` and `SOSLExecuteBeginLine` carry no namespace logic at all and so inherit the
 caller's. The caller is a second fact, and `Operation.callerNamespace` holds it.
 
+It is read off the **direct parent event**, not off the nearest ancestor that ranks as an operation.
+Measured over 298 real logs and 1,178,604 operations the two readings agree on every row, because
+the parser copies a namespace down to every child that has none. The only rows where they could
+diverge are the 289 whose parent is the `EXECUTION_STARTED` frame, and that frame is `default`. So
+the reading is the cheaper one to reason about rather than a different answer: it holds even if the
+set of frames the ranking skips grows.
+
 It does not earn a column. Measured over two real logs:
 
 | log | rows | caller differs |

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -121,9 +121,10 @@ export interface Operation {
   name: string;
   namespace: string;
   /**
-   * The namespace of the frame that called this one, which is not always the
-   * one the operation runs in: DML is pinned to `default` however it was
-   * reached, so only the caller says which package drove it.
+   * The namespace of the frame that called this one, read off the direct parent
+   * event. It is not always the one the operation runs in: DML is pinned to
+   * `default` however it was reached, so only the caller says which package
+   * drove it.
    *
    * Internal. The two are the same on all but a few percent of rows, so a
    * column would cost every response for an answer almost none of them carry;
@@ -243,7 +244,7 @@ export function listOperations(apexLog: ApexLog): Operation[] {
       kind,
       name: operationName(node),
       namespace: node.namespace || "default",
-      callerNamespace: parent?.namespace ?? "default",
+      callerNamespace: node.parent?.namespace || "default",
       callCount: 1,
       durationTotalNs: node.duration.total,
       durationSelfNs: node.duration.self,

--- a/tests/listSlowOperations.test.ts
+++ b/tests/listSlowOperations.test.ts
@@ -77,7 +77,8 @@ type PlanSpec = {
 
 function node(spec: NodeSpec): unknown {
   const total = spec.totalNs ?? 0;
-  return {
+  const children = (spec.children ?? []).map(node) as { parent?: unknown }[];
+  const built = {
     ...spec.plan,
     type: spec.type ?? null,
     ...(spec.subCategory && { subCategory: spec.subCategory }),
@@ -91,8 +92,13 @@ function node(spec: NodeSpec): unknown {
     dmlRowCount: { total: spec.dmlRowCount ?? 0, self: 0 },
     soslRowCount: { total: spec.soslRowCount ?? 0, self: 0 },
     totalThrownCount: spec.thrownCount ?? 0,
-    children: (spec.children ?? []).map(node),
+    children,
   };
+
+  // The parser links every child to its parent, and `callerNamespace` reads it.
+  children.forEach((child) => (child.parent = built));
+
+  return built;
 }
 
 /** A log whose root is the transaction frame, and which runs `children`. */

--- a/tests/operations.test.ts
+++ b/tests/operations.test.ts
@@ -33,7 +33,8 @@ type NodeSpec = {
 
 function node(spec: NodeSpec): unknown {
   const total = spec.totalNs ?? 0;
-  return {
+  const children = (spec.children ?? []).map(node) as { parent?: unknown }[];
+  const built = {
     type: spec.type ?? null,
     ...(spec.subCategory && { subCategory: spec.subCategory }),
     text: spec.text ?? null,
@@ -46,8 +47,13 @@ function node(spec: NodeSpec): unknown {
     dmlRowCount: { total: spec.dmlRowCount ?? 0, self: 0 },
     soslRowCount: { total: spec.soslRowCount ?? 0, self: 0 },
     totalThrownCount: spec.thrownCount ?? 0,
-    children: (spec.children ?? []).map(node),
+    children,
   };
+
+  // The parser links every child to its parent, and `callerNamespace` reads it.
+  children.forEach((child) => (child.parent = built));
+
+  return built;
 }
 
 /** A log whose root is the transaction frame the parser always emits. */
@@ -163,6 +169,41 @@ describe("listOperations", () => {
       name: "METHOD_ENTRY",
       namespace: "default",
     });
+  });
+
+  it("reads the calling namespace off the direct parent, not the nearest ranked one", () => {
+    const operations = listOperations(
+      logOf({
+        type: "METHOD_ENTRY",
+        subCategory: "Method",
+        text: "Custom.run",
+        namespace: "Custom",
+        totalNs: 50_000_000,
+        children: [
+          {
+            // Synthetic: the parser copies a namespace down, so no real log puts
+            // a namespace of its own on an untimed frame. It pins the reading to
+            // the direct parent even so.
+            type: "VARIABLE_ASSIGNMENT",
+            text: "row",
+            namespace: "Other",
+            children: [
+              {
+                type: "DML_BEGIN",
+                subCategory: "DML",
+                text: "DML Insert Account",
+                namespace: "default",
+                totalNs: 40_000_000,
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(
+      operations.find((operation) => operation.kind === "dml"),
+    ).toMatchObject({ callerNamespace: "Other" });
   });
 });
 


### PR DESCRIPTION
## 📝 What & why

`Operation.callerNamespace` read the nearest ancestor that ranks as an operation. It now reads the direct parent event, so the field no longer depends on which frames the ranking skips.

Measured over 298 logs and 1,178,604 operations the two readings agree on every row, because the parser copies a namespace down to every child that has none. Only the 289 rows under the `EXECUTION_STARTED` frame could diverge, and that frame is `default`. No response changes: the eval goldens are unmoved.

The test helpers built nodes with no `parent` link, which the real parser always sets. Both now link children to their parent.

## 🧩 Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance
- [ ] 📝 Docs
- [ ] 🔧 Chore (tooling, CI, deps)
- [ ] 💥 Breaking change

## 🔗 Related issues

Follows #127, which shipped `groupBy: "callerNamespace"` on the old reading. Still unreleased, so the semantics change costs no compatibility.

## 🧪 How was this tested?

- [x] `pnpm run build`
- [x] `pnpm run test`
- [x] `pnpm run lint`
- [x] `pnpm run eval` — 6/6, goldens unchanged
- [ ] Manually tested against an MCP client / debug log

## ✅ Checklist

- [x] Added or updated tests (or not needed)
- [x] Updated docs — README / CHANGELOG (or not needed)
