### PR TITLE
docs: correct the 1.x security claim and tool name in .github

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,7 @@ body:
     attributes:
       label: What happened?
       description: What went wrong, and what did you expect instead?
-      placeholder: 'e.g. "analyze_apex_log_performance returned an empty methods array for a log that clearly contains method calls. I expected the slow methods to be listed."'
+      placeholder: 'e.g. "apexlog_list_slow_operations returned an empty operations table for a log that clearly contains method calls. I expected the slow operations to be listed."'
     validations:
       required: true
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -9,4 +9,4 @@ Include the affected version and steps to reproduce. We'll acknowledge your repo
 ## Good to know
 
 - The server runs locally, makes no network calls of its own, and needs no API keys.
-- `execute_anonymous` runs Apex against real Salesforce orgs. It's disabled unless the `--allowed-orgs` flag is set - treat that allowlist as a security boundary.
+- `apexlog_execute_anonymous` runs Apex against real Salesforce orgs. Every call is authorized by the type of the org it targets: a production org, or one whose type cannot be read, needs `--allow-production-orgs` or a per-call confirmation. `--no-apex-execution` refuses every call.


### PR DESCRIPTION
## 📝 What & why

The security policy tells a reader that `execute_anonymous` is disabled unless `--allowed-orgs` is set, and calls that allowlist a security boundary. 2.0 removed the flag: the tool is always registered, and every call is authorized by the type of the org it targets. A reader assessing the risk was reading 1.x.

The bug report placeholder asks for a repro naming `analyze_apex_log_performance` and an empty `methods` array. Both were renamed, so the example points a reporter at a tool that no longer exists.

## 🧩 Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance
- [x] 📝 Docs
- [ ] 🔧 Chore (tooling, CI, deps)
- [ ] 💥 Breaking change

## 🔗 Related issues

None.

## 🧪 How was this tested?

- [x] `pnpm run build`
- [x] `pnpm run test`
- [x] `pnpm run lint`
- [ ] Manually tested against an MCP client / debug log

## ✅ Checklist

- [x] Added or updated tests (or not needed)
- [x] Updated docs - README / CHANGELOG (or not needed)

## Changes

- `SECURITY.md` states the 2.0 authorization: org type decides, a production org or an unreadable one needs `--allow-production-orgs` or a per-call confirmation, and `--no-apex-execution` refuses every call — so the stated boundary is the one the code enforces.
- `bug_report.yml` names `apexlog_list_slow_operations` and its `operations` table, so a reporter copies a tool that exists.