### PR TITLE
fix(deps): take apex-log-parser 0.1.1 for log size and heap frees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ _Upgrading from 1.x? Every tool is renamed, and `--allowed-orgs` is gone. See [M
 
 - Fix incorrectly reported timings for callouts in `apexlog_list_slow_operations`, which were counted in the calling method's self time ([#97], [#138])
 - Fix understated governor limit usage in `apexlog_get_summary` and `apexlog_list_limit_risks`, which reported the usage the transaction ended on rather than its peak ([#97])
+- Fix the understated size of a log holding non-ASCII characters, and the heap a row retains where the code freed memory, on apex-log-parser 0.1.1
 - Return the debug log of the run `apexlog_execute_anonymous` made, where the newest log for the user could be another process's ([#65])
 - Return an absolute log path from `apexlog_execute_anonymous`, and warn when `outputDir` resolves outside every folder the client opened ([#109])
 - Name the real reason a log file cannot be opened - a permission error used to read as "Log file not found" ([#109])

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ pnpm start
 - **src/tools/apexLogSource.ts**: `loadApexLog` and `walkLog`, the one way the analysis tools get a log. It caches the last parse against a stat fingerprint, shares one parse between concurrent callers, and drops it five minutes after its last use, because a parsed log holds four to five times the size of the file.
 - **`@apexdevtools/apex-log-parser`**: the parser, as a dependency - nothing here parses a log. Runtime values come from the package root, every type and const from `@apexdevtools/apex-log-parser/types`. Read `debugCategory` for an event's category, never `category`: that one is a UI grouping slated for deprecation, and `src/tools/operations.ts` reads it only as the flag that says an event has a duration.
 
-  `tests/parserContract.test.ts` pins what the tools assume, against a real parse - no other suite would notice a parser upgrade that broke one. One pinned assumption is a known defect, fixed upstream in 0.2.0: `ApexLog.size` counts UTF-16 code units, not bytes ([apex-log-parser#70](https://github.com/apex-dev-tools/apex-log-parser/issues/70)).
+  `tests/parserContract.test.ts` pins what the tools assume, against a real parse - no other suite would notice a parser upgrade that broke one.
 
 ### Key Data Structures
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "homepage": "https://github.com/certinia/debug-log-analyzer-mcp#readme",
   "dependencies": {
-    "@apexdevtools/apex-log-parser": "^0.1.0",
+    "@apexdevtools/apex-log-parser": "^0.1.1",
     "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/server": "^2.0.0",
     "@salesforce/core": "^8.32.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@apexdevtools/apex-log-parser':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.1.1
+        version: 0.1.1
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
         version: 2.0.0
@@ -63,8 +63,8 @@ importers:
 
 packages:
 
-  '@apexdevtools/apex-log-parser@0.1.0':
-    resolution: {integrity: sha512-UDIfkvZWJzspW2xvbMo4NEs0o2UfpYLde4O1ShIqM7ZphP8MoYEQ5eriOzNte9SfGZmXaO4l1YKsRltihwGHJA==}
+  '@apexdevtools/apex-log-parser@0.1.1':
+    resolution: {integrity: sha512-8KL/MAo6HsNJJryrV7ujsABRBe4QYXOrpZFzE+2fBZoftqip/9/FYMVufejtcFWWDpwciqVny46kF+ImWYToqw==}
     engines: {node: '>=20'}
 
   '@babel/code-frame@7.29.0':
@@ -2583,7 +2583,7 @@ packages:
 
 snapshots:
 
-  '@apexdevtools/apex-log-parser@0.1.0': {}
+  '@apexdevtools/apex-log-parser@0.1.1': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:

--- a/src/tools/listSlowOperations.ts
+++ b/src/tools/listSlowOperations.ts
@@ -183,9 +183,9 @@ export interface SlowOperation {
   rowCount: number;
   thrownCount: number;
   /**
-   * Net heap the row's own code retained: the signed `HEAP_ALLOCATE` bytes, so
-   * a row that released more than it took reads below zero. What counts as a
-   * free, and where a managed package's allocations land, are on
+   * Net heap the row's own code retained: what it allocated less what it
+   * freed, so a row that released more than it took reads below zero. What
+   * counts as a free, and where a managed package's allocations land, are on
    * `Operation.heapSelfNetBytes`.
    *
    * Present under `sortBy: "heapSelfNetBytes"` alone, because most logs record

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -124,11 +124,8 @@ export interface Operation {
   /**
    * Net heap the operation's own body retained, and not what it called.
    *
-   * The signed `HEAP_ALLOCATE` bytes, so a negative allocation is the free that
-   * brings the figure down and a body that releases more than it took reads
-   * below zero. `HEAP_DEALLOCATE` is *not* counted: the parser reads its bytes
-   * and drops them. No log in the corpus emits one, so nothing under-reads
-   * today, but a log that did would read as retaining what it freed.
+   * The signed `HEAP_ALLOCATE` bytes less the `HEAP_DEALLOCATE` bytes, so a
+   * body that releases more than it took reads below zero.
    *
    * A managed package is the exception to "not what it called". The parser
    * gives `ENTERING_MANAGED_PKG` no children, so an allocation logged inside

--- a/tests/parserContract.test.ts
+++ b/tests/parserContract.test.ts
@@ -49,15 +49,15 @@ describe("parser contract", () => {
       "",
     ].join("\n");
 
-    // Documented as bytes, but counted in UTF-16 code units, so it under-reads
-    // any log that is not ASCII. `apexlog_get_summary` publishes it as
-    // `fileSizeBytes`, so this case failing is the signal that the parser fixed
-    // it and the figure moved - apex-dev-tools/apex-log-parser#70, due in 0.2.0.
-    it("counts UTF-16 code units, not bytes", () => {
+    // `apexlog_get_summary` publishes it as `fileSizeBytes`, so a log that is
+    // not ASCII must not under-read. The code-unit length is asserted beside it
+    // because that is what makes the reading unambiguous: the two disagree only
+    // where the count is in bytes - apex-dev-tools/apex-log-parser#70.
+    it("counts UTF-8 bytes, not UTF-16 code units", () => {
       const { size } = parse(log);
 
-      expect(size).toBe(log.length);
-      expect(size).toBeLessThan(Buffer.byteLength(log, "utf8"));
+      expect(size).toBe(Buffer.byteLength(log, "utf8"));
+      expect(size).toBeGreaterThan(log.length);
     });
   });
 
@@ -173,6 +173,32 @@ describe("parser contract", () => {
         ["Outer.run()", 100, 1000],
         ["Inner.run()", 900, 900],
       ]);
+    });
+
+    const freed = [
+      HEADER,
+      "09:00:00.1 (1000)|EXECUTION_STARTED",
+      "09:00:00.1 (2000)|METHOD_ENTRY|[1]|01p000000000000|Outer.run()",
+      "09:00:00.2 (3000)|HEAP_ALLOCATE|[2]|Bytes:1000",
+      "09:00:00.3 (4000)|HEAP_DEALLOCATE|[3]|Bytes:400",
+      "09:00:00.6 (7000)|METHOD_EXIT|[1]|Outer.run()",
+      "09:00:01.0 (10000)|EXECUTION_FINISHED",
+      "",
+    ].join("\n");
+
+    // `heapSelfNetBytes` is a net, so a body that frees what it took must read
+    // below what it allocated. The gross is asserted beside it because that is
+    // what makes the net unambiguous: 600 against 1,000 is the free applied to
+    // one figure and not the other - apex-dev-tools/apex-log-parser#73.
+    it("nets HEAP_DEALLOCATE off the body that allocated", () => {
+      const parsed = parse(freed);
+      const [method] = tree(parsed).filter(
+        (node) => node.type === "METHOD_ENTRY",
+      );
+
+      expect(parsed.heapAllocated.total).toBe(600);
+      expect(parsed.heapGross.total).toBe(1000);
+      expect(method?.heapAllocated.self).toBe(600);
     });
   });
 


### PR DESCRIPTION
## 📝 What & why

Takes `@apexdevtools/apex-log-parser` 0.1.1, which fixes two defects this server reported through.

- `fileSizeBytes` in `apexlog_get_summary` counted UTF-16 code units, so any log holding non-ASCII characters under-read ([apex-log-parser#70](https://github.com/apex-dev-tools/apex-log-parser/issues/70)).
- `heapSelfNetBytes` in `apexlog_list_slow_operations` dropped `HEAP_DEALLOCATE` bytes, so a body that freed memory read as retaining it ([apex-log-parser#73](https://github.com/apex-dev-tools/apex-log-parser/issues/73)).

`tests/parserContract.test.ts` held the first as a pinned known defect, and the case failing was the signal the upstream fix had landed. Both are now pinned the right way round, so a regression fails here rather than reaching a response.

No fixture moves: every fixture is ASCII and none emits `HEAP_DEALLOCATE`, so the eval golden files are unchanged.

## 🧩 Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance
- [ ] 📝 Docs
- [x] 🔧 Chore (tooling, CI, deps)
- [ ] 💥 Breaking change

## 🔗 Related issues

None. The defects are upstream: apex-dev-tools/apex-log-parser#70 and #73.

## 🧪 How was this tested?

- [x] `pnpm run build`
- [x] `pnpm run test` - 369 pass, including the two rewritten parser contract cases
- [x] `pnpm run lint`
- [ ] Manually tested against an MCP client / debug log - `pnpm run eval` stood in: it drives the built server over stdio, and all 9 cases pass with the golden files unchanged

## ✅ Checklist

- [x] Added or updated tests (or not needed) - `ApexLog.size` now pins UTF-8 bytes, and a new case pins `HEAP_DEALLOCATE` netting off the body that allocated
- [x] Updated docs - README / CHANGELOG (or not needed) - one `Fixed` entry; the README needs nothing, since no figure it publishes moved
