### PR TITLE
chore: release 2.0.0-beta.0 under the beta npm dist-tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@certinia/apex-log-mcp",
-  "version": "1.0.0",
+  "version": "2.0.0-beta.0",
   "description": "MCP server that gives AI assistants tools to analyze Salesforce Apex debug logs for performance bottlenecks, slow methods, and governor limit usage.",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## 📝 What & why

`package.json` still says `1.0.0`, while `## [Unreleased]` holds a full breaking release. Nothing has reached a tester, and the milestone is otherwise empty.

This bumps the version to `2.0.0-beta.0`. The prerelease identifier picks the npm channel, so `scripts/release-tag.mjs` resolves `dist_tag=beta` and `latest` stays on `1.0.0` — which matters because the VS Code extension starts this server through `npx`, and `npx` follows `latest`. Testers install it with `@certinia/apex-log-mcp@beta`.

`## [Unreleased]` stays as it is: a beta previews the same unreleased content, and the heading becomes `## [2.0.0]` at the stable tag.

## 🧩 Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance
- [ ] 📝 Docs
- [x] 🔧 Chore (tooling, CI, deps)
- [ ] 💥 Breaking change

## 🔗 Related issues

Related to #123. That issue tracks the stable `2.0.0`: cutting `Unreleased` to `## [2.0.0] - <date>` and moving `latest`. Neither happens here, so it stays open.

## 🧪 How was this tested?

- [x] `pnpm run build`
- [x] `pnpm run test`
- [x] `pnpm run lint`
- [ ] Manually tested against an MCP client / debug log

`pnpm run eval` also passes, 9 cases, and no README figure moved.

The dist-tag was resolved before tagging:

```zsh
RELEASE_TAG=2.0.0-beta.0 PRERELEASE=true node scripts/release-tag.mjs
dist_tag=beta
```

## ✅ Checklist

- [x] Added or updated tests (or not needed)
- [x] Updated docs - README / CHANGELOG (or not needed)

## Release steps after merge

1. Draft a release, create the tag `2.0.0-beta.0` on publish.
2. **Tick "Set as a pre-release".** `release-tag.mjs` fails the release if the tick and the version disagree.
3. Publish, then check `npm dist-tag ls @certinia/apex-log-mcp` — `latest` must still read `1.0.0`.