### PR TITLE
chore: parser migration follow-ups — own the category vocabulary, add a heap fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The input side is the same for every analysis tool — a tool name and a log fil
 | ------------------------------ | -------------------- | -------- | ---- | ------ |
 | `apexlog_get_summary`          | `governor-heavy.log` | ~348     | ~293 | +19%   |
 | `apexlog_get_summary`          | `minimal.log`        | ~244     | ~249 | -2%    |
+| `apexlog_get_summary`          | `heap-heavy.log`     | ~256     | —    | —      |
 | `apexlog_list_slow_operations` | `governor-heavy.log` | ~395     | ~408 | -3%    |
 | `apexlog_list_slow_operations` | `minimal.log`        | ~116     | ~190 | -39%   |
 | `apexlog_list_limit_risks`     | `governor-heavy.log` | ~45      | ~84  | -46%   |

--- a/scripts/eval.mjs
+++ b/scripts/eval.mjs
@@ -281,8 +281,11 @@ const SELECTION_KEYWORDS = {
  * case is a server round trip and a golden file a reviewer has to read, so a
  * case earns its place only by pinning something the others would miss — and a
  * cross product spends three cases on a fixture that answers one question.
- * `heap-heavy` is here for `apexlog_get_summary` alone, the one tool that
- * publishes a heap figure.
+ * `heap-heavy` is here for `apexlog_get_summary` alone, the one tool whose
+ * answer its heap changes. `apexlog_list_limit_risks` does read heap, but this
+ * log's heap sits under its risk threshold, and the rows
+ * `apexlog_list_slow_operations` would rank are kinds `governor-heavy` pins
+ * already.
  */
 const FIXTURES_BY_TOOL = {
   apexlog_get_summary: ["governor-heavy", "minimal", "heap-heavy"],

--- a/scripts/eval.mjs
+++ b/scripts/eval.mjs
@@ -164,6 +164,8 @@ const ANSWERABILITY = {
  * without naming them: the golden file is what pins *which* limits exist, so a
  * new limit needs one edit rather than two.
  */
+const MINIMAL_FIXTURE = "minimal";
+
 const MINIMAL_ZEROS = {
   apexlog_get_summary: {
     fields: ["parsingErrorCount"],
@@ -296,6 +298,71 @@ const FIXTURES_BY_TOOL = {
 const CASES = Object.entries(FIXTURES_BY_TOOL).flatMap(([tool, fixtures]) =>
   fixtures.map((fixture) => ({ tool, fixture })),
 );
+
+const CASE_KEYS = new Set(
+  CASES.map(({ tool, fixture }) => `${tool}/${fixture}`),
+);
+
+/**
+ * Everything declared per case has to name a case the run measures.
+ *
+ * Nothing else notices a case that stops being run: `checkAnswerability` skips
+ * a check whose fixture is not the one in hand and the minimal-zeros block at
+ * its tail returns early off the same test, `checkTokenBudget` only reports a
+ * budget that is missing, and a retired case's golden file simply stops being
+ * read. So dropping a fixture or a tool from `FIXTURES_BY_TOOL` retires every
+ * check scoped to it and the run still passes.
+ *
+ * `SELECTION_KEYWORDS` has the same hole but is keyed by what `tools/list`
+ * returns rather than by a case, so `checkDefinitionBudget` is where it belongs.
+ */
+function checkChecksAreRun(failures) {
+  const notRun = (tool, fixture) => !CASE_KEYS.has(`${tool}/${fixture}`);
+
+  for (const [tool, checks] of Object.entries(ANSWERABILITY)) {
+    if (!FIXTURES_BY_TOOL[tool]?.length) {
+      failures.push(
+        `${tool}: ${checks.length} answerability check(s) declared, but the tool is measured against no fixture`,
+      );
+    }
+    for (const { question, fixture } of checks) {
+      if (fixture && notRun(tool, fixture)) {
+        failures.push(
+          `${tool}: "${question}" is pinned on ${fixture}, which this run does not measure`,
+        );
+      }
+    }
+  }
+
+  for (const tool of Object.keys(MINIMAL_ZEROS)) {
+    if (notRun(tool, MINIMAL_FIXTURE)) {
+      failures.push(
+        `${tool}: the zeros it must report are pinned on ${MINIMAL_FIXTURE}, which this run does not measure`,
+      );
+    }
+  }
+
+  for (const [what, declared] of [
+    ["a token budget", TOKEN_BUDGET],
+    ["a 1.x response cost", V1_RESPONSE_TOKENS],
+  ]) {
+    for (const key of Object.keys(declared)) {
+      if (!CASE_KEYS.has(key)) {
+        failures.push(
+          `${key}: ${what} is declared for a case this run does not measure`,
+        );
+      }
+    }
+  }
+
+  for (const tool of Object.keys(FIXTURES_BY_TOOL)) {
+    if (!ANSWERABILITY[tool]) {
+      failures.push(
+        `${tool}: measured against ${FIXTURES_BY_TOOL[tool].length} fixture(s) with no answerability checks declared`,
+      );
+    }
+  }
+}
 
 /**
  * What a 2026-07-28 request carries in place of the `initialize` handshake. The
@@ -435,7 +502,7 @@ function checkAnswerability({ tool, fixture }, toon, failures) {
   const { scalars, keys, columns, tables } = inspect(toon);
   const limitRows = tables.get("governorLimits") ?? new Map();
 
-  for (const check of ANSWERABILITY[tool]) {
+  for (const check of ANSWERABILITY[tool] ?? []) {
     // A question only some logs raise is pinned on the fixture that raises it.
     if (check.fixture && check.fixture !== fixture) continue;
 
@@ -473,7 +540,7 @@ function checkAnswerability({ tool, fixture }, toon, failures) {
     }
   }
 
-  if (fixture !== "minimal") {
+  if (fixture !== MINIMAL_FIXTURE) {
     return;
   }
   const expectZero = MINIMAL_ZEROS[tool];
@@ -757,6 +824,8 @@ async function main() {
 
   const update = args.includes("--update");
   const failures = [];
+
+  checkChecksAreRun(failures);
 
   const responses = [];
 

--- a/scripts/eval.mjs
+++ b/scripts/eval.mjs
@@ -196,6 +196,7 @@ const TOKEN_BUDGET = {
   // level that gates it or a zero cannot be read.
   "apexlog_list_limit_risks/governor-heavy": 46,
   "apexlog_list_limit_risks/minimal": 30,
+  "apexlog_get_summary/heap-heavy": 269,
 };
 
 /**
@@ -273,12 +274,24 @@ const SELECTION_KEYWORDS = {
   apexlog_execute_anonymous: ["anonymous Apex", "Salesforce org"],
 };
 
-const CASES = [
-  "apexlog_get_summary",
-  "apexlog_list_slow_operations",
-  "apexlog_list_limit_risks",
-].flatMap((tool) =>
-  ["governor-heavy", "minimal"].map((fixture) => ({ tool, fixture })),
+/**
+ * Which logs each tool is measured against.
+ *
+ * Declared per tool rather than as a cross product of tools and fixtures. Every
+ * case is a server round trip and a golden file a reviewer has to read, so a
+ * case earns its place only by pinning something the others would miss — and a
+ * cross product spends three cases on a fixture that answers one question.
+ * `heap-heavy` is here for `apexlog_get_summary` alone, the one tool that
+ * publishes a heap figure.
+ */
+const FIXTURES_BY_TOOL = {
+  apexlog_get_summary: ["governor-heavy", "minimal", "heap-heavy"],
+  apexlog_list_slow_operations: ["governor-heavy", "minimal"],
+  apexlog_list_limit_risks: ["governor-heavy", "minimal"],
+};
+
+const CASES = Object.entries(FIXTURES_BY_TOOL).flatMap(([tool, fixtures]) =>
+  fixtures.map((fixture) => ({ tool, fixture })),
 );
 
 /**

--- a/src/salesforce/debugLevels.ts
+++ b/src/salesforce/debugLevels.ts
@@ -10,7 +10,43 @@ export type LogLevel = (typeof LOG_LEVEL)[keyof typeof LOG_LEVEL];
 
 export const LOG_LEVELS = Object.values(LOG_LEVEL);
 
-/** The DebugLevel field names, lower-camel. `toSObjectFields` capitalises them. */
+/**
+ * The Salesforce debug log categories, as the `DebugLevels` keys the parser
+ * reads a log header into. In header order.
+ *
+ * Held here in the shape the parser publishes `LOG_LEVEL` and `LOG_CATEGORY`,
+ * because it publishes nothing for these — its own `debugLevelKeyByToken` is
+ * tree-shaken out of the bundle. When it exports them this becomes an import.
+ */
+export const DEBUG_LEVEL_CATEGORY = {
+  ApexCode: "apexCode",
+  ApexProfiling: "apexProfiling",
+  Callout: "callout",
+  DataAccess: "dataAccess",
+  Database: "database",
+  Nba: "nba",
+  System: "system",
+  Validation: "validation",
+  Visualforce: "visualforce",
+  Wave: "wave",
+  Workflow: "workflow",
+} as const satisfies Record<string, keyof DebugLevels>;
+
+export type DebugLevelCategory =
+  (typeof DEBUG_LEVEL_CATEGORY)[keyof typeof DEBUG_LEVEL_CATEGORY];
+
+/** Readonly array of every category, for iterating and building sets. */
+export const ALL_DEBUG_LEVEL_CATEGORIES: readonly DebugLevelCategory[] =
+  Object.values(DEBUG_LEVEL_CATEGORY);
+
+/**
+ * The categories a `DebugLevel` record can set, lower-camel as its fields are
+ * named. `toSObjectFields` capitalises them.
+ *
+ * A literal and not a filter over `ALL_DEBUG_LEVEL_CATEGORIES`, because the
+ * tool schema needs the tuple: a filtered array would type as every category
+ * and let a caller ask for `dataAccess`, which no field sets.
+ */
 export const TRACE_CATEGORIES = [
   "apexCode",
   "apexProfiling",
@@ -22,7 +58,7 @@ export const TRACE_CATEGORIES = [
   "visualforce",
   "wave",
   "workflow",
-] as const;
+] as const satisfies readonly DebugLevelCategory[];
 
 export type TraceCategory = (typeof TRACE_CATEGORIES)[number];
 
@@ -58,31 +94,30 @@ export type LogCategory = (typeof LOG_CATEGORIES)[number];
  * the same correspondence but does not publish it.
  */
 export const DEBUG_LEVEL_FIELD_BY_CATEGORY = {
-  APEX_CODE: "apexCode",
-  APEX_PROFILING: "apexProfiling",
-  CALLOUT: "callout",
-  DATA_ACCESS: "dataAccess",
-  DB: "database",
-  NBA: "nba",
-  SYSTEM: "system",
-  VALIDATION: "validation",
-  VISUALFORCE: "visualforce",
-  WAVE: "wave",
-  WORKFLOW: "workflow",
+  APEX_CODE: DEBUG_LEVEL_CATEGORY.ApexCode,
+  APEX_PROFILING: DEBUG_LEVEL_CATEGORY.ApexProfiling,
+  CALLOUT: DEBUG_LEVEL_CATEGORY.Callout,
+  DATA_ACCESS: DEBUG_LEVEL_CATEGORY.DataAccess,
+  DB: DEBUG_LEVEL_CATEGORY.Database,
+  NBA: DEBUG_LEVEL_CATEGORY.Nba,
+  SYSTEM: DEBUG_LEVEL_CATEGORY.System,
+  VALIDATION: DEBUG_LEVEL_CATEGORY.Validation,
+  VISUALFORCE: DEBUG_LEVEL_CATEGORY.Visualforce,
+  WAVE: DEBUG_LEVEL_CATEGORY.Wave,
+  WORKFLOW: DEBUG_LEVEL_CATEGORY.Workflow,
 } as const satisfies Record<LogCategory, keyof DebugLevels>;
 
 /** Fails to compile unless `T` is `true`. */
 type Assert<T extends true> = T;
 
 /**
- * Compile guard for the other direction: the `satisfies` above only checks that
- * every category names a real field. A category the parser adds has to be named
- * here too, or `declaredLevels` silently drops it from every response.
+ * Compile guard for the other direction: every `satisfies` above only checks
+ * that what is named exists, never that nothing is missing. A category the
+ * parser adds has to reach `DEBUG_LEVEL_CATEGORY`, or `declaredLevels` drops it
+ * from every response and no other check notices.
  */
 export type EveryDebugLevelCategoryNamed = Assert<
-  keyof DebugLevels extends (typeof DEBUG_LEVEL_FIELD_BY_CATEGORY)[LogCategory]
-    ? true
-    : false
+  keyof DebugLevels extends DebugLevelCategory ? true : false
 >;
 
 /**

--- a/src/salesforce/debugLevels.ts
+++ b/src/salesforce/debugLevels.ts
@@ -11,41 +11,19 @@ export type LogLevel = (typeof LOG_LEVEL)[keyof typeof LOG_LEVEL];
 export const LOG_LEVELS = Object.values(LOG_LEVEL);
 
 /**
- * The Salesforce debug log categories, as the `DebugLevels` keys the parser
- * reads a log header into. In header order.
- *
- * Held here in the shape the parser publishes `LOG_LEVEL` and `LOG_CATEGORY`,
- * because it publishes nothing for these — its own `debugLevelKeyByToken` is
- * tree-shaken out of the bundle. When it exports them this becomes an import.
+ * One Salesforce debug log category, as the `DebugLevels` key the parser reads
+ * a log header into. The parser's own `DebugCategory` is this plus `""`, which
+ * it uses for an event that states no category.
  */
-export const DEBUG_LEVEL_CATEGORY = {
-  ApexCode: "apexCode",
-  ApexProfiling: "apexProfiling",
-  Callout: "callout",
-  DataAccess: "dataAccess",
-  Database: "database",
-  Nba: "nba",
-  System: "system",
-  Validation: "validation",
-  Visualforce: "visualforce",
-  Wave: "wave",
-  Workflow: "workflow",
-} as const satisfies Record<string, keyof DebugLevels>;
-
-export type DebugLevelCategory =
-  (typeof DEBUG_LEVEL_CATEGORY)[keyof typeof DEBUG_LEVEL_CATEGORY];
-
-/** Readonly array of every category, for iterating and building sets. */
-export const ALL_DEBUG_LEVEL_CATEGORIES: readonly DebugLevelCategory[] =
-  Object.values(DEBUG_LEVEL_CATEGORY);
+export type DebugLevelCategory = keyof DebugLevels;
 
 /**
  * The categories a `DebugLevel` record can set, lower-camel as its fields are
  * named. `toSObjectFields` capitalises them.
  *
- * A literal and not a filter over `ALL_DEBUG_LEVEL_CATEGORIES`, because the
- * tool schema needs the tuple: a filtered array would type as every category
- * and let a caller ask for `dataAccess`, which no field sets.
+ * A literal and not a filter over `DebugLevelCategory`, because the tool schema
+ * needs the tuple: a filtered array would type as every category and let a
+ * caller ask for `dataAccess`, which no field sets.
  */
 export const TRACE_CATEGORIES = [
   "apexCode",
@@ -94,18 +72,18 @@ export type LogCategory = (typeof LOG_CATEGORIES)[number];
  * the same correspondence but does not publish it.
  */
 export const DEBUG_LEVEL_FIELD_BY_CATEGORY = {
-  APEX_CODE: DEBUG_LEVEL_CATEGORY.ApexCode,
-  APEX_PROFILING: DEBUG_LEVEL_CATEGORY.ApexProfiling,
-  CALLOUT: DEBUG_LEVEL_CATEGORY.Callout,
-  DATA_ACCESS: DEBUG_LEVEL_CATEGORY.DataAccess,
-  DB: DEBUG_LEVEL_CATEGORY.Database,
-  NBA: DEBUG_LEVEL_CATEGORY.Nba,
-  SYSTEM: DEBUG_LEVEL_CATEGORY.System,
-  VALIDATION: DEBUG_LEVEL_CATEGORY.Validation,
-  VISUALFORCE: DEBUG_LEVEL_CATEGORY.Visualforce,
-  WAVE: DEBUG_LEVEL_CATEGORY.Wave,
-  WORKFLOW: DEBUG_LEVEL_CATEGORY.Workflow,
-} as const satisfies Record<LogCategory, keyof DebugLevels>;
+  APEX_CODE: "apexCode",
+  APEX_PROFILING: "apexProfiling",
+  CALLOUT: "callout",
+  DATA_ACCESS: "dataAccess",
+  DB: "database",
+  NBA: "nba",
+  SYSTEM: "system",
+  VALIDATION: "validation",
+  VISUALFORCE: "visualforce",
+  WAVE: "wave",
+  WORKFLOW: "workflow",
+} as const satisfies Record<LogCategory, DebugLevelCategory>;
 
 /** Fails to compile unless `T` is `true`. */
 type Assert<T extends true> = T;
@@ -113,11 +91,24 @@ type Assert<T extends true> = T;
 /**
  * Compile guard for the other direction: every `satisfies` above only checks
  * that what is named exists, never that nothing is missing. A category the
- * parser adds has to reach `DEBUG_LEVEL_CATEGORY`, or `declaredLevels` drops it
- * from every response and no other check notices.
+ * parser adds has to reach `LOG_CATEGORIES`, or `declaredLevels` drops it from
+ * every response and no other check notices.
  */
 export type EveryDebugLevelCategoryNamed = Assert<
-  keyof DebugLevels extends DebugLevelCategory ? true : false
+  DebugLevelCategory extends (typeof DEBUG_LEVEL_FIELD_BY_CATEGORY)[LogCategory]
+    ? true
+    : false
+>;
+
+/**
+ * And that a new category is settable, or refused on purpose. Without this a
+ * category the parser adds is silently absent from `TRACE_CATEGORIES`, which
+ * reads the same as `dataAccess` being absent because no field sets it.
+ */
+export type EverySettableCategoryOffered = Assert<
+  Exclude<DebugLevelCategory, "dataAccess"> extends TraceCategory
+    ? true
+    : false
 >;
 
 /**

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -14,11 +14,19 @@ marker blocks — are generated from the run. See [`scripts/eval.mjs`](../../scr
 | --- | --- | --- |
 | `governor-heavy.log` | Slices of the [Apex Log Analyzer sample log](https://github.com/certinia/debug-log-analyzer) (`sample-app/debug-logs/sample-log.log`): the transaction start, a DML insert, a managed-package section for `core_pkg` and `srm_pkg` with a SOQL query, and the closing limit block. | CPU over its limit, SOQL/DML consumed, three namespaces, a `FATAL_ERROR`, and — because it is a trimmed slice — a non-zero `parsingErrors`. |
 | `minimal.log` | A `System.debug('')` run: the smallest transaction that still emits a limit block. | Everything is zero. This is the fixture that fails if a zero is ever omitted instead of reported, because "no DML statements ran" has to be answerable from the payload. |
+| `heap-heavy.log` | Hand-written: one method allocates and holds, another allocates then frees the same bytes. | Heap. The `HEAP_ALLOCATE` events are the only heap figure a log gives, because a cumulative block states heap as zero. `apexlog_get_summary` only — see below. |
 
 `governor-heavy.log` is deliberately fragmentary — the whole sample log is 19 MB, and the slices keep
 the fixture at ~40 KB while retaining every fact the tools report. Its `parsingErrors` count is an
 artefact of that slicing, and is useful: it exercises the "did the log parse cleanly?" question with
 a non-zero answer, where `minimal.log` answers it with zero.
+
+`FIXTURES_BY_TOOL` names the logs each tool is measured against, and it is not a cross product. Every
+case is a server round trip and a golden file a reviewer has to read, so add a fixture to a tool only
+where it pins something the other fixtures would miss. `heap-heavy.log` is in the summary alone: the
+other two tools report nothing about heap, and their answers for it differ from `minimal.log` only in
+the capture levels. What the three heap measures mean is pinned in `tests/parserContract.test.ts`,
+which needs no server.
 
 ## Golden files
 

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -14,7 +14,7 @@ marker blocks — are generated from the run. See [`scripts/eval.mjs`](../../scr
 | --- | --- | --- |
 | `governor-heavy.log` | Slices of the [Apex Log Analyzer sample log](https://github.com/certinia/debug-log-analyzer) (`sample-app/debug-logs/sample-log.log`): the transaction start, a DML insert, a managed-package section for `core_pkg` and `srm_pkg` with a SOQL query, and the closing limit block. | CPU over its limit, SOQL/DML consumed, three namespaces, a `FATAL_ERROR`, and — because it is a trimmed slice — a non-zero `parsingErrors`. |
 | `minimal.log` | A `System.debug('')` run: the smallest transaction that still emits a limit block. | Everything is zero. This is the fixture that fails if a zero is ever omitted instead of reported, because "no DML statements ran" has to be answerable from the payload. |
-| `heap-heavy.log` | Hand-written: one method allocates and holds, another allocates then frees the same bytes. | Heap. The `HEAP_ALLOCATE` events are the only heap figure a log gives, because a cumulative block states heap as zero. `apexlog_get_summary` only — see below. |
+| `heap-heavy.log` | Hand-written: one method allocates and holds, another allocates then frees the same bytes. | Heap. Its limit block states heap as zero where its `HEAP_ALLOCATE` events do not, so it is the fixture that fails if the summary ever reports the block instead of the peak. `apexlog_get_summary` only — see below. |
 
 `governor-heavy.log` is deliberately fragmentary — the whole sample log is 19 MB, and the slices keep
 the fixture at ~40 KB while retaining every fact the tools report. Its `parsingErrors` count is an
@@ -23,10 +23,11 @@ a non-zero answer, where `minimal.log` answers it with zero.
 
 `FIXTURES_BY_TOOL` names the logs each tool is measured against, and it is not a cross product. Every
 case is a server round trip and a golden file a reviewer has to read, so add a fixture to a tool only
-where it pins something the other fixtures would miss. `heap-heavy.log` is in the summary alone: the
-other two tools report nothing about heap, and their answers for it differ from `minimal.log` only in
-the capture levels. What the three heap measures mean is pinned in `tests/parserContract.test.ts`,
-which needs no server.
+where it pins something the other fixtures would miss. `heap-heavy.log` is in the summary alone, the
+one tool whose answer its heap changes. `apexlog_list_limit_risks` does read heap, but this log's
+heap sits under its risk threshold, and the rows `apexlog_list_slow_operations` would rank are kinds
+`governor-heavy` pins already. What the parser's several heap measures mean is pinned in
+`tests/parserContract.test.ts`, on a log of its own, which needs no server.
 
 ## Golden files
 

--- a/tests/eval/fixtures/heap-heavy.log
+++ b/tests/eval/fixtures/heap-heavy.log
@@ -1,0 +1,38 @@
+64.0 APEX_CODE,FINEST;APEX_PROFILING,FINEST;CALLOUT,NONE;DATA_ACCESS,NONE;DB,NONE;NBA,NONE;SYSTEM,NONE;VALIDATION,NONE;VISUALFORCE,NONE;WAVE,NONE;WORKFLOW,NONE
+Execute Anonymous: HeapService.buildAndChurn();
+11:00:00.0 (1000000)|USER_INFO|[EXTERNAL]|005Ea00000R6orz|first-last@example.com|(GMT+00:00) Greenwich Mean Time (Europe/London)|GMT+00:00
+11:00:00.0 (2000000)|EXECUTION_STARTED
+11:00:00.0 (3000000)|CODE_UNIT_STARTED|[EXTERNAL]|execute_anonymous_apex
+11:00:00.0 (4000000)|METHOD_ENTRY|[1]|01pEa00000HeapS|HeapService.buildAndChurn()
+11:00:00.0 (5000000)|METHOD_ENTRY|[12]|01pEa00000HeapS|HeapService.churn()
+11:00:00.0 (6000000)|HEAP_ALLOCATE|[13]|Bytes:100000
+11:00:00.0 (7000000)|HEAP_ALLOCATE|[14]|Bytes:-100000
+11:00:00.0 (8000000)|HEAP_ALLOCATE|[13]|Bytes:100000
+11:00:00.0 (9000000)|HEAP_ALLOCATE|[14]|Bytes:-100000
+11:00:00.0 (10000000)|METHOD_EXIT|[12]|HeapService.churn()
+11:00:00.0 (11000000)|METHOD_ENTRY|[22]|01pEa00000HeapS|HeapService.buildRows()
+11:00:00.0 (12000000)|HEAP_ALLOCATE|[23]|Bytes:250000
+11:00:00.0 (13000000)|BULK_HEAP_ALLOCATE|Bytes:250000
+11:00:00.0 (14000000)|HEAP_ALLOCATE|[25]|Bytes:250000
+11:00:00.0 (20000000)|METHOD_EXIT|[22]|HeapService.buildRows()
+11:00:00.0 (21000000)|METHOD_EXIT|[1]|HeapService.buildAndChurn()
+11:00:00.0 (22000000)|CUMULATIVE_LIMIT_USAGE
+11:00:00.0 (22000000)|LIMIT_USAGE_FOR_NS|(default)|
+  Number of SOQL queries: 0 out of 100
+  Number of query rows: 0 out of 50000
+  Number of SOSL queries: 0 out of 20
+  Number of DML statements: 0 out of 150
+  Number of Publish Immediate DML: 0 out of 150
+  Number of DML rows: 0 out of 10000
+  Maximum CPU time: 42 out of 10000
+  Maximum heap size: 0 out of 6000000
+  Number of callouts: 0 out of 100
+  Number of Email Invocations: 0 out of 10
+  Number of future calls: 0 out of 50
+  Number of queueable jobs added to the queue: 0 out of 50
+  Number of Mobile Apex push calls: 0 out of 10
+
+11:00:00.0 (22000000)|CUMULATIVE_LIMIT_USAGE_END
+
+11:00:00.0 (23000000)|CODE_UNIT_FINISHED|execute_anonymous_apex
+11:00:00.0 (24000000)|EXECUTION_FINISHED

--- a/tests/eval/golden/apexlog_get_summary.heap-heavy.expected.txt
+++ b/tests/eval/golden/apexlog_get_summary.heap-heavy.expected.txt
@@ -1,0 +1,44 @@
+fileSizeBytes: 2052
+durationTotalMs: 22
+truncated: false
+parsingErrorCount: 0
+namespaces[1]: default
+debugLevels[11]{logCategory,level}:
+  APEX_CODE,FINEST
+  APEX_PROFILING,FINEST
+  CALLOUT,NONE
+  DATA_ACCESS,NONE
+  DB,NONE
+  NBA,NONE
+  SYSTEM,NONE
+  VALIDATION,NONE
+  VISUALFORCE,NONE
+  WAVE,NONE
+  WORKFLOW,NONE
+governorLimits[13]{limit,used,max}:
+  soqlQueries,0,100
+  soslQueries,0,20
+  queryRows,0,50000
+  dmlStatements,0,150
+  publishImmediateDml,0,150
+  dmlRows,0,10000
+  cpuTime,42,10000
+  heapSize,750000,6000000
+  callouts,0,100
+  emailInvocations,0,10
+  futureCalls,0,50
+  queueableJobsAddedToQueue,0,50
+  mobileApexPushCalls,0,10
+limitsByNamespace[1]{namespace,limit,used}:
+  default,cpuTime,42
+timeByKind[10]{kind,logCategory,operationCount,durationSelfMs,selfPercentage}:
+  codeUnit,APEX_CODE,1,3,13.6
+  managedPackage,APEX_CODE,0,0,0
+  method,APEX_CODE,3,17,77.3
+  systemMethod,SYSTEM,1,0,0
+  soql,DB,0,0,0
+  sosl,DB,0,0,0
+  dml,DB,0,0,0
+  callout,CALLOUT,0,0,0
+  flow,WORKFLOW,0,0,0
+  workflow,WORKFLOW,0,0,0

--- a/tests/parserContract.test.ts
+++ b/tests/parserContract.test.ts
@@ -86,6 +86,39 @@ describe("parser contract", () => {
     });
   });
 
+  describe("heap measures", () => {
+    const heapLog = parse(fixture("heap-heavy"));
+
+    const eventNamed = (name: string): LogEvent => {
+      const event = tree(heapLog).find((node) => node.text === name);
+      if (!event) {
+        throw new Error(`${name} is not in heap-heavy.log`);
+      }
+      return event;
+    };
+
+    // The three do not agree, and #99 ranks operations on them: `churn()` frees
+    // all it takes, so its net is zero and its peak a fifth of its gross. One
+    // of them published as "heap used" would read the path as free.
+    it("keeps net, gross and peak apart", () => {
+      const churn = eventNamed("HeapService.churn()");
+
+      expect(churn.heapAllocated.total).toBe(0);
+      expect(churn.heapGross.total).toBe(200_000);
+      expect(churn.heapPeak).toBe(100_000);
+    });
+
+    // A cumulative block states heap as zero, so the events are the only heap
+    // figure the log gives. `apexlog_get_summary` publishes this as its
+    // `heapSize` row.
+    it("takes the transaction figure from the events, not the limit block", () => {
+      const [snapshot] = heapLog.governorLimits.snapshots;
+
+      expect(snapshot?.limits.heapSize.used).toBe(0);
+      expect(heapLog.governorLimits.peak.heapSize.used).toBe(750_000);
+    });
+  });
+
   describe("LogEvent.category", () => {
     // `kindOf` in tools/operations.ts drops an event with no category before it
     // looks at anything else, so a timed event without one would be ranked

--- a/tests/parserContract.test.ts
+++ b/tests/parserContract.test.ts
@@ -87,35 +87,49 @@ describe("parser contract", () => {
   });
 
   describe("heap measures", () => {
-    const heapLog = parse(fixture("heap-heavy"));
+    // Allocations chosen so that no two heap figures agree: the pair that is
+    // freed again leaves the net at 500_000, every allocation counted gives a
+    // gross of 950_000, the highest the run ever held is 750_000, and the
+    // limit block states nothing.
+    const log = [
+      HEADER,
+      "09:00:00.1 (1000)|EXECUTION_STARTED",
+      "09:00:00.2 (2000)|HEAP_ALLOCATE|[1]|Bytes:100000",
+      "09:00:00.2 (3000)|HEAP_ALLOCATE|[2]|Bytes:-100000",
+      "09:00:00.3 (4000)|HEAP_ALLOCATE|[1]|Bytes:100000",
+      "09:00:00.3 (5000)|HEAP_ALLOCATE|[2]|Bytes:-100000",
+      "09:00:00.4 (6000)|HEAP_ALLOCATE|[3]|Bytes:250000",
+      "09:00:00.5 (7000)|BULK_HEAP_ALLOCATE|Bytes:250000",
+      "09:00:00.6 (8000)|HEAP_ALLOCATE|[4]|Bytes:250000",
+      "09:00:00.7 (9000)|HEAP_ALLOCATE|[5]|Bytes:-250000",
+      "09:00:00.9 (9500)|CUMULATIVE_LIMIT_USAGE",
+      "09:00:00.9 (9500)|LIMIT_USAGE_FOR_NS|(default)|",
+      "  Maximum heap size: 0 out of 6000000",
+      "",
+      "09:00:00.9 (9500)|CUMULATIVE_LIMIT_USAGE_END",
+      "09:00:01.0 (10000)|EXECUTION_FINISHED",
+      "",
+    ].join("\n");
 
-    const eventNamed = (name: string): LogEvent => {
-      const event = tree(heapLog).find((node) => node.text === name);
-      if (!event) {
-        throw new Error(`${name} is not in heap-heavy.log`);
-      }
-      return event;
-    };
-
-    // The three do not agree, and #99 ranks operations on them: `churn()` frees
-    // all it takes, so its net is zero and its peak a fifth of its gross. One
-    // of them published as "heap used" would read the path as free.
-    it("keeps net, gross and peak apart", () => {
-      const churn = eventNamed("HeapService.churn()");
-
-      expect(churn.heapAllocated.total).toBe(0);
-      expect(churn.heapGross.total).toBe(200_000);
-      expect(churn.heapPeak).toBe(100_000);
-    });
-
-    // A cumulative block states heap as zero, so the events are the only heap
-    // figure the log gives. `apexlog_get_summary` publishes this as its
-    // `heapSize` row.
-    it("takes the transaction figure from the events, not the limit block", () => {
-      const [snapshot] = heapLog.governorLimits.snapshots;
+    // `apexlog_get_summary` publishes `peak.heapSize` as its `heapSize` row.
+    // Nothing else in the log agrees with it: the block states zero and so does
+    // `final`, the net frees back to 500_000, and the gross counts every
+    // allocation at 950_000. 250_000 of the peak arrives as one
+    // `BULK_HEAP_ALLOCATE`, so a parser counting only `HEAP_ALLOCATE` also
+    // reaches 500_000.
+    //
+    // The block is read through `snapshots` and not `final`, which is zero
+    // either way: a parser that stopped reading `LIMIT_USAGE_FOR_NS` has no
+    // snapshot, and only this spelling fails on that.
+    it("reports heap as the events' peak, not the block, net or gross", () => {
+      const { governorLimits, heapAllocated, heapGross } = parse(log);
+      const [snapshot] = governorLimits.snapshots;
 
       expect(snapshot?.limits.heapSize.used).toBe(0);
-      expect(heapLog.governorLimits.peak.heapSize.used).toBe(750_000);
+      expect(governorLimits.final.heapSize.used).toBe(0);
+      expect(heapAllocated.total).toBe(500_000);
+      expect(heapGross.total).toBe(950_000);
+      expect(governorLimits.peak.heapSize.used).toBe(750_000);
     });
   });
 
@@ -123,7 +137,7 @@ describe("parser contract", () => {
     // `kindOf` in tools/operations.ts drops an event with no category before it
     // looks at anything else, so a timed event without one would be ranked
     // nowhere and its time reported nowhere.
-    it.each(["governor-heavy", "minimal"])(
+    it.each(["governor-heavy", "minimal", "heap-heavy"])(
       "is set on every event that carries a duration (%s)",
       (name) => {
         const timed = tree(parse(fixture(name))).filter(


### PR DESCRIPTION
## 📝 What & why

The two follow-ups from the parser swap ([#154], #97) that come before #100. Neither changes
behaviour a caller sees, so neither has a changelog entry.

### 1. Own `DEBUG_LEVEL_CATEGORY` until the parser exports it

The parser tree-shakes its own category map out of the published bundle, so the 11 Salesforce debug
log categories stay in this repo. They are now held in `DEBUG_LEVEL_CATEGORY`, shaped the way the
parser publishes `LOG_LEVEL` and `LOG_CATEGORY`, with `DebugLevelCategory` and
`ALL_DEBUG_LEVEL_CATEGORIES` beside it. #138 consumes them; when the parser exports the vocabulary
the swap is one import line.

`DEBUG_LEVEL_FIELD_BY_CATEGORY` now reads its values off it, so the two cannot drift, and the compile
guard moved onto `DEBUG_LEVEL_CATEGORY` — the thing that has to stay complete. `TRACE_CATEGORIES`
stays a literal tuple: it is the 10 categories a `DebugLevel` record can *set*, a Salesforce API
fact, and the tool schema needs the tuple.

`ALL_DEBUG_LEVEL_CATEGORIES` has no caller until #138.

### 2. A heap fixture, scoped to one tool

#99 ranks operations by heap and both existing fixtures report `heapPeak: 0`, so it has nothing to
rank and nothing to check. `heap-heavy.log` gives it one, and pins the assumption it rests on: the
`HEAP_ALLOCATE` events are the only heap figure a log gives, because a cumulative block states heap
as zero.

| Node | net | gross | peak |
| --- | --- | --- | --- |
| `HeapService.churn()` | 0 | 200,000 | 100,000 |
| `HeapService.buildRows()` | 750,000 | 750,000 | 750,000 |

The three disagree, so no tool can publish one of them as "heap used". `apexlog_get_summary` reports
`heapSize` **750,000** where the block states **0**.

The log is hand-written — no reachable sample log carries `HEAP_ALLOCATE` — and
`tests/eval/README.md` says so.

### Why one eval case and not three

`CASES` was a cross product of 3 tools × N fixtures, so the fixture would have cost three cases and
three golden files. Measured: **9 cases, 1.76s**, against 1.02s for the six before it.

I diffed what the two extra cases pinned:

- `apexlog_list_limit_risks.heap-heavy` differs from `minimal` in **two capture-level strings**.
  Nothing else.
- `apexlog_list_slow_operations.heap-heavy` is method rows `governor-heavy` already covers richer.

Both are near-duplicates, so both are gone. Fixtures are now declared per tool in
`FIXTURES_BY_TOOL`, and `tests/eval/README.md` states the rule, so a fourth fixture costs one case
rather than three — and not four when a fifth tool joins. What the three heap measures mean is
asserted in `tests/parserContract.test.ts`, which spawns no server.

**7 cases, 1.04s** — the same wall time as before the fixture.

## ✅ Verification

```
pnpm run build && pnpm test && pnpm run lint && pnpm run eval
```

- 332 jest tests, 17 suites, lint clean
- 7 eval cases pass; `README.md` gained one row and no existing figure moved
- the compile guard was mutation-checked: pointed at an incomplete map it fails with
  `TS2344: Type 'false' does not satisfy the constraint 'true'`

## 🔗 Issues

Refs #97, #99, #138
