### PR TITLE
docs: cut the migration guide to what a human must change

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,9 @@
 # Migrating from 1.x
 
+The tools describe themselves, so an agent reads the new parameters and fields off the wire. Two
+things do not arrive that way: the tool names in your permission lists, and the flags you start the
+server with. The [changelog](CHANGELOG.md) lists what else moved.
+
 ## Tool names
 
 Every tool was renamed - see [Naming Tools and Fields](DEVELOPING.md#-naming-tools-and-fields).
@@ -16,61 +20,15 @@ Update wherever you name a tool yourself:
 - Tool allow and deny lists. Some clients qualify a name with the server, so `execute_anonymous` may appear as `mcp__apex-log-mcp__execute_anonymous`.
 - Prompts, agents and skills.
 
-Response fields changed too - see the [changelog](CHANGELOG.md).
+## Server flags
 
-## Operation categories
+`--allowed-orgs` is ignored and warns on stderr. Delete it. The type of the org decides instead.
 
-`kind` is gone from every response and parameter. A ranked row states `debugCategory`, the Salesforce
-debug log category the platform stamped on the event, and `type`, the log's own event type. Both come
-from the log rather than from this server, and every category on the wire is now spelled as the
-`DebugLevel` field is - `database`, not `DB` - which is the spelling `apexlog_execute_anonymous`
-already takes as input.
+| 1.x                             | 2.0                                                        |
+| ------------------------------- | ---------------------------------------------------------- |
+| No flag (tool hidden)           | No flag - the tool works against non-production orgs       |
+| `--allowed-orgs ALLOW_ALL_ORGS` | No flag. Add `--allow-production-orgs` to target production |
+| `--allowed-orgs <org>,<org>`    | No flag. Org type decides, not an org list                 |
 
-| 1.x `kind`       | 2.0 `debugCategory` | 2.0 `type`                                                |
-| ---------------- | ------------------- | --------------------------------------------------------- |
-| `codeUnit`       | `apexCode`          | `CODE_UNIT_STARTED`                                       |
-| `managedPackage` | `apexCode`          | `ENTERING_MANAGED_PKG`                                    |
-| `method`         | `apexCode`          | `METHOD_ENTRY`, `CONSTRUCTOR_ENTRY`                       |
-| `systemMethod`   | `system`            | `SYSTEM_METHOD_ENTRY`, `SYSTEM_CONSTRUCTOR_ENTRY`         |
-| `soql`           | `database`          | `SOQL_EXECUTE_BEGIN`, `QUERY_MORE_BEGIN`                  |
-| `sosl`           | `database`          | `SOSL_EXECUTE_BEGIN`                                      |
-| `dml`            | `database`          | `DML_BEGIN`                                               |
-| `callout`        | `callout`           | `CALLOUT_REQUEST`                                         |
-| `flow`           | `workflow`          | `FLOW_*`, `EVENT_SERVICE_*`                               |
-| `workflow`       | `workflow`          | `WF_*`                                                    |
-
-Two families move, because 1.x read a grouping meant for a timeline rather than the category the log
-states. Visualforce events reported `APEX_CODE` or `SYSTEM` and now report `visualforce`; the
-cumulative limit and profiling events reported `SYSTEM` and now report `apexProfiling`. Next Best
-Action reported `systemMethod` and now reports `nba`. If you group or filter on the old values,
-expect a Visualforce transaction to move most of its time.
-
-Update wherever you name one: the `kind` parameter is now `debugCategory` and `type`, both arrays,
-and so is `namespace`.
-
-## Governor limit figures
-
-`used` is now the peak each limit reached, not the usage the transaction ended on. A counter falls
-when the frame that spent it exits, so a 1.x figure could read below the ceiling a run had already
-breached. Expect a counter to read the same or higher than 1.x did for the same log, in
-`apexlog_get_summary.governorLimits`, its `limitsByNamespace`, and the limits
-`apexlog_list_limit_risks` selects.
-
-`heapSize` moves the other way on a log with more than one namespace. 1.x added each namespace's
-figure together, and heap is a level and not a counter, so the total was never a sum. It is now the
-highest figure any namespace reported, which is lower.
-
-If you compare figures across versions, re-baseline them rather than treating either move as a
-regression.
-
-## Org access
-
-`--allowed-orgs` is ignored and warns on stderr. Delete it.
-
-| 1.x                             | 2.0                                                              |
-| ------------------------------- | ---------------------------------------------------------------- |
-| No flag (tool hidden)           | No flag - the tool works against non-production orgs             |
-| `--allowed-orgs ALLOW_ALL_ORGS` | No flag. Add `--allow-production-orgs` to target production       |
-| `--allowed-orgs <org>,<org>`    | No flag. Org type decides, not an org list                       |
-
-`ALLOW_ALL_ORGS` no longer implies consent to run against production.
+`ALLOW_ALL_ORGS` no longer implies consent to run against production. To stop Apex running at all,
+add `--no-apex-execution`; the log analysis tools keep working.


### PR DESCRIPTION
## 📝 What & why

The migration guide spent 55 of its 76 lines mapping renamed response fields - the `kind` to `debugCategory`/`type` table, the peak-limit and `heapSize` notes, `success` to `succeeded`. An agent reads all of that off `tools/list`, so a reader had to work through four sections to find the two things nobody hands them: the tool names in their permission lists, and the flags they start the server with.

The guide is now 34 lines and covers those two only. Everything else points at the changelog.

## 🧩 Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance
- [x] 📝 Docs
- [ ] 🔧 Chore (tooling, CI, deps)
- [ ] 💥 Breaking change

## 🔗 Related issues

Related to #123, which asks for the guide to be read against the final tool set.

## 🧪 How was this tested?

- [ ] `pnpm run build`
- [ ] `pnpm run test`
- [ ] `pnpm run lint`
- [ ] Manually tested against an MCP client / debug log

Prose only, and nothing reads it: no test, script or doc links to a heading in this file, and `pnpm run eval` passes unchanged at 9 cases.

## ✅ Checklist

- [x] Added or updated tests (or not needed)
- [x] Updated docs - README / CHANGELOG (or not needed)

## Changes

- Kept the tool rename table and the org flag table in full - a permission list and a command line are the only places a name is typed by hand.
- Cut the operation category table, the governor limit figures section and the `succeeded` rename. The tool definitions carry those names, and the changelog states each move.
- Added `--no-apex-execution` to the flags section, which the table never mentioned.
- Renamed the section to `Server flags`, since it now covers more than org access.