### PR TITLE
chore(deps): keep @types/node on the engines floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
     groups:
       npm-minor-patch:
         update-types: ['minor', 'patch']
+    ignore:
+      # Types track the engines floor, not the newest runtime. On newer types
+      # tsc accepts an API Node 22 lacks, and no CI job can catch it: the type
+      # error is what should have stopped it.
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,7 @@ updates:
       npm-minor-patch:
         update-types: ['minor', 'patch']
     ignore:
-      # Types track the engines floor, not the newest runtime. On newer types
-      # tsc accepts an API Node 22 lacks, and no CI job can catch it: the type
-      # error is what should have stopped it.
+      # Newer types let tsc accept an API Node 22 lacks, and no CI job catches it.
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
   - package-ecosystem: 'github-actions'


### PR DESCRIPTION
`@types/node` major bumps are now ignored, so the types stay on the version of Node the package supports.

## Why

`package.json` says `engines: node >=22`, and `@types/node` is `^22.19.13`. #106 offers 26.1.2.

On 26 types, tsc accepts an API that Node 22 does not have. Nothing then fails: the Node 22, 24 and 26 test matrix runs the same source, and the type error that should have stopped the build is the thing we removed. A user on Node 22 finds it at runtime.

So the types track the floor. They rise when `engines` rises, which is a deliberate change with a changelog line, not a weekly offer.

Minor and patch releases of `@types/node` still arrive as before.

## Evidence

I merged #106 into `main` locally and ran the gate: build, 366 tests, lint and `pnpm run eval` all pass. Green is why this needs saying out loud - the bump is not caught by anything we run, which is the argument for the ignore rather than against it.

Closes #106.
