### PR TITLE
chore: release 2.0.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@certinia/apex-log-mcp",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "MCP server that gives AI assistants tools to analyze Salesforce Apex debug logs for performance bottlenecks, slow methods, and governor limit usage.",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## 📝 What & why

Cuts `2.0.0-beta.2`, so the four changes merged since `2.0.0-beta.1` reach testers.

| Merged | What it gives a tester |
| --- | --- |
| #193 | Log size in bytes for a log holding non-ASCII characters, and the heap a row retains where the code freed memory |
| #192 | Each debug log category stated once in `apexlog_get_summary`, with the level it was captured at |
| #190 | Tool definitions down to ~1,232 tokens on every turn |
| #187 | A changelog and README cut to what a reader needs |

`## [Unreleased]` stays as it is: a beta previews the same unreleased content, and the heading becomes `## [2.0.0]` at the stable tag.

The prerelease identifier picks the channel, so `latest` stays on `1.0.0` - which matters because the VS Code extension starts this server through `npx`, and `npx` follows `latest`. Testers install `@certinia/apex-log-mcp@beta`.

## 🧩 Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance
- [ ] 📝 Docs
- [x] 🔧 Chore (tooling, CI, deps)
- [ ] 💥 Breaking change

## 🔗 Related issues

Related to #123, which tracks the stable `2.0.0` and stays open.

## 🧪 How was this tested?

- [x] `pnpm run build`
- [x] `pnpm run test` - 369 pass
- [x] `pnpm run lint`
- [ ] Manually tested against an MCP client / debug log - `pnpm run eval` stood in: 9 cases pass, and no README figure moved

The dist-tag was resolved before tagging:

```zsh
RELEASE_TAG=2.0.0-beta.2 PRERELEASE=true node scripts/release-tag.mjs
dist_tag=beta
```

## ✅ Checklist

- [x] Added or updated tests (or not needed) - not needed, the version is the only change
- [x] Updated docs - README / CHANGELOG (or not needed) - not needed, `## [Unreleased]` already carries this content

## Release steps after merge

1. Draft a release, create the tag `2.0.0-beta.2` on publish.
2. **Tick "Set as a pre-release".** `release-tag.mjs` fails the release if the tick and the version disagree.
3. Publish, then check `npm dist-tag ls @certinia/apex-log-mcp` - `latest` must still read `1.0.0`.
