### PR TITLE
chore: release 2.0.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@certinia/apex-log-mcp",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "MCP server that gives AI assistants tools to analyze Salesforce Apex debug logs for performance bottlenecks, slow methods, and governor limit usage.",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## 📝 What & why

`2.0.0-beta.0` never reached npm. The publish run authenticated anonymously and the registry answered `404 Not Found - PUT`. #184 fixes the workflow.

A `release` run uses the workflow file at its own tag, so the fix cannot reach `2.0.0-beta.0` without moving a pushed tag. This bumps to `2.0.0-beta.1` instead, and the beta is cut again from the fixed workflow.

The prerelease identifier still picks the channel, so `latest` stays on `1.0.0` - which matters because the VS Code extension starts this server through `npx`, and `npx` follows `latest`. Testers install `@certinia/apex-log-mcp@beta`.

`## [Unreleased]` stays as it is: a beta previews the same unreleased content, and the heading becomes `## [2.0.0]` at the stable tag.

## 🧩 Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance
- [ ] 📝 Docs
- [x] 🔧 Chore (tooling, CI, deps)
- [ ] 💥 Breaking change

## 🔗 Related issues

Depends on #184 - merge that first, or the release fails the same way. Related to #123, which tracks the stable `2.0.0` and stays open.

## 🧪 How was this tested?

- [x] `pnpm run build`
- [x] `pnpm run test`
- [x] `pnpm run lint`
- [ ] Manually tested against an MCP client / debug log

`pnpm run eval` also passes, 9 cases, and no README figure moved.

The dist-tag was resolved before tagging:

```zsh
RELEASE_TAG=2.0.0-beta.1 PRERELEASE=true node scripts/release-tag.mjs
dist_tag=beta
```

## ✅ Checklist

- [x] Added or updated tests (or not needed)
- [x] Updated docs - README / CHANGELOG (or not needed)

## Release steps after merge

1. Merge #184 first.
2. Draft a release, create the tag `2.0.0-beta.1` on publish.
3. **Tick "Set as a pre-release".** `release-tag.mjs` fails the release if the tick and the version disagree.
4. Publish, then check `npm dist-tag ls @certinia/apex-log-mcp` - `latest` must still read `1.0.0`.
