### PR TITLE
fix: log lookup date literal, and the Salesforce CLI log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
+import "./salesforce/logging.js";
 import { parseServerConfig, runStdioServer } from "./server.js";
 
 runStdioServer(parseServerConfig(process.argv.slice(2)));

--- a/src/salesforce/logging.ts
+++ b/src/salesforce/logging.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * Turn the Salesforce CLI log off, before anything reaches `@salesforce/core`.
+ *
+ * Core logs through a pino worker thread nothing listens to, so a failed write
+ * to `~/.sf` ends the process, and under `DEBUG` it writes to stdout, which is
+ * the MCP transport. Nothing here reads that log. Set `SF_DISABLE_LOG_FILE` to
+ * anything but `true` to keep it, and it goes to stderr.
+ *
+ * A module of its own, because a module body runs after every import it sits
+ * beside: only the import graph can put this ahead of core's first `Logger`.
+ */
+process.env.SF_DISABLE_LOG_FILE ||= "true";
+process.env.SF_LOG_STDERR ||= "true";

--- a/src/salesforce/soql.ts
+++ b/src/salesforce/soql.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * A date the jsforce query builder renders as a SOQL date-time literal.
+ *
+ * The builder has a case for its own `SfDate` and none for a `Date`, which it
+ * passes through `String` into prose SOQL rejects. Anything else it stringifies
+ * as it stands, so a value that stringifies to ISO 8601 is the literal.
+ */
+export function toDateTimeLiteral(date: Date): { toString(): string } {
+  return { toString: () => date.toISOString() };
+}

--- a/src/salesforce/traceFlags.ts
+++ b/src/salesforce/traceFlags.ts
@@ -1,11 +1,8 @@
 import { Connection } from "@salesforce/core";
+import { toDateTimeLiteral } from "./soql.js";
 
 const TRACE_FLAG_SOBJECT = "TraceFlag";
 const USER_DEBUG = "USER_DEBUG";
