### PR TITLE
ci(publish): install an npm that can use trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,22 +38,20 @@ jobs:
       # No registry-url: it writes an .npmrc line reading
       # `_authToken=${NODE_AUTH_TOKEN}`, and an auth line with no token behind
       # it stops npm reaching the OIDC exchange.
+      #
+      # Node 24 rather than .nvmrc, for the npm that ships beside it: `pnpm
+      # publish` shells out to `npm publish`, and the OIDC exchange lives in
+      # the npm CLI. Node 22 carries npm 10, which cannot do it - 2.0.0-beta.0
+      # published anonymously and the registry answered 404. Trusted
+      # publishing needs npm 11.5.1; Node 24 carries 11.19. Installing a newer
+      # npm by hand would do as well, but that is a package outside the
+      # lockfile, which zizmor rejects. `tsc` output does not depend on the
+      # Node that runs it, and the test matrix already covers 24.
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version-file: ".nvmrc"
+          node-version: "24"
           package-manager-cache: false
-
-      # `pnpm publish` shells out to `npm publish`, and OIDC lives in the npm
-      # CLI, so the npm beside Node decides whether trusted publishing happens.
-      # Node 22 carries npm 10, which has none: 2.0.0-beta.0 published
-      # anonymously and the registry answered 404. Trusted publishing needs
-      # 11.5.1 or later. Pinned, like the actionlint tarball in
-      # workflow-lint.yml, so it needs a manual bump.
-      - name: Install an npm that can use trusted publishing
-        env:
-          NPM_VERSION: 11.19.1
-        run: npm install --global "npm@${NPM_VERSION}"
 
       # Before the install, which is the slow step here: a release published
       # from the wrong tag would otherwise ship silently, and there is no

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,12 +34,26 @@ jobs:
       # `package-manager-cache` defaults to true - it only auto-caches when
       # `packageManager` names npm, and saying so here keeps the guarantee from
       # resting on that field staying `pnpm`.
+      #
+      # No registry-url: it writes an .npmrc line reading
+      # `_authToken=${NODE_AUTH_TOKEN}`, and an auth line with no token behind
+      # it stops npm reaching the OIDC exchange.
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
-          registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
+
+      # `pnpm publish` shells out to `npm publish`, and OIDC lives in the npm
+      # CLI, so the npm beside Node decides whether trusted publishing happens.
+      # Node 22 carries npm 10, which has none: 2.0.0-beta.0 published
+      # anonymously and the registry answered 404. Trusted publishing needs
+      # 11.5.1 or later. Pinned, like the actionlint tarball in
+      # workflow-lint.yml, so it needs a manual bump.
+      - name: Install an npm that can use trusted publishing
+        env:
+          NPM_VERSION: 11.19.1
+        run: npm install --global "npm@${NPM_VERSION}"
 
       # Before the install, which is the slow step here: a release published
       # from the wrong tag would otherwise ship silently, and there is no


### PR DESCRIPTION
The 2.0.0-beta.0 release failed: `npm error 404 Not Found - PUT https://registry.npmjs.org/@certinia%2fapex-log-mcp`.

A 404 on a PUT means the request was anonymous. The trusted publisher on npm is configured correctly - `certinia/debug-log-analyzer-mcp`, `publish.yml`, no environment, `npm publish` permitted - but the run never asked for a token.

`pnpm publish` shells out to `npm publish`, and the OIDC exchange lives in the npm CLI, not in `libnpmpublish`. So the npm beside Node decides whether trusted publishing happens at all. The run used Node 22.23.2, which bundles npm 10.9.8, and trusted publishing needs 11.5.1 or later. The log has no OIDC line anywhere in it. Provenance was still signed, because Sigstore uses the `id-token` directly, which is why the failure looked half-successful.

`2.0.0-beta.0` was the first release since the switch to OIDC in 33de047. `1.0.0` published with `secrets.NPM_TOKEN`, so nothing had exercised this path before.

## Changes

- Publish from Node 24, which bundles npm 11.19.0. `.nvmrc` stays at 22 for everything else. A global `npm install` would work too, but it is a package outside the lockfile and zizmor rejects it. `tsc` output does not depend on the Node that runs it, and the test matrix already covers 24.
- Drop `registry-url` from `setup-node`. It writes `_authToken=${NODE_AUTH_TOKEN}` into a temporary `.npmrc`, the run warned `Failed to replace env in config`, and an auth line with no token behind it can stop npm reaching the exchange. The default registry is npmjs anyway.

## Verified

`actionlint` and `zizmor` both pass on the workflow. The exchange itself only proves out on a runner.

## Note for the release

Re-running the failed run will not pick this up - a `release` run uses the workflow file at the tag. Either move `2.0.0-beta.0` to the fixed commit, or cut `2.0.0-beta.1`.
