### PR TITLE
perf(tools): cut the standing cost of the tool definitions to ~1,232 tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ _Upgrading from 1.x? Every tool is renamed, and `--allowed-orgs` is gone. See [M
 - `apexlog_execute_anonymous` renames `success` to `succeeded`, and reports a duration that agrees with `apexlog_get_summary` ([#65], [#109])
 - `apexlog_list_slow_operations` caps a response by size, not by row count, so one huge log cannot flood the reply: the biggest of 124 real logs returns 15,511 tokens, down from 35,520 ([#108])
 - Cut tool responses with no fact lost - `apexlog_list_limit_risks` by 54%, `apexlog_execute_anonymous` by 30%. `apexlog_get_summary` costs 24% more, for the two tables it gained ([#62], [#86], [#97], [#108], [#109], [#120], [#138])
-- Cut the cost of having the server connected by 15%, and let a client cache the tool definitions for an hour, though `apexlog_list_slow_operations` costs more for what it now selects and ranks ([#87], [#94], [#99], [#101], [#103], [#126], [#127], [#138], [#188])
+- Cut the cost of having the server connected by 19%, and let a client cache the tool definitions for an hour, though `apexlog_list_slow_operations` costs more for what it now selects and ranks ([#87], [#94], [#99], [#101], [#103], [#126], [#127], [#138], [#188], [#189])
 - The server starts in 55 ms, down from 290 ms, and reuses the log it parsed, so a second question about the same file skips the parse ([#88], [#165])
 
 ### Fixed
@@ -85,3 +85,4 @@ _Upgrading from 1.x? Every tool is renamed, and `--allowed-orgs` is gone. See [M
 [#100]: https://github.com/certinia/debug-log-analyzer-mcp/issues/100
 [#165]: https://github.com/certinia/debug-log-analyzer-mcp/issues/165
 [#188]: https://github.com/certinia/debug-log-analyzer-mcp/issues/188
+[#189]: https://github.com/certinia/debug-log-analyzer-mcp/issues/189

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ _Upgrading from 1.x? Every tool is renamed, and `--allowed-orgs` is gone. See [M
 - `apexlog_execute_anonymous` renames `success` to `succeeded`, and reports a duration that agrees with `apexlog_get_summary` ([#65], [#109])
 - `apexlog_list_slow_operations` caps a response by size, not by row count, so one huge log cannot flood the reply: the biggest of 124 real logs returns 15,511 tokens, down from 35,520 ([#108])
 - Cut tool responses with no fact lost - `apexlog_list_limit_risks` by 54%, `apexlog_execute_anonymous` by 30%. `apexlog_get_summary` costs 24% more, for the two tables it gained ([#62], [#86], [#97], [#108], [#109], [#120], [#138])
-- Cut the cost of having the server connected by 9%, and let a client cache the tool definitions for an hour, though `apexlog_list_slow_operations` costs 145% more for what it now selects and ranks ([#87], [#94], [#99], [#101], [#103], [#126], [#127], [#138])
+- Cut the cost of having the server connected by 15%, and let a client cache the tool definitions for an hour, though `apexlog_list_slow_operations` costs more for what it now selects and ranks ([#87], [#94], [#99], [#101], [#103], [#126], [#127], [#138], [#188])
 - The server starts in 55 ms, down from 290 ms, and reuses the log it parsed, so a second question about the same file skips the parse ([#88], [#165])
 
 ### Fixed
@@ -84,3 +84,4 @@ _Upgrading from 1.x? Every tool is renamed, and `--allowed-orgs` is gone. See [M
 [#99]: https://github.com/certinia/debug-log-analyzer-mcp/issues/99
 [#100]: https://github.com/certinia/debug-log-analyzer-mcp/issues/100
 [#165]: https://github.com/certinia/debug-log-analyzer-mcp/issues/165
+[#188]: https://github.com/certinia/debug-log-analyzer-mcp/issues/188

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Responses are TOON-encoded and lean, but the saving comes from shape, never from
 
 Decisions worth not undoing: no prose `summary` or `recommendations`; report a table even when empty, beside the parameter that selected it, since a cutoff left unstated cannot be read; a column only one `sortBy` populates appears under that `sortBy` alone.
 
-The tool definitions follow the same rule and are charged on every turn, called or not - see [Shaping Tool Definitions](DEVELOPING.md#️-shaping-tool-definitions). An enum already lists its values, so a `.describe()` must not repeat them; set `title` at the top level only, because `annotations.title` is an alias and is sent twice; anything true of every tool goes in the server `instructions` once.
+The tool definitions follow the same rule and are charged on every turn, called or not - the budgets and the checks are in [`scripts/eval.mjs`](scripts/eval.mjs). An enum already lists its values, so a `.describe()` must not repeat them; set `title` at the top level only, because `annotations.title` is an alias and is sent twice; anything true of every tool goes in the server `instructions` once.
 
 `pnpm run eval` (`scripts/eval.mjs`, wired into CI) is the gate: it drives the built server over stdio and checks answerability, duplication, token budgets, golden files, and that startup loads no Salesforce SDK - none of which the jest suite can do, because it swaps TOON for a JSON stand-in. It also generates the README's token tables, parameter tables and response shapes, so a change that moves any of them fails until the README is regenerated with it. Re-record with `pnpm run build && pnpm run eval:update` and read the diff.
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -321,8 +321,8 @@ user questions are still answerable, that no figure appears twice, that the payl
 budget, and that it matches its golden file. Run it - and `pnpm run eval:update` to re-record the
 goldens - for any change to a response shape; the golden diff *is* the review of the change.
 
-Two further checks run once per run: the definition budget described in
-[Shaping Tool Definitions](#️-shaping-tool-definitions), and the generated README blocks - both
+Further checks run once per run: the definition budgets in [`scripts/eval.mjs`](scripts/eval.mjs),
+and the generated README blocks - both
 [Token Cost](README.md#token-cost) tables, each tool's parameter table, and the shape of each
 response. A change that moves any of them fails until `pnpm run eval:update` regenerates the README
 with it, so the prose beside those blocks is the only part you edit by hand.
@@ -336,13 +336,14 @@ If you change a tool's output shape, update the [CHANGELOG](CHANGELOG.md) and th
 ## 🏷️ Shaping Tool Definitions
 
 A definition is charged on every request, called or not. Server `instructions` are charged once per
-session, a response only when the tool is called. Put each fact where its audience reads it, at the
-frequency it is worth.
+session, a response only when the tool is called. So a fact true of every tool belongs in
+`instructions`, and a fact true of one belongs in that tool's description.
 
 The [MCP spec](https://modelcontextprotocol.io/specification/2025-06-18/server/tools) covers the
 rest - what `title`, `description` and each annotation are for. Where it is silent, `pnpm run eval`
 is the rule, not this file: it measures every wire object in a live `tools/list` and fails with the
-reason. Read `scripts/eval.mjs` for the current budgets.
+reason. Read `scripts/eval.mjs` for the current budgets, and the definition tests in `tests/` for
+the annotations, which no budget with headroom would notice coming back.
 
 One trade a budget cannot see: a description is a selection prompt, so a trim that saves tokens can
 cost discovery. `SELECTION_KEYWORDS` makes that fail loudly instead of passing quietly.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -339,7 +339,7 @@ A definition is charged on every request, called or not. Server `instructions` a
 session, a response only when the tool is called. So a fact true of every tool belongs in
 `instructions`, and a fact true of one belongs in that tool's description.
 
-The [MCP spec](https://modelcontextprotocol.io/specification/2025-06-18/server/tools) covers the
+The [MCP spec](https://modelcontextprotocol.io/specification/latest/server/tools) covers the
 rest - what `title`, `description` and each annotation are for. Where it is silent, `pnpm run eval`
 is the rule, not this file: it measures every wire object in a live `tools/list` and fails with the
 reason. Read `scripts/eval.mjs` for the current budgets, and the definition tests in `tests/` for

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -335,45 +335,17 @@ If you change a tool's output shape, update the [CHANGELOG](CHANGELOG.md) and th
 
 ## 🏷️ Shaping Tool Definitions
 
-A response is paid for when a tool is called. A **definition** is paid for on every request, called or
-not, because the client sends all four with each one. Server `instructions` sit between them: sent once
-per session. So put each fact where its audience reads it, and at the frequency it is worth. A guarantee
-that holds for every tool - "a zero is a measured zero" - belongs in `instructions`, not repeated in
-four descriptions. A rule that applies to one tool belongs in that tool's description.
+A definition is charged on every request, called or not. Server `instructions` are charged once per
+session, a response only when the tool is called. Put each fact where its audience reads it, at the
+frequency it is worth.
 
-### Budget the whole wire object
+The [MCP spec](https://modelcontextprotocol.io/specification/2025-06-18/server/tools) covers the
+rest - what `title`, `description` and each annotation are for. Where it is silent, `pnpm run eval`
+is the rule, not this file: it measures every wire object in a live `tools/list` and fails with the
+reason. Read `scripts/eval.mjs` for the current budgets.
 
-`pnpm run eval` sums `estimateTokens(JSON.stringify(tool))` for each tool in a live `tools/list`
-response, so the budget covers `name`, `title`, `description`, `inputSchema`, `annotations` and
-everything else the client receives. A budget over a subset of the fields guards a subset of the cost:
-it would let `title` or `annotations` grow without a word of complaint.
-
-Three assertions run against those figures:
-
-- **Per-tool budgets** (`DEFINITION_BUDGET`), with about 5% headroom, so one careless sentence fails.
-- **A total under the 1.x baseline** (`V1_DEFINITION_TOKENS`, measured at `b79328f` over this same
-  stdio path). The total also catches a fifth tool, which no per-tool budget can.
-- **Selection keywords** (`SELECTION_KEYWORDS`), one or two phrases per tool. A description is a
-  selection prompt: clients match the words in it, so a trim that saves tokens can cost discovery.
-  The keyword assertion makes that trade visible instead of silent.
-
-The unit tests pin the parts a token budget with headroom would not notice, such as an
-[annotation](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations)
-hint quietly coming back.
-
-### Only annotate what carries information
-
-`destructiveHint` and `idempotentHint` are defined as meaningful only when `readOnlyHint` is false, so
-the three read-only tools declare `readOnlyHint: true` and `openWorldHint: false` and nothing more -
-both differ from the spec default, and both say something. `apexlog_execute_anonymous` keeps all four hints; it
-is the one tool where a client that misreads a default runs Apex against an org.
-
-### Know the floor
-
-Two fields per tool come from the SDK and cannot be removed through a public API: `$schema`, which
-zod's `toJSONSchema` emits (~52 tokens across the four tools), and `execution`, which `McpServer` adds
-(~40). About 90 tokens of the total are not ours to spend, and are not worth reaching into SDK
-internals for.
+One trade a budget cannot see: a description is a selection prompt, so a trim that saves tokens can
+cost discovery. `SELECTION_KEYWORDS` makes that fail loudly instead of passing quietly.
 
 ## 🧪 Testing Your Changes
 

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Every request carries all four tool definitions, called or not - the standing co
 
 | Tool                           | Tokens                              | 1.x        | Change   |
 | ------------------------------ | ----------------------------------- | ---------- | -------- |
-| `apexlog_list_slow_operations` | ~558                                | ~247       | +126%    |
-| `apexlog_execute_anonymous`    | ~421                                | ~844       | -50%     |
-| `apexlog_list_limit_risks`     | ~164                                | ~267       | -39%     |
-| `apexlog_get_summary`          | ~159                                | ~171       | -7%      |
-| **Total**                      | **~1,302** (0.7% of a 200K context) | **~1,529** | **-15%** |
+| `apexlog_list_slow_operations` | ~539                                | ~247       | +118%    |
+| `apexlog_execute_anonymous`    | ~407                                | ~844       | -52%     |
+| `apexlog_list_limit_risks`     | ~150                                | ~267       | -44%     |
+| `apexlog_get_summary`          | ~145                                | ~171       | -15%     |
+| **Total**                      | **~1,241** (0.6% of a 200K context) | **~1,529** | **-19%** |
 
 <!-- token-cost-definitions:end -->
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The [Quick Start](#quick-start) config gives you all four tools.
 | `production` | Anything else                     | Confirmation required |
 | `unknown`    | The org could not be queried      | Confirmation required |
 
-For a production org, `--allow-production-orgs` runs it anyway. Otherwise the server asks you to confirm - naming the org, showing the Apex - if your client supports [elicitation](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation); if not, it refuses and names both ways to proceed.
+For a production org, `--allow-production-orgs` runs it anyway. Otherwise the server asks you to confirm - naming the org, showing the Apex - if your client supports [elicitation](https://modelcontextprotocol.io/specification/latest/client/elicitation); if not, it refuses and names both ways to proceed.
 
 An org that cannot be identified is treated as production, so a network or permissions problem can never silently downgrade one.
 

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ Every request carries all four tool definitions, called or not - the standing co
 
 <!-- token-cost-definitions:start -->
 
-| Tool                           | Tokens                              | 1.x        | Change  |
-| ------------------------------ | ----------------------------------- | ---------- | ------- |
-| `apexlog_list_slow_operations` | ~606                                | ~247       | +145%   |
-| `apexlog_execute_anonymous`    | ~421                                | ~844       | -50%    |
-| `apexlog_list_limit_risks`     | ~192                                | ~267       | -28%    |
-| `apexlog_get_summary`          | ~174                                | ~171       | +2%     |
-| **Total**                      | **~1,393** (0.7% of a 200K context) | **~1,529** | **-9%** |
+| Tool                           | Tokens                              | 1.x        | Change   |
+| ------------------------------ | ----------------------------------- | ---------- | -------- |
+| `apexlog_list_slow_operations` | ~558                                | ~247       | +126%    |
+| `apexlog_execute_anonymous`    | ~421                                | ~844       | -50%     |
+| `apexlog_list_limit_risks`     | ~164                                | ~267       | -39%     |
+| `apexlog_get_summary`          | ~159                                | ~171       | -7%      |
+| **Total**                      | **~1,302** (0.7% of a 200K context) | **~1,529** | **-15%** |
 
 <!-- token-cost-definitions:end -->
 
@@ -84,7 +84,7 @@ Cost does not scale with the log: a response is bounded by its shape - a fixed t
 
 ## Tools Reference
 
-All tools return [TOON](https://github.com/toon-format/toon)-encoded flat tables - lean by shape, not by dropping facts. Every limit, category and column is returned, so `0` means none rather than "not measured"; only what did not happen is omitted, which is fatal errors, lost log content and query plans. Nothing is reported twice. Durations are milliseconds to 3 decimal places, percentages to 1.
+The analysis tools take an absolute path to a `.log` file. All tools return [TOON](https://github.com/toon-format/toon)-encoded flat tables - lean by shape, not by dropping facts. Every limit, category and column is returned, so `0` means none rather than "not measured"; only what did not happen is omitted, which is fatal errors, lost log content and query plans. Nothing is reported twice. Durations are milliseconds to 3 decimal places, percentages to 1.
 
 ### apexlog_list_slow_operations
 
@@ -114,15 +114,15 @@ Two columns classify each row, both straight from the log. `debugCategory` is wh
 
 | Parameter       | Type     | Required | Description |
 | --------------- | -------- | -------- | --- |
-| `logFilePath`   | string   | Yes      | Absolute path to the Apex debug log file (.log) |
+| `logFilePath`   | string   | Yes      | Absolute path |
 | `debugCategory` | string[] | No       | Rank only these debug log categories |
 | `type`          | string[] | No       | Rank only these log event types, e.g. SOQL_EXECUTE_BEGIN, DML_BEGIN, METHOD_ENTRY |
 | `namespace`     | string[] | No       | Rank only these namespaces |
 | `minSelfMs`     | number   | No       | Drop operations below this self time (default: 0), whichever sortBy is used |
 | `limit`         | number   | No       | Page size (default: 10); fewer if the page would be too large |
 | `offset`        | number   | No       | Ranked rows to skip (default: 0). Advance it by the rows you got, which can be fewer than limit. |
-| `groupBy`       | string   | No       | Fold repeats into one row: by name (default), by namespace, by callerNamespace, which attributes platform DML to the package that drove it, or by debugCategory, which folds a namespace's event types into one row per category and so states no type or name. A grouped durationTotalMs is what the transaction takes back if the group never runs - never sum it across rows. Pass none to rank each call on its own. |
-| `sortBy`        | string   | No       | Rank on (default: durationSelfMs). heapSelfNetBytes adds that column. |
+| `groupBy`       | string   | No       | Fold repeats into one row; default name. callerNamespace attributes platform DML to the package that drove it. debugCategory folds a namespace's event types together and so states no type or name. none ranks each call on its own. A grouped durationTotalMs is what the transaction takes back if the group never runs - never sum it across rows. |
+| `sortBy`        | string   | No       | Default durationSelfMs. heapSelfNetBytes adds that column. |
 
 <!-- params-apexlog_list_slow_operations:end -->
 
@@ -150,9 +150,9 @@ All thirteen governor limits are listed, zeros included. `limitsByNamespace` cov
 
 <!-- params-apexlog_get_summary:start -->
 
-| Parameter     | Type   | Required | Description                                     |
-| ------------- | ------ | -------- | ----------------------------------------------- |
-| `logFilePath` | string | Yes      | Absolute path to the Apex debug log file (.log) |
+| Parameter     | Type   | Required | Description   |
+| ------------- | ------ | -------- | ------------- |
+| `logFilePath` | string | Yes      | Absolute path |
 
 <!-- params-apexlog_get_summary:end -->
 
@@ -175,7 +175,7 @@ The `threshold` that selected the rows is reported beside them, so an empty tabl
 
 | Parameter     | Type   | Required | Description |
 | ------------- | ------ | -------- | --- |
-| `logFilePath` | string | Yes      | Absolute path to the Apex debug log file (.log) |
+| `logFilePath` | string | Yes      | Absolute path |
 | `threshold`   | number | No       | Report a limit once it is this percentage consumed (default: 80) |
 
 <!-- params-apexlog_list_limit_risks:end -->

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Every request carries all four tool definitions, called or not - the standing co
 
 | Tool                           | Tokens                                                      |
 | ------------------------------ | ----------------------------------------------------------- |
-| `apexlog_list_slow_operations` | ~539                                                        |
+| `apexlog_list_slow_operations` | ~530                                                        |
 | `apexlog_execute_anonymous`    | ~407                                                        |
 | `apexlog_list_limit_risks`     | ~150                                                        |
 | `apexlog_get_summary`          | ~145                                                        |
-| **Total**                      | **~1,241** (0.6% of a 200K context), **-19% vs 1.x ~1,529** |
+| **Total**                      | **~1,232** (0.6% of a 200K context), **-19% vs 1.x ~1,529** |
 
 <!-- token-cost-definitions:end -->
 

--- a/README.md
+++ b/README.md
@@ -56,15 +56,17 @@ Every request carries all four tool definitions, called or not - the standing co
 
 <!-- token-cost-definitions:start -->
 
-| Tool                           | Tokens                              | 1.x        | Change   |
-| ------------------------------ | ----------------------------------- | ---------- | -------- |
-| `apexlog_list_slow_operations` | ~539                                | ~247       | +118%    |
-| `apexlog_execute_anonymous`    | ~407                                | ~844       | -52%     |
-| `apexlog_list_limit_risks`     | ~150                                | ~267       | -44%     |
-| `apexlog_get_summary`          | ~145                                | ~171       | -15%     |
-| **Total**                      | **~1,241** (0.6% of a 200K context) | **~1,529** | **-19%** |
+| Tool                           | Tokens                                                      |
+| ------------------------------ | ----------------------------------------------------------- |
+| `apexlog_list_slow_operations` | ~539                                                        |
+| `apexlog_execute_anonymous`    | ~407                                                        |
+| `apexlog_list_limit_risks`     | ~150                                                        |
+| `apexlog_get_summary`          | ~145                                                        |
+| **Total**                      | **~1,241** (0.6% of a 200K context), **-19% vs 1.x ~1,529** |
 
 <!-- token-cost-definitions:end -->
+
+Only the total compares with 1.x: per tool it would compare different tools, since `apexlog_list_slow_operations` replaced one that took three selection parameters and ranked methods where this one takes eight and ranks every timed event.
 
 ### Calling a tool
 

--- a/scripts/eval.mjs
+++ b/scripts/eval.mjs
@@ -304,15 +304,22 @@ const DEFINITION_BUDGET = {
 const TOOLS_LIST_CACHE_HINT = { ttlMs: 3_600_000, cacheScope: "public" };
 
 /**
- * The whole of `tools/list` must stay under what 1.x charged for it: 247 + 171 +
- * 267 + 844, measured as `V1_RESPONSE_TOKENS` was. One figure rather than four,
- * because two of those tools were renamed and re-scoped, so a per-tool
- * comparison names a tool that no longer exists.
+ * What 1.x charged for the whole of `tools/list`: 247 + 171 + 267 + 844,
+ * measured as `V1_RESPONSE_TOKENS` was. One figure rather than four, because two
+ * of those tools were renamed and re-scoped, so a per-tool comparison names a
+ * tool that no longer exists. The README publishes it.
+ */
+const V1_DEFINITION_TOTAL = 1529;
+
+/**
+ * The ceiling `tools/list` must stay under, which starts at what 1.x charged and
+ * ratchets down with each saving. Separate from the released figure above, so
+ * lowering the gate cannot rewrite what the README says 1.x cost.
  *
  * The per-tool budgets cannot assert this on their own - a fifth tool would
  * pass all four and still put the total back over the baseline.
  */
-const TOTAL_DEFINITION_BUDGET = 1529;
+const TOTAL_DEFINITION_BUDGET = V1_DEFINITION_TOTAL;
 
 /**
  * The words a client's tool search matches on. Asserted so that a trim which
@@ -952,7 +959,7 @@ function comparison(before, after) {
 function renderTokenCost(costs, responses) {
   const total = costs.reduce((sum, cost) => sum + cost.tokens, 0);
   const share = ((100 * total) / CONTEXT_WINDOW).toFixed(1);
-  const [v1TotalCell, totalChange] = comparison(TOTAL_DEFINITION_BUDGET, total);
+  const [v1TotalCell, totalChange] = comparison(V1_DEFINITION_TOTAL, total);
 
   // Only the total compares with 1.x: per tool it would compare renamed,
   // re-scoped tools. The README's Token Cost prose states why.

--- a/scripts/eval.mjs
+++ b/scripts/eval.mjs
@@ -286,12 +286,12 @@ const DEFINITION_BUDGET = {
   // cannot show the case for is `sortBy`: on the 40 logs of a 123-log corpus that
   // record an allocation, a heap ranking's top ten holds a median six rows the
   // self-time top ten never returns.
-  apexlog_list_slow_operations: 566,
+  apexlog_list_slow_operations: 557,
   // Covers the two facts the summary gained: per-namespace limit usage, and
   // time by category.
-  apexlog_get_summary: 152,
+  apexlog_get_summary: 153,
   apexlog_list_limit_risks: 158,
-  apexlog_execute_anonymous: 427,
+  apexlog_execute_anonymous: 428,
 };
 
 /**

--- a/scripts/eval.mjs
+++ b/scripts/eval.mjs
@@ -293,12 +293,12 @@ const DEFINITION_BUDGET = {
   // cannot show the case for is `sortBy`: on the 40 logs of a 123-log corpus that
   // record an allocation, a heap ranking's top ten holds a median six rows the
   // self-time top ten never returns.
-  apexlog_list_slow_operations: 586,
+  apexlog_list_slow_operations: 566,
   // Covers the two facts the summary gained: per-namespace limit usage, and
   // time by category.
-  apexlog_get_summary: 167,
-  apexlog_list_limit_risks: 173,
-  apexlog_execute_anonymous: 443,
+  apexlog_get_summary: 152,
+  apexlog_list_limit_risks: 158,
+  apexlog_execute_anonymous: 427,
 };
 
 /**
@@ -789,6 +789,30 @@ function definitionCosts(tools) {
     .sort((a, b) => b.tokens - a.tokens);
 }
 
+/**
+ * Two things zod emits that no client reads, and that a budget with 5% headroom
+ * would not notice coming back: the dialect `$schema` states (14 tokens a tool,
+ * dropped by `toolInputSchema`) and the safe-integer `maximum` an `.int()` with
+ * no ceiling of its own carries (3 tokens a field, see `MAX_PAGE_SIZE`).
+ */
+function checkNothingUnreadOnTheWire(tools, failures) {
+  for (const tool of tools) {
+    if (tool.inputSchema?.$schema !== undefined) {
+      failures.push(
+        `${tool.name}: inputSchema states its JSON Schema dialect, which MCP fixes and no client reads - wrap the shape in toolInputSchema`,
+      );
+    }
+    const properties = Object.entries(tool.inputSchema?.properties ?? {});
+    for (const [property, schema] of properties) {
+      if (schema.maximum === Number.MAX_SAFE_INTEGER) {
+        failures.push(
+          `${tool.name}: ${property} states zod's safe-integer maximum - give it a ceiling of its own`,
+        );
+      }
+    }
+  }
+}
+
 function checkDefinitionBudget(costs, failures) {
   for (const { name, tokens } of costs) {
     const budget = DEFINITION_BUDGET[name];
@@ -1099,6 +1123,7 @@ async function main() {
     const { tools } = await client.toolsList();
     const costs = definitionCosts(tools);
     checkDefinitionBudget(costs, failures);
+    checkNothingUnreadOnTheWire(tools, failures);
     checkSelectionKeywords(costs, failures);
     await checkReadme(
       [

--- a/scripts/eval.mjs
+++ b/scripts/eval.mjs
@@ -786,8 +786,8 @@ function definitionCosts(tools) {
 /**
  * Two things zod emits that no client reads, and that a budget with 5% headroom
  * would not notice coming back: the dialect `$schema` states (14 tokens a tool,
- * dropped by `toolInputSchema`) and the safe-integer `maximum` an `.int()` with
- * no ceiling of its own carries (3 tokens a field, see `MAX_PAGE_SIZE`).
+ * dropped by `toolInputSchema`) and the safe-integer bounds an `.int()` carries
+ * where it states no ceiling or floor of its own (see `MAX_PAGE_SIZE`).
  */
 function checkNothingUnreadOnTheWire(tools, failures) {
   for (const tool of tools) {
@@ -796,15 +796,51 @@ function checkNothingUnreadOnTheWire(tools, failures) {
         `${tool.name}: inputSchema states its JSON Schema dialect, which MCP fixes and no client reads - wrap the shape in toolInputSchema`,
       );
     }
-    const properties = Object.entries(tool.inputSchema?.properties ?? {});
-    for (const [property, schema] of properties) {
-      if (schema.maximum === Number.MAX_SAFE_INTEGER) {
-        failures.push(
-          `${tool.name}: ${property} states zod's safe-integer maximum - give it a ceiling of its own`,
-        );
-      }
+    for (const where of safeIntegerBounds(tool.inputSchema ?? {}, [])) {
+      failures.push(
+        `${tool.name}: ${where} states zod's safe-integer bound - state a floor and a ceiling of its own`,
+      );
     }
   }
+}
+
+/**
+ * Every place in a JSON Schema stating a safe-integer bound, by path.
+ *
+ * Recursive because the bound is a property of the number, not of the tool: an
+ * `.int()` inside an array or an object states it one level down, where a check
+ * on the top-level properties reads nothing. `minimum` as well as `maximum`,
+ * because `-9007199254740991` is a character longer than the ceiling.
+ */
+function safeIntegerBounds(schema, path) {
+  if (typeof schema !== "object" || schema === null) {
+    return [];
+  }
+  const stated = [schema.minimum, schema.maximum].some(
+    (bound) =>
+      typeof bound === "number" && Math.abs(bound) === Number.MAX_SAFE_INTEGER,
+  );
+  const named = path.length ? path.join(".") : "the schema";
+
+  return [
+    ...(stated ? [named] : []),
+    ...Object.entries(schema).flatMap(([keyword, value]) => {
+      if (keyword === "properties" || keyword === "patternProperties") {
+        return Object.entries(value ?? {}).flatMap(([property, child]) =>
+          safeIntegerBounds(child, [...path, property]),
+        );
+      }
+      if (["items", "additionalProperties", "not"].includes(keyword)) {
+        return safeIntegerBounds(value, [...path, keyword]);
+      }
+      if (["anyOf", "oneOf", "allOf", "prefixItems"].includes(keyword)) {
+        return (value ?? []).flatMap((child, index) =>
+          safeIntegerBounds(child, [...path, `${keyword}[${index}]`]),
+        );
+      }
+      return [];
+    }),
+  ];
 }
 
 function checkDefinitionBudget(costs, failures) {

--- a/scripts/eval.mjs
+++ b/scripts/eval.mjs
@@ -259,18 +259,11 @@ const TOKEN_BUDGET = {
 };
 
 /**
- * What 1.x cost, so the README can show what changed. Both sets were measured
- * once, through this same stdio path and this same estimator, against the server
- * built at b79328f - the commit before the shaping work. Static on purpose: a
- * released figure cannot change.
+ * What 1.x cost, so the README can show what changed. Measured once, through
+ * this same stdio path and this same estimator, against the server built at
+ * b79328f - the commit before the shaping work. Static on purpose: a released
+ * figure cannot change.
  */
-const V1_DEFINITION_TOKENS = {
-  apexlog_list_slow_operations: 247,
-  apexlog_get_summary: 171,
-  apexlog_list_limit_risks: 267,
-  apexlog_execute_anonymous: 844,
-};
-
 const V1_RESPONSE_TOKENS = {
   "apexlog_get_summary/governor-heavy": 293,
   "apexlog_get_summary/minimal": 249,
@@ -311,14 +304,15 @@ const DEFINITION_BUDGET = {
 const TOOLS_LIST_CACHE_HINT = { ttlMs: 3_600_000, cacheScope: "public" };
 
 /**
- * The whole of `tools/list` must stay under what 1.x charged for it. The per-tool
- * budgets cannot assert this on their own - a fifth tool would pass all four and
- * still put the total back over the baseline.
+ * The whole of `tools/list` must stay under what 1.x charged for it: 247 + 171 +
+ * 267 + 844, measured as `V1_RESPONSE_TOKENS` was. One figure rather than four,
+ * because two of those tools were renamed and re-scoped, so a per-tool
+ * comparison names a tool that no longer exists.
+ *
+ * The per-tool budgets cannot assert this on their own - a fifth tool would
+ * pass all four and still put the total back over the baseline.
  */
-const TOTAL_DEFINITION_BUDGET = Object.values(V1_DEFINITION_TOKENS).reduce(
-  (sum, tokens) => sum + tokens,
-  0,
-);
+const TOTAL_DEFINITION_BUDGET = 1529;
 
 /**
  * The words a client's tool search matches on. Asserted so that a trim which
@@ -924,22 +918,21 @@ function renderTokenCost(costs, responses) {
   const share = ((100 * total) / CONTEXT_WINDOW).toFixed(1);
   const [v1TotalCell, totalChange] = comparison(TOTAL_DEFINITION_BUDGET, total);
 
+  // Only the total compares with 1.x: per tool it would compare renamed,
+  // re-scoped tools. The README's Token Cost prose states why.
   return [
     {
       id: "token-cost-definitions",
       table: renderTable(
-        ["Tool", "Tokens", "1.x", "Change"],
+        ["Tool", "Tokens"],
         [
           ...costs.map(({ name, tokens }) => [
             `\`${name}\``,
             `~${thousands(tokens)}`,
-            ...comparison(V1_DEFINITION_TOKENS[name], tokens),
           ]),
           [
             "**Total**",
-            `**~${thousands(total)}** (${share}% of a 200K context)`,
-            `**${v1TotalCell}**`,
-            `**${totalChange}**`,
+            `**~${thousands(total)}** (${share}% of a 200K context), **${totalChange} vs 1.x ${v1TotalCell}**`,
           ],
         ],
       ),

--- a/scripts/eval.mjs
+++ b/scripts/eval.mjs
@@ -288,36 +288,17 @@ const V1_RESPONSE_TOKENS = {
  * not a silent tax on every request.
  */
 const DEFINITION_BUDGET = {
-  // Raised for the five selection parameters, which the caller acts on: without
-  // them a ranking over every operation kind can only be read whole, and for the
-  // warning that a grouped durationTotalMs must not be summed across rows, and
-  // for what grouping by default now states about the row it returns, and for
-  // callerNamespace, which needs a clause to say what it attributes, and for the
-  // clause #120 added to say the response also carries the query plans, and
-  // for `offset` beside the whole-number floor on `limit` - a schema that
-  // states `integer` and `minimum` costs tokens, and buys a `limit` of -5 no
-  // longer returning the whole ranking bar its five fastest rows, and for the
-  // clause saying
-  // a plan names its row except under a namespace grouping - an agent that
-  // assumes the query text is always there reads `undefined` - and for telling
-  // a caller to advance `offset` by the rows it got, since the page budget can
-  // return fewer than `limit` and paging by `limit` would then skip rows, and
-  // for `sortBy`, which buys the one question self time cannot answer: on the
-  // 40 logs of a 123-log corpus that record an allocation, a heap ranking's top
-  // ten holds a median six rows the self-time top ten never returns.
-  //
-  // Raised again by #138, which replaced the one `kind` filter with the two axes
-  // the log itself has - `debugCategory` and the event `type` - and widened
-  // both, and `namespace`, to arrays, so one call can ask for a family. `type`
-  // takes free strings and names three examples rather than an enum, for the
-  // reason recorded on the field itself. The `groupBy` clause grew by the
-  // category fold, which is the one grouping that states no type or name.
-  apexlog_list_slow_operations: 610,
-  // Raised for the two facts the summary gained: per-namespace limit usage, and
+  // The ranking is dear because it carries eight selection parameters, and each
+  // buys a question the response cannot be read for. The one of them the schema
+  // cannot show the case for is `sortBy`: on the 40 logs of a 123-log corpus that
+  // record an allocation, a heap ranking's top ten holds a median six rows the
+  // self-time top ten never returns.
+  apexlog_list_slow_operations: 586,
+  // Covers the two facts the summary gained: per-namespace limit usage, and
   // time by category.
-  apexlog_get_summary: 180,
-  apexlog_list_limit_risks: 210,
-  apexlog_execute_anonymous: 449,
+  apexlog_get_summary: 167,
+  apexlog_list_limit_risks: 173,
+  apexlog_execute_anonymous: 443,
 };
 
 /**

--- a/scripts/eval.mjs
+++ b/scripts/eval.mjs
@@ -305,21 +305,9 @@ const TOOLS_LIST_CACHE_HINT = { ttlMs: 3_600_000, cacheScope: "public" };
 
 /**
  * What 1.x charged for the whole of `tools/list`: 247 + 171 + 267 + 844,
- * measured as `V1_RESPONSE_TOKENS` was. One figure rather than four, because two
- * of those tools were renamed and re-scoped, so a per-tool comparison names a
- * tool that no longer exists. The README publishes it.
+ * measured as `V1_RESPONSE_TOKENS` was. The README publishes it.
  */
 const V1_DEFINITION_TOTAL = 1529;
-
-/**
- * The ceiling `tools/list` must stay under, which starts at what 1.x charged and
- * ratchets down with each saving. Separate from the released figure above, so
- * lowering the gate cannot rewrite what the README says 1.x cost.
- *
- * The per-tool budgets cannot assert this on their own - a fifth tool would
- * pass all four and still put the total back over the baseline.
- */
-const TOTAL_DEFINITION_BUDGET = V1_DEFINITION_TOTAL;
 
 /**
  * The words a client's tool search matches on. Asserted so that a trim which
@@ -791,10 +779,9 @@ function definitionCosts(tools) {
 }
 
 /**
- * Two things zod emits that no client reads, and that a budget with 5% headroom
- * would not notice coming back: the dialect `$schema` states (14 tokens a tool,
- * dropped by `toolInputSchema`) and the safe-integer bounds an `.int()` carries
- * where it states no ceiling or floor of its own (see `MAX_PAGE_SIZE`).
+ * The fields `toolInputSchema` drops, back on the wire: the JSON Schema dialect
+ * and a bound at zod's safe-integer figure. A tool registered without the
+ * wrapper states both, and a budget with 5% headroom would not notice.
  */
 function checkNothingUnreadOnTheWire(tools, failures) {
   for (const tool of tools) {
@@ -803,21 +790,18 @@ function checkNothingUnreadOnTheWire(tools, failures) {
         `${tool.name}: inputSchema states its JSON Schema dialect, which MCP fixes and no client reads - wrap the shape in toolInputSchema`,
       );
     }
-    for (const where of safeIntegerBounds(tool.inputSchema ?? {}, [])) {
+    for (const where of safeIntegerBounds(tool.inputSchema, [])) {
       failures.push(
-        `${tool.name}: ${where} states zod's safe-integer bound - state a floor and a ceiling of its own`,
+        `${tool.name}: ${where} states zod's safe-integer bound, which describes the double and not the parameter`,
       );
     }
   }
 }
 
 /**
- * Every place in a JSON Schema stating a safe-integer bound, by path.
- *
- * Recursive because the bound is a property of the number, not of the tool: an
- * `.int()` inside an array or an object states it one level down, where a check
- * on the top-level properties reads nothing. `minimum` as well as `maximum`,
- * because `-9007199254740991` is a character longer than the ceiling.
+ * Every place in a JSON Schema stating a safe-integer bound, by path. Recursive
+ * over values, because the bound belongs to the number: an `.int()` inside an
+ * array or a record states it a level down.
  */
 function safeIntegerBounds(schema, path) {
   if (typeof schema !== "object" || schema === null) {
@@ -827,26 +811,15 @@ function safeIntegerBounds(schema, path) {
     (bound) =>
       typeof bound === "number" && Math.abs(bound) === Number.MAX_SAFE_INTEGER,
   );
-  const named = path.length ? path.join(".") : "the schema";
 
   return [
-    ...(stated ? [named] : []),
-    ...Object.entries(schema).flatMap(([keyword, value]) => {
-      if (keyword === "properties" || keyword === "patternProperties") {
-        return Object.entries(value ?? {}).flatMap(([property, child]) =>
-          safeIntegerBounds(child, [...path, property]),
-        );
-      }
-      if (["items", "additionalProperties", "not"].includes(keyword)) {
-        return safeIntegerBounds(value, [...path, keyword]);
-      }
-      if (["anyOf", "oneOf", "allOf", "prefixItems"].includes(keyword)) {
-        return (value ?? []).flatMap((child, index) =>
-          safeIntegerBounds(child, [...path, `${keyword}[${index}]`]),
-        );
-      }
-      return [];
-    }),
+    ...(stated ? [path.join(".") || "the schema"] : []),
+    ...Object.entries(schema).flatMap(([keyword, value]) =>
+      safeIntegerBounds(
+        value,
+        keyword === "properties" ? path : [...path, keyword],
+      ),
+    ),
   ];
 }
 
@@ -866,10 +839,18 @@ function checkDefinitionBudget(costs, failures) {
       failures.push(`${name}: budgeted but absent from tools/list`);
     }
   }
-  const total = costs.reduce((sum, cost) => sum + cost.tokens, 0);
-  if (total > TOTAL_DEFINITION_BUDGET) {
+  // The budgets themselves, not the measurements: every tool has one - the loop
+  // above fails a tool that does not - so a run under all four is under their
+  // sum, and a fifth tool cannot slip past. What no per-tool budget can say is
+  // that the sum is still under what 1.x charged, which is the figure the README
+  // publishes as the saving.
+  const budgeted = Object.values(DEFINITION_BUDGET).reduce(
+    (sum, budget) => sum + budget,
+    0,
+  );
+  if (budgeted > V1_DEFINITION_TOTAL) {
     failures.push(
-      `tools/list is ~${total} tokens, over the ${TOTAL_DEFINITION_BUDGET} that 1.x charged for it`,
+      `the definition budgets sum to ${budgeted}, over the ${V1_DEFINITION_TOTAL} that 1.x charged for tools/list`,
     );
   }
 }
@@ -961,8 +942,6 @@ function renderTokenCost(costs, responses) {
   const share = ((100 * total) / CONTEXT_WINDOW).toFixed(1);
   const [v1TotalCell, totalChange] = comparison(V1_DEFINITION_TOTAL, total);
 
-  // Only the total compares with 1.x: per tool it would compare renamed,
-  // re-scoped tools. The README's Token Cost prose states why.
   return [
     {
       id: "token-cost-definitions",

--- a/src/tools/apexLogSource.ts
+++ b/src/tools/apexLogSource.ts
@@ -17,11 +17,14 @@ import type { ApexLog, LogEvent } from "@apexdevtools/apex-log-parser";
  * and not where the caller is. Resolving would read a different file, or none,
  * and report neither. Refinements do not reach the JSON schema, so this costs
  * no tokens in the tool definition - `pnpm run eval` holds that to its budget.
+ *
+ * Two words of describe: the server `instructions` state the absolute `.log`
+ * path once, which is where a fact true of every tool belongs.
  */
 export const logFilePathSchema = z
   .string()
   .refine(isAbsolute, "must be an absolute path")
-  .describe("Absolute path to the Apex debug log file (.log)");
+  .describe("Absolute path");
 
 type CachedLog = {
   path: string;

--- a/src/tools/executeAnonymousDefinition.ts
+++ b/src/tools/executeAnonymousDefinition.ts
@@ -19,6 +19,7 @@ import {
   TRACE_CATEGORIES,
 } from "../salesforce/debugLevels.js";
 import { APEX_EXECUTION_DISABLED_MESSAGE } from "../policy/orgExecutionPolicy.js";
+import { toolInputSchema } from "./inputSchema.js";
 
 const logLevelSchema = z.enum(LOG_LEVELS);
 
@@ -85,7 +86,7 @@ export function executeAnonymousToolConfig(apexExecutionDisabled = false) {
     description: apexExecutionDisabled
       ? `[DISABLED on this server] ${EXECUTE_ANONYMOUS_DESCRIPTION} ${APEX_EXECUTION_DISABLED_MESSAGE}`
       : EXECUTE_ANONYMOUS_DESCRIPTION,
-    inputSchema: executeAnonymousInputSchema,
+    inputSchema: toolInputSchema(executeAnonymousInputSchema),
     annotations: {
       readOnlyHint: false,
       destructiveHint: true,

--- a/src/tools/executeAnonymousDefinition.ts
+++ b/src/tools/executeAnonymousDefinition.ts
@@ -87,6 +87,9 @@ export function executeAnonymousToolConfig(apexExecutionDisabled = false) {
       ? `[DISABLED on this server] ${EXECUTE_ANONYMOUS_DESCRIPTION} ${APEX_EXECUTION_DISABLED_MESSAGE}`
       : EXECUTE_ANONYMOUS_DESCRIPTION,
     inputSchema: toolInputSchema(executeAnonymousInputSchema),
+    // All four hints, where the read-only tools state only the two that differ
+    // from the spec default: this is the one tool where a client that misreads a
+    // default runs Apex against an org.
     annotations: {
       readOnlyHint: false,
       destructiveHint: true,

--- a/src/tools/getLogSummary.ts
+++ b/src/tools/getLogSummary.ts
@@ -42,7 +42,7 @@ export type LogSummaryArgs = z.infer<
 export const getLogSummaryToolConfig = {
   title: "Get Apex Log Summary",
   description:
-    "Get a high-level summary of an Apex debug log: how long the transaction ran, where the time went by debug log category, every governor limit it and each namespace consumed, the debug levels it was logged at, whether the log is complete, and what ended the transaction if it failed. Best for a quick overview before deeper analysis.",
+    "Get a high-level summary of an Apex debug log: how long the transaction ran, where the time went by debug log category, every governor limit it and each namespace consumed, the debug levels it was logged at, whether the log is complete, and what ended the transaction if it failed. Best for a quick overview.",
   inputSchema: getLogSummaryInputSchema,
   annotations: {
     readOnlyHint: true,

--- a/src/tools/getLogSummary.ts
+++ b/src/tools/getLogSummary.ts
@@ -5,6 +5,7 @@
 import { z } from "zod";
 import { encode } from "@toon-format/toon";
 import { loadApexLog, logFilePathSchema } from "./apexLogSource.js";
+import { toolInputSchema } from "./inputSchema.js";
 import {
   declaredLevels,
   listOperations,
@@ -43,7 +44,7 @@ export const getLogSummaryToolConfig = {
   title: "Get Apex Log Summary",
   description:
     "Get a high-level summary of an Apex debug log: how long the transaction ran, where the time went by debug log category, every governor limit it and each namespace consumed, the debug levels it was logged at, whether the log is complete, and what ended the transaction if it failed. Best for a quick overview.",
-  inputSchema: getLogSummaryInputSchema,
+  inputSchema: toolInputSchema(getLogSummaryInputSchema),
   annotations: {
     readOnlyHint: true,
     openWorldHint: false,

--- a/src/tools/inputSchema.ts
+++ b/src/tools/inputSchema.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+import { z } from "zod";
+
+/**
+ * A tool's input schema, as the wire wants it: zod for validation, and no
+ * `$schema`.
+ *
+ * `z.toJSONSchema` states the dialect it emitted - 14 tokens a tool, charged on
+ * every request - and MCP fixes the dialect for a tool's `inputSchema`, so no
+ * client reads it. The SDK converts through the schema's own
+ * `~standard.jsonSchema`, which is a documented interface, so a proxy that swaps
+ * that one property leaves the real zod object doing the validating.
+ *
+ * Wrapping also takes the four tools off `registerTool`'s raw-shape overload,
+ * which the SDK deprecates in favour of `z.object`.
+ */
+export function toolInputSchema<S extends z.ZodRawShape>(
+  shape: S,
+): z.ZodObject<S> {
+  const object = z.object(shape);
+  const { jsonSchema, ...rest } = object["~standard"];
+  const withoutDialect = (
+    convert: (options: Parameters<typeof jsonSchema.input>[0]) => Record<string, unknown>,
+  ) => (options: Parameters<typeof jsonSchema.input>[0]) => {
+    const { $schema: _dialect, ...schema } = convert(options);
+    return schema;
+  };
+  const standard = {
+    ...rest,
+    jsonSchema: {
+      input: withoutDialect(jsonSchema.input),
+      output: withoutDialect(jsonSchema.output),
+    },
+  };
+
+  return new Proxy(object, {
+    get: (target, property, receiver) =>
+      property === "~standard"
+        ? standard
+        : Reflect.get(target, property, receiver),
+  });
+}

--- a/src/tools/inputSchema.ts
+++ b/src/tools/inputSchema.ts
@@ -4,15 +4,26 @@
 
 import { z } from "zod";
 
+/** What zod states and no client reads, where the value is zod's and not ours. */
+const UNREAD = new Set(["$schema", "minimum", "maximum"]);
+
 /**
- * A tool's input schema, as the wire wants it: zod for validation, and no
- * `$schema`.
+ * A tool's input schema, as the wire wants it: zod for validation, and none of
+ * what zod says to itself.
  *
- * `z.toJSONSchema` states the dialect it emitted - 14 tokens a tool, charged on
- * every request - and MCP fixes the dialect for a tool's `inputSchema`, so no
- * client reads it. The SDK converts through the schema's own
- * `~standard.jsonSchema`, which is a documented interface, so a proxy that swaps
- * that one property leaves the real zod object doing the validating.
+ * `$schema` names the dialect zod converted to, 14 tokens a tool, and MCP fixes
+ * the dialect for a tool's `inputSchema`. `minimum` and `maximum` at the
+ * safe-integer bound are what `.int()` emits where the field states no bound of
+ * its own, and they describe the double, not the parameter. Both are charged on
+ * every request.
+ *
+ * Neither is reachable through zod: `$ZodConfig` has no JSON Schema knob, and
+ * `z.toJSONSchema` derives the dialect from the target alone. The SDK converts
+ * through the schema's own `~standard.jsonSchema`, so replacing that one
+ * property leaves the real zod object doing the validating - it keeps its
+ * refinements, its bounds and its type. `fromJsonSchema` would put an exact
+ * document on the wire, but it validates through JSON Schema, which would drop
+ * both the refinements and the inferred argument types.
  *
  * Wrapping also takes the four tools off `registerTool`'s raw-shape overload,
  * which the SDK deprecates in favour of `z.object`.
@@ -21,31 +32,58 @@ export function toolInputSchema<S extends z.ZodRawShape>(
   shape: S,
 ): z.ZodObject<S> {
   const object = z.object(shape);
-  const { jsonSchema, ...rest } = object["~standard"];
+  const standard = object["~standard"];
   // A zod that no longer publishes the converter is one the SDK falls back to
-  // `z.toJSONSchema` for, and a saving of 14 tokens is not worth trading that
-  // fallback for a TypeError at import, which would take all four tools with it.
-  if (jsonSchema === undefined) {
+  // `z.toJSONSchema` for, and 14 tokens are not worth trading that for a throw
+  // at import, which would take every tool with it.
+  if (standard.jsonSchema === undefined) {
     return object;
   }
-  const withoutDialect = (
-    convert: (options: Parameters<typeof jsonSchema.input>[0]) => Record<string, unknown>,
-  ) => (options: Parameters<typeof jsonSchema.input>[0]) => {
-    const { $schema: _dialect, ...schema } = convert(options);
-    return schema;
-  };
-  const standard = {
-    ...rest,
+
+  object["~standard"] = {
+    ...standard,
     jsonSchema: {
-      input: withoutDialect(jsonSchema.input),
-      output: withoutDialect(jsonSchema.output),
+      ...standard.jsonSchema,
+      input: (options) => withoutUnread(standard.jsonSchema.input(options)),
     },
   };
 
-  return new Proxy(object, {
-    get: (target, property, receiver) =>
-      property === "~standard"
-        ? standard
-        : Reflect.get(target, property, receiver),
-  });
+  return object;
+}
+
+/**
+ * The document without the keywords above, at any depth.
+ *
+ * Recursive over values rather than over the keywords that nest, because the
+ * bound belongs to the number: an `.int()` inside an array or a record states it
+ * a level down, where a pass over the top-level properties reads nothing.
+ */
+function withoutUnread(schema: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(schema)
+      .filter(([keyword, value]) => !isUnread(keyword, value))
+      .map(([keyword, value]) => [keyword, prune(value)]),
+  );
+}
+
+function isUnread(keyword: string, value: unknown): boolean {
+  if (!UNREAD.has(keyword)) {
+    return false;
+  }
+  // `$schema` is ours to drop whatever it says; a bound only where the figure is
+  // the double's, not one the field asked for.
+  return (
+    keyword === "$schema" ||
+    (typeof value === "number" && Math.abs(value) === Number.MAX_SAFE_INTEGER)
+  );
+}
+
+function prune(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(prune);
+  }
+  if (typeof value === "object" && value !== null) {
+    return withoutUnread(value as Record<string, unknown>);
+  }
+  return value;
 }

--- a/src/tools/inputSchema.ts
+++ b/src/tools/inputSchema.ts
@@ -22,6 +22,12 @@ export function toolInputSchema<S extends z.ZodRawShape>(
 ): z.ZodObject<S> {
   const object = z.object(shape);
   const { jsonSchema, ...rest } = object["~standard"];
+  // A zod that no longer publishes the converter is one the SDK falls back to
+  // `z.toJSONSchema` for, and a saving of 14 tokens is not worth trading that
+  // fallback for a TypeError at import, which would take all four tools with it.
+  if (jsonSchema === undefined) {
+    return object;
+  }
   const withoutDialect = (
     convert: (options: Parameters<typeof jsonSchema.input>[0]) => Record<string, unknown>,
   ) => (options: Parameters<typeof jsonSchema.input>[0]) => {

--- a/src/tools/listLimitRisks.ts
+++ b/src/tools/listLimitRisks.ts
@@ -71,7 +71,7 @@ export interface LimitRiskResult {
 export const listLimitRisksToolConfig = {
   title: "List Apex Log Limit Risks",
   description:
-    "List the governor limits an Apex log transaction has nearly consumed - CPU time, heap, SOQL and SOSL queries, DML statements, and the rows each returned or wrote - worst first, with how much of each was used. Best for checking whether a transaction is at risk of failing on a limit.",
+    "List the governor limits an Apex log transaction has nearly consumed - CPU time, heap, SOQL and SOSL queries, DML statements, and the rows each returned or wrote - worst first, with how much of each was used",
   inputSchema: listLimitRisksInputSchema,
   annotations: {
     readOnlyHint: true,

--- a/src/tools/listLimitRisks.ts
+++ b/src/tools/listLimitRisks.ts
@@ -9,6 +9,7 @@ import type {
   Limits,
 } from "@apexdevtools/apex-log-parser/types";
 import { loadApexLog, logFilePathSchema } from "./apexLogSource.js";
+import { toolInputSchema } from "./inputSchema.js";
 import { capturedAt, type DeclaredLevel } from "./operations.js";
 import {
   limitGatingCategory,
@@ -72,7 +73,7 @@ export const listLimitRisksToolConfig = {
   title: "List Apex Log Limit Risks",
   description:
     "List the governor limits an Apex log transaction has nearly consumed - CPU time, heap, SOQL and SOSL queries, DML statements, and the rows each returned or wrote - worst first, with how much of each was used",
-  inputSchema: listLimitRisksInputSchema,
+  inputSchema: toolInputSchema(listLimitRisksInputSchema),
   annotations: {
     readOnlyHint: true,
     openWorldHint: false,

--- a/src/tools/listSlowOperations.ts
+++ b/src/tools/listSlowOperations.ts
@@ -67,11 +67,14 @@ const COMPARE_BY: Record<SortBy, (a: Operation, b: Operation) => number> = {
 /**
  * The largest page and the furthest offset the schema accepts.
  *
- * Stated, because `.int()` alone puts zod's safe-integer maximum,
- * `9007199254740991`, on the wire for both fields - 5 tokens of every request to
- * bound a page that `PAGE_CHAR_BUDGET` cuts long before either figure.
+ * Stated, because `.int()` alone puts zod's safe-integer bounds on the wire for
+ * both fields, which no client reads. Both sit above anything a real call asks
+ * for - the largest log in a 124-log corpus ranks 39,415 rows - because a page
+ * is bounded by `PAGE_CHAR_BUDGET`, and "fewer rows than you asked for" is the
+ * answer a caller gets today. A ceiling low enough to refuse a large `limit`
+ * would trade that for an error, which is not what 3 tokens buy.
  */
-const MAX_PAGE_SIZE = 1_000;
+const MAX_PAGE_SIZE = 100_000;
 const MAX_OFFSET = 1_000_000;
 
 export const listSlowOperationsInputSchema = {

--- a/src/tools/listSlowOperations.ts
+++ b/src/tools/listSlowOperations.ts
@@ -64,19 +64,6 @@ const COMPARE_BY: Record<SortBy, (a: Operation, b: Operation) => number> = {
     b.heapSelfNetBytes - a.heapSelfNetBytes || bySelfTime(a, b),
 };
 
-/**
- * The largest page and the furthest offset the schema accepts.
- *
- * Stated, because `.int()` alone puts zod's safe-integer bounds on the wire for
- * both fields, which no client reads. Both sit above anything a real call asks
- * for - the largest log in a 124-log corpus ranks 39,415 rows - because a page
- * is bounded by `PAGE_CHAR_BUDGET`, and "fewer rows than you asked for" is the
- * answer a caller gets today. A ceiling low enough to refuse a large `limit`
- * would trade that for an error, which is not what 3 tokens buy.
- */
-const MAX_PAGE_SIZE = 100_000;
-const MAX_OFFSET = 1_000_000;
-
 export const listSlowOperationsInputSchema = {
   logFilePath: logFilePathSchema,
   debugCategory: z
@@ -101,20 +88,20 @@ export const listSlowOperationsInputSchema = {
       "Drop operations below this self time (default: 0), whichever sortBy is used",
     ),
   // `.min(0)` so a negative page size cannot read as "every row bar the fastest".
+  // No ceiling: a page is bounded by `PAGE_CHAR_BUDGET`, and the safe-integer
+  // maximum `.int()` states is dropped by `toolInputSchema`, not by a figure
+  // invented here - one low enough to refuse a large `limit` would turn a
+  // trimmed page into an error.
   limit: z
     .number()
     .int()
     .min(0)
-    .max(MAX_PAGE_SIZE)
     .optional()
     .describe("Page size (default: 10); fewer if the page would be too large"),
-  // The describe says advance by the rows you got, because the page budget can
-  // return fewer than `limit` and paging by `limit` would then skip rows.
   offset: z
     .number()
     .int()
     .min(0)
-    .max(MAX_OFFSET)
     .optional()
     .describe(
       "Ranked rows to skip (default: 0). Advance it by the rows you got, which can be fewer than limit.",

--- a/src/tools/listSlowOperations.ts
+++ b/src/tools/listSlowOperations.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import type { ApexLog } from "@apexdevtools/apex-log-parser";
 import { encode } from "@toon-format/toon";
 import { loadApexLog, logFilePathSchema } from "./apexLogSource.js";
+import { toolInputSchema } from "./inputSchema.js";
 import {
   capturedAt,
   GROUP_BY,
@@ -63,6 +64,16 @@ const COMPARE_BY: Record<SortBy, (a: Operation, b: Operation) => number> = {
     b.heapSelfNetBytes - a.heapSelfNetBytes || bySelfTime(a, b),
 };
 
+/**
+ * The largest page and the furthest offset the schema accepts.
+ *
+ * Stated, because `.int()` alone puts zod's safe-integer maximum,
+ * `9007199254740991`, on the wire for both fields - 5 tokens of every request to
+ * bound a page that `PAGE_CHAR_BUDGET` cuts long before either figure.
+ */
+const MAX_PAGE_SIZE = 1_000;
+const MAX_OFFSET = 1_000_000;
+
 export const listSlowOperationsInputSchema = {
   logFilePath: logFilePathSchema,
   debugCategory: z
@@ -86,16 +97,21 @@ export const listSlowOperationsInputSchema = {
     .describe(
       "Drop operations below this self time (default: 0), whichever sortBy is used",
     ),
+  // `.min(0)` so a negative page size cannot read as "every row bar the fastest".
   limit: z
     .number()
     .int()
     .min(0)
+    .max(MAX_PAGE_SIZE)
     .optional()
     .describe("Page size (default: 10); fewer if the page would be too large"),
+  // The describe says advance by the rows you got, because the page budget can
+  // return fewer than `limit` and paging by `limit` would then skip rows.
   offset: z
     .number()
     .int()
     .min(0)
+    .max(MAX_OFFSET)
     .optional()
     .describe(
       "Ranked rows to skip (default: 0). Advance it by the rows you got, which can be fewer than limit.",
@@ -141,7 +157,7 @@ export const listSlowOperationsToolConfig = {
   title: "List Slow Apex Log Operations",
   description:
     "Rank what an Apex debug log spent its time on by self-execution time, or on the heap it retains - code units, methods, queries, searches, DML, flows and workflows in one table, each row with its calls, durations, database counts and rows, so the caller can see what to optimize and why, beside the query optimizer's plan for the queries among them.",
-  inputSchema: listSlowOperationsInputSchema,
+  inputSchema: toolInputSchema(listSlowOperationsInputSchema),
   annotations: {
     readOnlyHint: true,
     openWorldHint: false,

--- a/src/tools/listSlowOperations.ts
+++ b/src/tools/listSlowOperations.ts
@@ -104,14 +104,12 @@ export const listSlowOperationsInputSchema = {
     .enum([...GROUP_BY, "none"])
     .optional()
     .describe(
-      "Fold repeats into one row: by name (default), by namespace, by callerNamespace, which attributes platform DML to the package that drove it, or by debugCategory, which folds a namespace's event types into one row per category and so states no type or name. A grouped durationTotalMs is what the transaction takes back if the group never runs - never sum it across rows. Pass none to rank each call on its own.",
+      "Fold repeats into one row; default name. callerNamespace attributes platform DML to the package that drove it. debugCategory folds a namespace's event types together and so states no type or name. none ranks each call on its own. A grouped durationTotalMs is what the transaction takes back if the group never runs - never sum it across rows.",
     ),
   sortBy: z
     .enum(SORT_BY)
     .optional()
-    .describe(
-      "Rank on (default: durationSelfMs). heapSelfNetBytes adds that column.",
-    ),
+    .describe("Default durationSelfMs. heapSelfNetBytes adds that column."),
 };
 
 /**
@@ -142,7 +140,7 @@ export type SlowOperationsArgs = z.infer<
 export const listSlowOperationsToolConfig = {
   title: "List Slow Apex Log Operations",
   description:
-    "Rank what an Apex debug log spent its time on by self-execution time, or on the heap it retains - code units, methods, queries, searches, DML, flows and workflows in one table, each row with its calls, durations, database counts and rows, so the caller can see what to optimize and why, beside the query optimizer's plan for the queries among them. A plan names its row, or the query itself under a namespace or category grouping.",
+    "Rank what an Apex debug log spent its time on by self-execution time, or on the heap it retains - code units, methods, queries, searches, DML, flows and workflows in one table, each row with its calls, durations, database counts and rows, so the caller can see what to optimize and why, beside the query optimizer's plan for the queries among them.",
   inputSchema: listSlowOperationsInputSchema,
   annotations: {
     readOnlyHint: true,

--- a/tests/inputSchema.test.ts
+++ b/tests/inputSchema.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+import { z } from "zod";
+import { toolInputSchema } from "../src/tools/inputSchema";
+
+describe("toolInputSchema", () => {
+  const schema = toolInputSchema({
+    logFilePath: z
+      .string()
+      .refine((value) => value.startsWith("/"), "must be an absolute path"),
+    limit: z.number().int().min(0).max(1000).optional(),
+  });
+
+  // The proxy swaps one property of a real zod object, so what matters is that
+  // everything else still reaches zod: a refinement, a bound and a type.
+  it("validates as the zod object it wraps", () => {
+    expect(schema.safeParse({ logFilePath: "/tmp/a.log" }).success).toBe(true);
+    expect(schema.safeParse({ logFilePath: "a.log" }).success).toBe(false);
+    expect(
+      schema.safeParse({ logFilePath: "/tmp/a.log", limit: 5000 }).success,
+    ).toBe(false);
+    expect(
+      schema.safeParse({ logFilePath: "/tmp/a.log", limit: "10" }).success,
+    ).toBe(false);
+  });
+
+  it("states the properties but not the dialect", () => {
+    const json = schema["~standard"].jsonSchema.input({
+      target: "draft-2020-12",
+    });
+
+    expect(json.$schema).toBeUndefined();
+    expect(json).toMatchObject({
+      type: "object",
+      properties: { logFilePath: { type: "string" } },
+      required: ["logFilePath"],
+    });
+  });
+});

--- a/tests/inputSchema.test.ts
+++ b/tests/inputSchema.test.ts
@@ -2,40 +2,40 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 
-import { z } from "zod";
 import { toolInputSchema } from "../src/tools/inputSchema";
+import { listSlowOperationsInputSchema } from "../src/tools/listSlowOperations";
+
+// The shipped shape, because it is the one that has to survive the wrapper: a
+// refinement (`logFilePath`), a floor and an integer (`limit`), and an enum.
+const schema = toolInputSchema(listSlowOperationsInputSchema);
+const logFilePath = "/tmp/a.log";
 
 describe("toolInputSchema", () => {
-  const schema = toolInputSchema({
-    logFilePath: z
-      .string()
-      .refine((value) => value.startsWith("/"), "must be an absolute path"),
-    limit: z.number().int().min(0).max(1000).optional(),
-  });
-
-  // The proxy swaps one property of a real zod object, so what matters is that
-  // everything else still reaches zod: a refinement, a bound and a type.
   it("validates as the zod object it wraps", () => {
-    expect(schema.safeParse({ logFilePath: "/tmp/a.log" }).success).toBe(true);
+    expect(schema.safeParse({ logFilePath }).success).toBe(true);
     expect(schema.safeParse({ logFilePath: "a.log" }).success).toBe(false);
-    expect(
-      schema.safeParse({ logFilePath: "/tmp/a.log", limit: 5000 }).success,
-    ).toBe(false);
-    expect(
-      schema.safeParse({ logFilePath: "/tmp/a.log", limit: "10" }).success,
-    ).toBe(false);
+    expect(schema.safeParse({ logFilePath, limit: -1 }).success).toBe(false);
+    expect(schema.safeParse({ logFilePath, limit: "10" }).success).toBe(false);
+    expect(schema.safeParse({ logFilePath, groupBy: "nope" }).success).toBe(
+      false,
+    );
   });
 
-  it("states the properties but not the dialect", () => {
+  // The safe-integer bound is dropped where the figure is zod's, and kept where
+  // the field asked for it - `limit` states `.min(0)`, and 0 reaches the wire.
+  it("drops what only zod reads, at any depth", () => {
     const json = schema["~standard"].jsonSchema.input({
       target: "draft-2020-12",
     });
+    const limit = (json.properties as Record<string, Record<string, unknown>>)
+      .limit;
 
     expect(json.$schema).toBeUndefined();
-    expect(json).toMatchObject({
-      type: "object",
-      properties: { logFilePath: { type: "string" } },
-      required: ["logFilePath"],
+    expect(limit).toEqual({
+      description: expect.stringContaining("Page size"),
+      type: "integer",
+      minimum: 0,
     });
+    expect(JSON.stringify(json)).not.toContain("9007199254740991");
   });
 });


### PR DESCRIPTION
Closes #188. Closes #189.

`tools/list` is charged on every request, called or not, and two rows of the README's Token Cost table read badly: `apexlog_list_slow_operations` at +145% on 1.x, and a total only 9% under it. Nothing here drops a fact.

| Tool | 1.x | before | after |
| --- | --- | --- | --- |
| `apexlog_list_slow_operations` | ~247 | ~606 | **~530** |
| `apexlog_execute_anonymous` | ~844 | ~421 | **~407** |
| `apexlog_list_limit_risks` | ~267 | ~192 | **~150** |
| `apexlog_get_summary` | ~171 | ~174 | **~145** |
| **Total** | **~1,529** | **~1,393** | **~1,232** |

19% under 1.x, where it was 9%. Responses are untouched.

## What came off the wire

**Text the wire already carried.** `groupBy` and `sortBy` restated their own enum values. The shared `logFilePath` describe stated the absolute `.log` path in three tools, where the server `instructions` state it once and a relative path is refused with "must be an absolute path". The ranking's description explained where a query plan names its row, which the response shape says and the README documents. Two descriptions closed on a "Best for" sentence that restated the tool name - `apexlog_get_summary` keeps its own, the only place the locked selection keyword "overview" appears.

**What zod says to itself.** `$schema` names the JSON Schema dialect zod converted to, 14 tokens a tool, and the spec is explicit that `inputSchema` "defaults to 2020-12 if no `$schema` field is present". `minimum`/`maximum` at zod's safe-integer figure are what `.int()` emits where the field states no bound of its own; they describe the double, not the parameter. `toolInputSchema` drops both, at any depth, by replacing one property of a real zod object - `~standard.jsonSchema`, the SDK's own documented interface - so the schema still validates: refinements, bounds, enums and types all still reject. It also takes the four tools off `registerTool`'s raw-shape overload, which the SDK deprecates in favour of `z.object`.

`.min(0)` stays and still reaches the wire as `minimum: 0`. A large `limit` is trimmed by `PAGE_CHAR_BUDGET` as before, and `limit: 1e20` is still refused - by zod, which never stopped checking.

This corrects `DEVELOPING.md`'s "Know the floor", which claimed ~90 SDK tokens that "cannot be removed through a public API". `execution` had already left `tools/list` in SDK v2, and `$schema` comes out through a documented interface.

## What the README publishes

The per-tool 1.x column is gone. It compared `apexlog_list_slow_operations` with `analyze_apex_log_performance`, a tool that took three selection parameters and ranked methods where this one takes eight and ranks every timed event: the percentage measured the capability gap, and no trim makes it read fairly. The total is what a session pays for the server, then and now, so the comparison moves there and the prose beside the table says why.

## Checks

- `checkNothingUnreadOnTheWire` fails the run if the dialect or a safe-integer bound returns. It recurses over values, so an `.int()` inside an array or a record is caught a level down. Negative-tested both ways.
- `tests/inputSchema.test.ts` wraps the shipped `listSlowOperationsInputSchema` and pins that a refinement, a floor, a type and an enum still reject through the wrapper, and that no safe-integer figure survives.
- The total gate now asserts that the per-tool budgets **sum** under what 1.x charged. The previous form could not fire: a tool with no budget already fails, so nothing could reach a ceiling 288 tokens above the budgets gating it.
- `DEVELOPING.md`'s definitions section is three paragraphs pointing at the MCP spec and at the checks, with the two facts neither carries kept: where a fact belongs by how often it is charged, and why the destructive tool states all four annotation hints. Spec links are revision-free so they track the current revision.

`pnpm run eval` (9 cases), `pnpm test` (368) and `pnpm run lint` pass at every commit, not only at the tip.

## Reviewed

`/code-review` and `/simplify` both ran over the range. Between them they took out the Proxy (`~standard` is a writable accessor, so assignment does it - 91 bytes lighter a schema), the two invented page ceilings (a wire problem does not belong in the request contract, and the first figure refused a `limit` the pager used to trim), a keyword allowlist in the gate that matched nothing these schemas emit while still missing `$defs`, and a dead total-budget assertion. Also deleted `dist/tools/leanSchema.js`, an orphan a publish would have shipped.

Left for their own issues: an upstream patch so the SDK strips the dialect for every zod-based server, and a wire-field allowlist in place of a check per artefact.