-
-function toDateTimeLiteral(date: Date): { toString(): string } {
-  return { toString: () => date.toISOString() };
-}
 
 type TraceFlag = {
   Id: string;

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -21,6 +21,7 @@ import { ensureTraceFlag } from "../salesforce/traceFlags.js";
 import { loadApexLog } from "./apexLogSource.js";
 import { NS_TO_MS, roundMs } from "./responseShaping.js";
 import { resolveOrg } from "../salesforce/connection.js";
+import { toDateTimeLiteral } from "../salesforce/soql.js";
 import {
   classifyOrg,
   type OrgClassification,
@@ -405,7 +406,7 @@ async function findStoredLogId(
         {
           LogUserId: userId,
           LogLength: Buffer.byteLength(debugLog, "utf-8"),
-          StartTime: { $gte: since },
+          StartTime: { $gte: toDateTimeLiteral(since) },
         },
         ["Id"],
         { sort: { StartTime: -1 } },

--- a/tests/executeAnonymous.test.ts
+++ b/tests/executeAnonymous.test.ts
@@ -490,7 +490,7 @@ describe("Execute Anonymous", () => {
         {
           LogUserId: customUserId,
           LogLength: Buffer.byteLength(testLogBody, "utf-8"),
-          StartTime: { $gte: expect.any(Date) },
+          StartTime: { $gte: expect.anything() },
         },
         ["Id"],
         { sort: { StartTime: -1 } },
@@ -510,12 +510,14 @@ describe("Execute Anonymous", () => {
       );
 
       const { StartTime } = mockFindOne.mock.calls[0][0] as {
-        StartTime: { $gte: Date };
+        StartTime: { $gte: { toString(): string } };
       };
-      expect(StartTime.$gte.getTime()).toBeGreaterThanOrEqual(
-        before - CLOCK_SKEW_MS,
-      );
-      expect(StartTime.$gte.getTime()).toBeLessThanOrEqual(Date.now());
+      // The builder renders the bound with `String()`, and only a bare ISO 8601
+      // literal is a date SOQL reads.
+      const bound = String(StartTime.$gte);
+      expect(bound).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/);
+      expect(Date.parse(bound)).toBeGreaterThanOrEqual(before - CLOCK_SKEW_MS);
+      expect(Date.parse(bound)).toBeLessThanOrEqual(Date.now());
     });
 
     // The id is matched, not given, so a wrong match must cost a filename

--- a/tests/salesforce/logging.test.ts
+++ b/tests/salesforce/logging.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+const DISABLE = "SF_DISABLE_LOG_FILE";
+const STDERR = "SF_LOG_STDERR";
+
+/** The module writes to the environment, so each case gets it back as it was. */
+describe("Salesforce logging", () => {
+  const before = {
+    [DISABLE]: process.env[DISABLE],
+    [STDERR]: process.env[STDERR],
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    delete process.env[DISABLE];
+    delete process.env[STDERR];
+  });
+
+  afterAll(() => {
+    for (const [name, value] of Object.entries(before)) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  });
+
+  const load = async () => await import("../../src/salesforce/logging");
+
+  it("should turn the log off when nothing asked for it", async () => {
+    await load();
+
+    expect(process.env[DISABLE]).toBe("true");
+    expect(process.env[STDERR]).toBe("true");
+  });
+
+  it("should keep the log for a caller that asked for it", async () => {
+    process.env[DISABLE] = "false";
+
+    await load();
+
+    expect(process.env[DISABLE]).toBe("false");
+  });
+
+  // A wrapper forwarding a variable it has not set gives an empty string, which
+  // core reads as "log", not as "unset".
+  it("should turn the log off when the setting is empty", async () => {
+    process.env[DISABLE] = "";
+    process.env[STDERR] = "";
+
+    await load();
+
+    expect(process.env[DISABLE]).toBe("true");
+    expect(process.env[STDERR]).toBe("true");
+  });
+});

--- a/tests/salesforce/soql.test.ts
+++ b/tests/salesforce/soql.test.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+import { toDateTimeLiteral } from "../../src/salesforce/soql";
+
+describe("toDateTimeLiteral", () => {
+  it("should stringify to a bare ISO 8601 literal", () => {
+    const date = new Date("2026-08-20T09:15:30.500Z");
+
+    // A `Date` here stringifies to "Thu Aug 20 2026 …", which SOQL rejects.
+    expect(String(toDateTimeLiteral(date))).toBe("2026-08-20T09:15:30.500Z");
+  });
+});


### PR DESCRIPTION
Two independent fixes, one commit each.

## The log lookup sent a date SOQL rejects

The jsforce query builder has a case for its own `SfDate` and none for a `Date`,
so it renders a `Date` through `String()` as `Thu Aug 20 2026 12:32:01 GMT+0100 …`.
The query for the stored `ApexLog` therefore always failed, and the run reported
no log id.

The bound is now a value that stringifies to ISO 8601, which the builder emits
bare. `traceFlags` has done this since March, so the helper moves to
`src/salesforce/soql.ts` and both callers share it.

Proved against a live org, same condition, three value types:

```
plain string  → SELECT Id FROM ApexLog WHERE StartTime >= '2026-08-19T13:01:04.290Z'   FAILED
{toString}    → OK -> 07LRK00000c7Jub2AE
raw Date      → ... WHERE StartTime >= Wed Aug 19 2026 14:01:04 GMT+0100                FAILED
```

A plain ISO string cannot be used: the builder quotes every string, and SOQL
rejects a quoted dateTime. `SfDate` would need `@jsforce/jsforce-node` as a
direct dependency, which today is only transitive.

## The Salesforce CLI log could kill the server, or corrupt its stdout

`@salesforce/core` writes its `~/.sf` log through a pino worker thread nothing
listens to, so a failed write (`EPERM` on a read-only home) ends the process.
With `DEBUG` set it writes to stdout instead, which is the MCP transport.

Nothing here reads that log, so it is off, and it goes to stderr for a caller
that asks for it back with `SF_DISABLE_LOG_FILE=false`. It is a module of its
own, imported above `./server.js`: a module body runs after every import beside
it, so only the import graph can put this ahead of core's first `Logger`.

## Checks

- `tsc --noEmit`, `pnpm run lint` clean; jest 306 pass / 16 suites; `pnpm run eval` 6/6, goldens unchanged
- live scratch org, home unwritable → log saved, `succeeded: true`, no crash
- live scratch org, `DEBUG=1 SF_LOG_LEVEL=debug` → stdout stayed parsable JSON-RPC, and `~/.sf/sf-2026-08-20.log` was not touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)