### PR TITLE
docs: cut the changelog and README to what a reader needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,41 +10,40 @@ _Upgrading from 1.x? Every tool is renamed, and `--allowed-orgs` is gone. See [M
 
 ### Added
 
-- `apexlog_list_slow_operations` folds repeat calls into one row - by name, by `callerNamespace`, or by debug log category - each row totalling what the transaction saves if the group never runs, so the rows do not add up ([#101], [#126], [#127], [#131], [#138])
-- `apexlog_list_slow_operations` sorts by an operation's net heap allocation, not only time (`sortBy: "heapSelfNetBytes"`) ([#99], [#127], [#138])
-- `apexlog_list_slow_operations` returns the query optimiser's plan for each query it ranked ([#120])
-- `apexlog_list_slow_operations` returns `matchedCount`, so you can tell whether the page hid rows ([#63])
-- `apexlog_list_slow_operations` and `apexlog_list_limit_risks` report the level each debug log category was logged at ([#102], [#138])
-- `apexlog_execute_anonymous` reports progress, and says when the org logged at levels other than the ones asked for ([#65])
-- `--no-apex-execution` stops `apexlog_execute_anonymous` running Apex, while the log analysis tools keep working ([#52])
+- Report where the time went by category, and governor limits by namespace, in `apexlog_get_summary` ([#62], [#86], [#108])
+- Report the level each debug log category was captured at, in `apexlog_list_slow_operations` and `apexlog_list_limit_risks`, so you can see what the log could not show ([#102], [#138])
+- Group operations in `apexlog_list_slow_operations` by name, namespace, caller namespace or debug log category, so you can see whether the time went to one slow call or many small repeats ([#101], [#126], [#127], [#131], [#138])
+- Rank operations by the heap they retain in `apexlog_list_slow_operations`, not only by time ([#99], [#127], [#138])
+- Return the query optimiser's plan for each query `apexlog_list_slow_operations` ranked ([#120])
+- Report progress while `apexlog_execute_anonymous` connects, sets the trace flag, runs and writes, and report when the org logged at levels other than the ones asked for ([#65])
+- Add `--no-apex-execution`, which stops `apexlog_execute_anonymous` running Apex while the log analysis tools keep working ([#52])
+- Support the 2026-07-28 protocol revision - clients on the 2025 revisions keep working ([#103])
 
 ### Changed
 
-- **Breaking:** rename every tool with an `apexlog_` prefix: `analyze_apex_log_performance` is now `apexlog_list_slow_operations`. Full mapping in [Migrating from 1.x](MIGRATING.md) ([#107])
-- **Breaking:** `apexlog_execute_anonymous` refuses a production org, or one it cannot classify, unless you confirm the run or set `--allow-production-orgs` ([#52], [#93])
-- `apexlog_list_slow_operations` ranks every timed operation by self time - a callout or a query as well as a method - in place of the five lists and the prose advice of `analyze_apex_log_performance` ([#86], [#97], [#108], [#126])
-- `apexlog_get_summary` reports all thirteen governor limits, zeros included, plus time by category and limits by namespace, so a managed package spending your CPU time is visible ([#62], [#86], [#108])
-- `apexlog_get_summary` and `apexlog_list_limit_risks` report each governor limit's peak, not the figure the transaction ended on ([#97])
-- `apexlog_list_limit_risks` returns one table of the limits nearest their ceiling, covering thirteen where `find_performance_bottlenecks` covered six ([#108])
-- `apexlog_get_summary` says whether the log was truncated, by what, and how much it skipped ([#100])
-- `apexlog_list_slow_operations` renames its parameters and row fields - `topMethods` is now `limit`, `minDuration` is `minSelfMs`, and `kind` is the platform's debug log category and event type, `database,SOQL_EXECUTE_BEGIN` - and takes a list in every filter ([#86], [#97], [#108], [#138])
-- `apexlog_execute_anonymous` renames `success` to `succeeded`, and reports a duration that agrees with `apexlog_get_summary` ([#65], [#109])
-- `apexlog_list_slow_operations` caps a response by size, not by row count, so one huge log cannot flood the reply: the biggest of 124 real logs returns 15,511 tokens, down from 35,520 ([#108])
-- Cut tool responses with no fact lost - `apexlog_list_limit_risks` by 54%, `apexlog_execute_anonymous` by 30%. `apexlog_get_summary` costs 24% more, for the two tables it gained ([#62], [#86], [#97], [#108], [#109], [#120], [#138])
-- Cut the cost of having the server connected by 9%, and let a client cache the tool definitions for an hour, though `apexlog_list_slow_operations` costs 145% more for what it now selects and ranks ([#87], [#94], [#99], [#101], [#103], [#126], [#127], [#138])
-- The server starts in 55 ms, down from 290 ms, and reuses the log it parsed, so a second question about the same file skips the parse ([#88], [#165])
+- **Breaking:** rename every tool with an `apexlog_` prefix - `analyze_apex_log_performance` is now `apexlog_list_slow_operations`. Update your permission lists and prompts; the full mapping is in [Migrating from 1.x](MIGRATING.md) ([#107])
+- **Breaking:** refuse to run Apex from `apexlog_execute_anonymous` for production orgs or orgs whose type cannot be determined, unless you confirm. Clients name the org and show the Apex. Allow with `--allow-production-orgs`. Sandbox, scratch, trial and Developer orgs run unprompted ([#52], [#93])
+- Rank every timed operation by self time in one `apexlog_list_slow_operations` list - instead of the five lists and the prose advice of `analyze_apex_log_performance` ([#86], [#97], [#108], [#126])
+- Report all thirteen governor limits in `apexlog_get_summary`, zeros included where 1.x reported only those above zero, and state each limit's unit ([#62], [#86], [#108], [#167])
+- Report the limits nearest their ceiling in `apexlog_list_limit_risks` as one table, beside the threshold that selected it, in place of the four overlapping sections of `find_performance_bottlenecks` ([#108])
+- Report failed logs, partial logs, fatal errors and their exception messages in `apexlog_get_summary` ([#97], [#100])
+- Cut tool responses with no fact lost - `apexlog_list_limit_risks` by 58%, and `apexlog_list_slow_operations` ~2.2× smaller, capped by size rather than row count and stating how many rows matched ([#63], [#97], [#108], [#109], [#120], [#138])
+- Reduce the tool definitions token cost on every request by 9%, ~1,529 to ~1,393. Clients can also cache them for an hour ([#87], [#94], [#99], [#101], [#103], [#126], [#127], [#138])
+- Start the server in 55 ms, down from 290 ms, and answer a second question about the same log without parsing it again ([#88], [#165])
 
 ### Fixed
 
-- `apexlog_execute_anonymous` returns the log for the Apex you ran, not the newest log for the user ([#65])
-- `apexlog_execute_anonymous` returns an absolute log path, and warns when `outputDir` lands outside the folders the client opened ([#109])
-- The log analysis tools name the real reason a log file cannot be opened. A permission error used to read as "Log file not found" ([#109])
-- `apexlog_execute_anonymous` is marked destructive, so clients stop running it unprompted ([#52])
+- Fix incorrectly reported timings for callouts in `apexlog_list_slow_operations`, which were counted in the calling method's self time ([#97], [#138])
+- Fix understated governor limit usage in `apexlog_get_summary` and `apexlog_list_limit_risks`, which reported the usage the transaction ended on rather than its peak ([#97])
+- Return the debug log of the run `apexlog_execute_anonymous` made, where the newest log for the user could be another process's ([#65])
+- Return an absolute log path from `apexlog_execute_anonymous`, and warn when `outputDir` resolves outside every folder the client opened ([#109])
+- Name the real reason a log file cannot be opened - a permission error used to read as "Log file not found" ([#109])
+- Mark `apexlog_execute_anonymous` destructive, so clients stop running it unprompted ([#52])
 
 ### Removed
 
-- **Breaking:** remove `--allowed-orgs` and its special tokens. The flag is accepted, ignored and warns, and the org's type decides instead ([#52])
-- **Breaking:** drop Node.js 20 (end of life April 2026). Minimum node version is 22
+- **Breaking:** remove `--allowed-orgs` and its special tokens - the flag is accepted, ignored and warns, and the org's type decides instead ([#52])
+- **Breaking:** drop Node.js 20 (end of life April 2026) - Node.js 22 is the minimum
 
 ## [1.0.0] - 2026-03-20
 
@@ -84,3 +83,4 @@ _Upgrading from 1.x? Every tool is renamed, and `--allowed-orgs` is gone. See [M
 [#99]: https://github.com/certinia/debug-log-analyzer-mcp/issues/99
 [#100]: https://github.com/certinia/debug-log-analyzer-mcp/issues/100
 [#165]: https://github.com/certinia/debug-log-analyzer-mcp/issues/165
+[#167]: https://github.com/certinia/debug-log-analyzer-mcp/issues/167

--- a/README.md
+++ b/README.md
@@ -5,24 +5,13 @@
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org/)
 
-**Analyze Salesforce Apex debug logs from your AI assistant. Finds slow methods, governor limit risks, and where a transaction spent its time.**
+**MCP Server to Analyze Salesforce Apex debug logs from your AI assistant. Finds slow methods, governor limit risks, and where a transaction spent its time.**
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/certinia/debug-log-analyzer-mcp/main/docs/images/apex-log-mcp.png" alt="Claude analyzing an Apex debug log for performance bottlenecks and governor limit concerns" width="800" />
 </p>
 
-Works with Claude, Copilot, or any MCP client. Instead of scrolling thousands of log lines, ask what's slow and why. Uses the same parser as the [Apex Log Analyzer VS Code extension](https://github.com/certinia/debug-log-analyzer).
-
-[Quick Start](#quick-start) |
-[What You Can Do](#what-you-can-do) |
-[Token Cost](#token-cost) |
-[Tools Reference](#tools-reference) |
-[Configuration](#configuration) |
-[How It Works](#how-it-works) |
-[Documentation](#documentation) |
-[Contributing](#contributing) |
-[Contributors](#contributors) |
-[License](#license)
+Instead of scrolling thousands of log lines, ask what's slow and why. Uses the same parser as the [Apex Log Analyzer VS Code extension](https://github.com/certinia/debug-log-analyzer).
 
 ## Quick Start
 
@@ -41,50 +30,22 @@ Requires [Node.js](https://nodejs.org/) 22 or later. Add this to your MCP client
 
 Then ask your assistant to analyze a log. `apexlog_execute_anonymous` also needs an org authenticated with the [Salesforce CLI](https://developer.salesforce.com/tools/salesforcecli).
 
-## What You Can Do
+## Example Prompts
 
 - "Give me a summary of this debug log"
 - "Show me the 5 slowest methods in the default namespace"
 - "Are we approaching any governor limits in this transaction?"
 - "Run this Apex against my scratch org and analyze the performance"
 
-## Token Cost
-
-### Enabling the tools
-
-Every request carries all four tool definitions, called or not - the standing cost of having the server connected. Each figure is the whole definition: name, title, description, input schema and annotations.
-
-<!-- token-cost-definitions:start -->
-
-| Tool                           | Tokens                              | 1.x        | Change  |
-| ------------------------------ | ----------------------------------- | ---------- | ------- |
-| `apexlog_list_slow_operations` | ~606                                | ~247       | +145%   |
-| `apexlog_execute_anonymous`    | ~421                                | ~844       | -50%    |
-| `apexlog_list_limit_risks`     | ~192                                | ~267       | -28%    |
-| `apexlog_get_summary`          | ~174                                | ~171       | +2%     |
-| **Total**                      | **~1,393** (0.7% of a 200K context) | **~1,529** | **-9%** |
-
-<!-- token-cost-definitions:end -->
-
-### Calling a tool
-
-A call takes a tool name and a log path, about 15 tokens, so a call costs what it returns. Each row answers the same log as 1.x did, with the same facts in a cheaper shape.
-
-Cost does not scale with the log: a response is bounded by its shape - a fixed table of governor limits, a row cap on ranked operations - not by the bytes parsed. Measured against a 40 KB slice of [the Apex Log Analyzer sample log](https://github.com/certinia/debug-log-analyzer/blob/main/sample-app/debug-logs/sample-log.log); on the full 19.7 MB original, `apexlog_get_summary` returns ~374 tokens instead of ~364 and `apexlog_list_limit_risks` the same ~35.
-
-<!-- token-cost-answers:start -->
-
-| Tool                           | Response | 1.x  | Change |
-| ------------------------------ | -------- | ---- | ------ |
-| `apexlog_get_summary`          | ~364     | ~293 | +24%   |
-| `apexlog_list_slow_operations` | ~396     | ~408 | -3%    |
-| `apexlog_list_limit_risks`     | ~35      | ~84  | -58%   |
-
-<!-- token-cost-answers:end -->
+Keeping the server connected costs ~1,393 tokens, 0.7% of a 200K context. See [Token Cost](#token-cost).
 
 ## Tools Reference
 
-All tools return [TOON](https://github.com/toon-format/toon)-encoded flat tables - lean by shape, not by dropping facts. Every limit, category and column is returned, so `0` means none rather than "not measured"; only what did not happen is omitted, which is fatal errors, lost log content and query plans. Nothing is reported twice. Durations are milliseconds to 3 decimal places, percentages to 1.
+Every tool returns one flat table, encoded as [TOON](https://github.com/toon-format/toon). Nothing is repeated, and nothing is dropped to save space.
+
+A `0` means none, not "not measured". Only what did not happen is left out: fatal errors, lost log content, query plans. Durations are in milliseconds to 3 decimal places, percentages to 1.
+
+The server runs as a local process started by your client over stdio, no network calls and no API keys. Each log is parsed once, so follow up questions are faster.
 
 ### apexlog_list_slow_operations
 
@@ -100,15 +61,24 @@ A default response returns:
 
 <!-- shape-apexlog_list_slow_operations:end -->
 
-beside the transaction's `durationTotalMs`, the `returnedSelfPercentage` those rows account for, and the `matchedCount` matched before paging. `durationSelfMaxMs` is the slowest single call in a grouped row - against `durationSelfMs` it tells one bad call from sheer volume - and is absent when a row is already one call.
+Each response also gives `durationTotalMs` for the whole transaction, `returnedSelfPercentage` for the share these rows account for, and `matchedCount` for the rows that matched before paging.
 
-Two columns classify each row, both straight from the log. `debugCategory` is what Salesforce stamped on the event, which decided whether it was logged at all, and is the spelling `apexlog_execute_anonymous` takes. `type` is the event type, which the category cannot imply: `SOQL_EXECUTE_BEGIN`, `SOSL_EXECUTE_BEGIN` and `DML_BEGIN` all sit under `database`, and `ENTERING_MANAGED_PKG` - the time a package spent where the log shows nothing, often most of a transaction - sits under `apexCode` beside the methods it hides.
+`durationSelfMaxMs` is the slowest single call in a grouped row. Read it against `durationSelfMs` to tell one bad call from many small ones. It is absent when the row is already one call.
 
-`sortBy: "heapSelfNetBytes"` ranks by retained heap instead of time, adding that column and a `returnedHeapPercentage`; both are absent otherwise. It is signed `HEAP_ALLOCATE` bytes, so a row that released more than it took reads below zero, and allocations are logged only at `apexCode` FINER and above - the `apexCode` row of `capturedAt` says whether a zero is real.
+Two columns say what a row is, both taken straight from the log:
 
-`capturedAt` covers the categories among the returned rows, keyed to join with them.
+- `debugCategory` - what Salesforce stamped on the event. It decided whether the event was logged at all, and it is the spelling `apexlog_execute_anonymous` takes.
+- `type` - the event type. The category cannot imply it: `SOQL_EXECUTE_BEGIN`, `SOSL_EXECUTE_BEGIN` and `DML_BEGIN` all sit under `database`.
 
-`queryPlans` is what the optimizer decided about the queries behind those rows: `relativeCost` above 1 means it will not treat the query as selective. It is absent when the log explained none, since explain lines are written at `database` FINEST alone. `operationRow` is the 1-based line of `operations` - except under a `namespace`, `callerNamespace` or `debugCategory` grouping, where the row is not named after the query, so the plan carries the query text as `name`.
+Watch for `ENTERING_MANAGED_PKG`. It is time a package spent where the log shows nothing, and it is often most of a transaction.
+
+`sortBy: "heapSelfNetBytes"` ranks by retained heap instead of time, adding that column and `returnedHeapPercentage`. Both are absent otherwise. The figure is signed, so a row that released more than it took reads below zero. Heap is logged only at `apexCode` FINER and above, so check the `apexCode` row of `capturedAt` before trusting a zero.
+
+`capturedAt` gives the level each category in the returned rows was logged at.
+
+`queryPlans` is what the query optimizer decided about the queries behind those rows. A `relativeCost` above 1 means it will not treat the query as selective. Plans are absent when the log explained none, because explain lines need `database` FINEST.
+
+`operationRow` points at a row of `operations`, counting from 1. Under a `namespace`, `callerNamespace` or `debugCategory` grouping a row is not one query, so the plan carries the query text in `name` instead.
 
 <!-- params-apexlog_list_slow_operations:start -->
 
@@ -140,13 +110,22 @@ How long the transaction ran, where the time went, what it consumed, and whether
 
 <!-- shape-apexlog_get_summary:end -->
 
-All thirteen governor limits are listed, zeros included. `limitsByNamespace` covers each limit a namespace consumed - how you see a managed package spending your CPU time. It names no ceiling: there is one per limit for the whole transaction, already in `governorLimits`.
+All thirteen governor limits are listed, zeros included.
 
-`timeByCategory` covers all eleven categories. Since the category decided whether an operation was logged at all, read a zero against `debugLevels`: `database 0` beside `database NONE` means the queries were not logged; beside `database FINEST` it means none ran. Three categories - `dataAccess`, `wave` and `validation` - can only ever be zero, because no timed event carries them.
+`limitsByNamespace` shows what each namespace consumed. This is how you see a managed package spending your CPU time. It has no ceiling column, because a ceiling is per limit for the whole transaction and already sits in `governorLimits`.
 
-`truncated` says whether the log is complete; every figure in a partial one is a floor. Where the platform cut it, `truncatedBy` names how (`skipped-lines` for a hole, `max-size` for a missing tail) and `skippedBytes` how much went; both are absent on a log that merely stops mid-frame. `thrownCount` counts exceptions thrown, zero included.
+`timeByCategory` covers all eleven categories. A category decided whether an operation was logged, so read a zero against `debugLevels`:
 
-`fatalErrors` appears once per failure that ended a transaction, with the innermost three frames and a trailing `…` where there were more. It is the only field that says a transaction did not finish - a fatal error need breach no limit, so nothing else reveals one.
+- `database 0` beside `database NONE` - the queries were not logged.
+- `database 0` beside `database FINEST` - no queries ran.
+
+`dataAccess`, `wave` and `validation` are always zero. No timed event carries them.
+
+`truncated` says whether the log is complete. In a partial log, every figure is a floor. Where the platform cut it, `truncatedBy` says how - `skipped-lines` for a hole, `max-size` for a missing tail - and `skippedBytes` says how much went. Both are absent when a log merely stops mid-frame.
+
+`thrownCount` counts the exceptions thrown, zero included.
+
+`fatalErrors` appears once per failure that ended the transaction, with the innermost three frames and a trailing `…` where there were more. It is the only field that says a transaction did not finish, because a fatal error need not breach any limit.
 
 <!-- params-apexlog_get_summary:start -->
 
@@ -167,9 +146,9 @@ The governor limits nearest their ceiling, worst first.
 
 <!-- shape-apexlog_list_limit_risks:end -->
 
-The `threshold` that selected the rows is reported beside them, so an empty table reads as "nothing is that far consumed" rather than as a missing answer.
+`threshold` is reported beside the rows, so an empty table means nothing reached it rather than that the answer is missing.
 
-`capturedAt` covers the categories gating the limits returned: `apexProfiling` for the cumulative blocks every limit but heap comes from, `apexCode` for the heap allocations behind `heapSize`.
+`capturedAt` gives the level that gated each returned limit. Every limit but heap comes from `apexProfiling`; `heapSize` comes from `apexCode`.
 
 <!-- params-apexlog_list_limit_risks:start -->
 
@@ -184,7 +163,7 @@ The `threshold` that selected the rows is reported beside them, so an empty tabl
 
 Runs anonymous Apex against an authenticated org, saves the debug log locally, and returns the path. Pass that path to any analysis tool.
 
-The response also gives the org username (and alias, if set), the org type, and an execution summary. Logs go to `.apex-log-mcp/` by default - add it to your `.gitignore`. Production orgs are gated: see [Production safety](#production-safety).
+The response also gives the org username, its alias if set, the org type, and a summary of the run. Logs go to `.apex-log-mcp/` by default - add it to your `.gitignore`. Production orgs are gated: see [Production safety](#production-safety).
 
 <!-- params-apexlog_execute_anonymous:start -->
 
@@ -212,13 +191,43 @@ Levels are `NONE`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `FINE`, `FINER`, `FINEST`.
 - "Execute this Apex with all debug levels set to FINEST"
 - "Run this Apex against my QA org with database logging set to FINEST"
 
+## Token Cost
+
+Every request carries all four tool definitions, whether you call them or not. Each figure below is a whole definition: name, title, description, input schema and annotations.
+
+<!-- token-cost-definitions:start -->
+
+| Tool                           | Tokens                              | 1.x        | Change  |
+| ------------------------------ | ----------------------------------- | ---------- | ------- |
+| `apexlog_list_slow_operations` | ~606                                | ~247       | +145%   |
+| `apexlog_execute_anonymous`    | ~421                                | ~844       | -50%    |
+| `apexlog_list_limit_risks`     | ~192                                | ~267       | -28%    |
+| `apexlog_get_summary`          | ~174                                | ~171       | +2%     |
+| **Total**                      | **~1,393** (0.7% of a 200K context) | **~1,529** | **-9%** |
+
+<!-- token-cost-definitions:end -->
+
+A call itself is about 15 tokens - a tool name and a log path - so what a call costs is what it returns.
+
+Cost does not grow with the log size. The figures below are measured against a 40 KB slice of [the Apex Log Analyzer sample log](https://github.com/certinia/debug-log-analyzer/blob/main/sample-app/debug-logs/sample-log.log). On the full 19.7 MB original, `apexlog_get_summary` returns ~374 tokens instead of ~364, and `apexlog_list_limit_risks` the same ~35.
+
+<!-- token-cost-answers:start -->
+
+| Tool                           | Response | 1.x  | Change |
+| ------------------------------ | -------- | ---- | ------ |
+| `apexlog_get_summary`          | ~364     | ~293 | +24%   |
+| `apexlog_list_slow_operations` | ~396     | ~408 | -3%    |
+| `apexlog_list_limit_risks`     | ~35      | ~84  | -58%   |
+
+<!-- token-cost-answers:end -->
+
 ## Configuration
 
 The [Quick Start](#quick-start) config gives you all four tools.
 
 ### Production safety
 
-`apexlog_execute_anonymous` runs arbitrary Apex, so the server identifies the org before running anything. It asks once per session:
+`apexlog_execute_anonymous` runs arbitrary Apex, so the server identifies the org before running anything:
 
 | Org type     | Identified by                     | Behaviour             |
 | ------------ | --------------------------------- | --------------------- |
@@ -229,16 +238,16 @@ The [Quick Start](#quick-start) config gives you all four tools.
 | `production` | Anything else                     | Confirmation required |
 | `unknown`    | The org could not be queried      | Confirmation required |
 
-For a production org, `--allow-production-orgs` runs it anyway. Otherwise the server asks you to confirm - naming the org, showing the Apex - if your client supports [elicitation](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation); if not, it refuses and names both ways to proceed.
+For a production org, `--allow-production-orgs` runs it anyway. Otherwise the server asks you to confirm, naming the org and showing the Apex. That needs a client that supports [elicitation](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation); without one the call is refused, and the message names both ways to proceed. Each confirmation authorizes one run.
 
-An org that cannot be identified is treated as production, so a network or permissions problem can never silently downgrade one.
+An org that cannot be identified is treated as production, so a network or permissions problem can never quietly downgrade one.
 
 ### Server flags
 
-| Flag                      | Description                                                                                                            |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Flag                      | Description                                                                                                              |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `--allow-production-orgs` | Treat production orgs like any other - no confirmation, no refusal. Only set this if production targets are intentional. |
-| `--no-apex-execution`     | Refuse every Apex execution. The tool stays visible so agents know it exists. The three analysis tools are unaffected. |
+| `--no-apex-execution`     | Refuse every Apex execution. The tool stays visible so agents know it exists. The three analysis tools are unaffected.   |
 
 For an analysis-only deployment:
 
@@ -253,30 +262,15 @@ For an analysis-only deployment:
 }
 ```
 
-## How It Works
-
-- **Runs as a local process.** Your client spawns the server and talks to it over stdio. No network requests, no API keys.
-- **Uses the [Apex Log Analyzer](https://github.com/certinia/debug-log-analyzer) parser**, the same one the VS Code extension runs on.
-- **Returns structured data** - durations in milliseconds, limits as used/max rows, operations with SOQL and DML counts.
-- **Parses a log once, not once per tool.** A summary followed by a deeper look at the same file reuses the parse.
-
 ## Documentation
 
 - [User Guide & Docs](https://certinia.github.io/debug-log-analyzer/)
+- [Apex Log Analyzer VS Code Extension](https://github.com/certinia/debug-log-analyzer) - the full log analyzer for VS Code
 - [MCP Specification](https://modelcontextprotocol.io/)
-
-### Related Projects
-
-- [Apex Log Analyzer VS Code Extension](https://github.com/certinia/debug-log-analyzer) - full Apex log analyzer for VS Code
 
 ## Contributing
 
-See the [Contributing Guide](https://github.com/certinia/debug-log-analyzer-mcp/blob/main/CONTRIBUTING.md).
-
-- [Developing](https://github.com/certinia/debug-log-analyzer-mcp/blob/main/DEVELOPING.md) - set up your development environment
-- [Code of Conduct](https://github.com/certinia/debug-log-analyzer-mcp/blob/main/CODE_OF_CONDUCT.md) - community guidelines
-
-## Contributors
+See the [Contributing Guide](https://github.com/certinia/debug-log-analyzer-mcp/blob/main/CONTRIBUTING.md), [Developing](https://github.com/certinia/debug-log-analyzer-mcp/blob/main/DEVELOPING.md) to set up your environment, and the [Code of Conduct](https://github.com/certinia/debug-log-analyzer-mcp/blob/main/CODE_OF_CONDUCT.md).
 
 <p align="center">
   <a href="https://github.com/certinia/debug-log-analyzer-mcp/graphs/contributors">
@@ -286,11 +280,4 @@ See the [Contributing Guide](https://github.com/certinia/debug-log-analyzer-mcp/
 
 ## License
 
-<p align="center">
-Copyright &copy; Certinia Inc. All rights reserved.
-</p>
-<p align="center">
-  <a href="https://opensource.org/licenses/BSD-3-Clause">
-    <img src="https://img.shields.io/badge/License-BSD_3--Clause-blue.svg?style=flat-square" alt="BSD 3-Clause License"/>
-  </a>
-</p>
+[BSD 3-Clause](https://opensource.org/licenses/BSD-3-Clause). Copyright &copy; Certinia Inc. All rights reserved.


### PR DESCRIPTION
Cuts the unreleased changelog and the README to what a reader needs. No code change.

## Changelog

Reads as a list of capabilities, not an inventory of fields. This is an agent-facing MCP server, so
a field or parameter rename reaches nobody: the agent reads them off the wire, which MIGRATING.md
already says. Entries name the tool they apply to.

Corrections found while checking every figure:

- Limit risk responses fall 58%, not 54% - the generated README table says so.
- The 30% saving claimed for `apexlog_execute_anonymous` had no source. `token-cost-answers` does
  not measure it.
- The page cap makes the worst of 123 corpus logs 2.2x smaller, re-measured this pass.
- 1.x `find_performance_bottlenecks` did **not** cover six limits. `analyzeGovernorLimits` iterated
  all thirteen and reported any above 80%.

Peak-against-final limit usage and callout self time are accuracy fixes, so they sit in Fixed with
no breaking marker. `**Breaking:**` is left on four entries only: tool renames, the production gate,
`--allowed-orgs`, Node 20.

## README

- Drops the ten-link nav, which duplicates the outline GitHub and npm render, and the centred
  licence block, which restates a badge.
- Moves the token tables below the tools reference. One line up top carries the total.
- Folds "How It Works" into the reference intro.
- Rewrites the tool prose in plain English: long paragraphs become bullets or short sentences.
  1,129 to 981 words of prose, no fact dropped.
- States that a confirmation authorizes one run, which the old "asks once per session" left
  ambiguous.

Generated blocks were carried across verbatim, then regenerated with `pnpm run eval:update` after an
editor reflowed three parameter tables.

## Verification

- `pnpm run eval` - 9/9
- `pnpm test` - 366/366
- changelog reference links balanced
