### PR TITLE
build(deps): bump @salesforce/core from 8.32.6 to 9.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@apexdevtools/apex-log-parser": "^0.1.1",
     "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/server": "^2.0.0",
-    "@salesforce/core": "^8.32.3",
+    "@salesforce/core": "^9.1.11",
     "@toon-format/toon": "^4.1.1",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       '@salesforce/core':
-        specifier: ^8.32.3
-        version: 8.32.6
+        specifier: ^9.1.11
+        version: 9.1.11
       '@toon-format/toon':
         specifier: ^4.1.1
         version: 4.1.1
@@ -449,8 +449,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@jsforce/jsforce-node@3.10.19':
-    resolution: {integrity: sha512-k7i2Tntu1fLvkMtRcKDFU64/Fr2M692ECtbwIGX6hcOh5mj+jrMa1tlvcdwffxAMl+lPYCXnY2bjErxWmP84zA==}
+  '@jsforce/jsforce-node@3.10.25':
+    resolution: {integrity: sha512-L4GfTOzmGBypjG1O7aTxwbk4DTKitU7yvnnqQE7wypFyEyHH9VR6cVZxi4+Gfk7cmItHRHAV7MyBTFfrP5DaHA==}
     engines: {node: '>=22'}
 
   '@jsonjoy.com/base64@1.1.2':
@@ -518,16 +518,17 @@ packages:
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  '@salesforce/core@8.32.6':
-    resolution: {integrity: sha512-ZR973WoqCgi6cR58WhgokbHVZOaADNKHiuM1FAwS5pTLQnC91xYi04i2e/gpAX2AUf7Ya6zjbusYtZNpSyKKAQ==}
-    engines: {node: '>=18.0.0'}
+  '@salesforce/core@9.1.11':
+    resolution: {integrity: sha512-EE4oGYsoKThank4dQ1mVIzJjS9yP6C6s7JzKDx+ki8AFAxgpposzLc6GYwZZq1tS0XaOfBL2x+8RrgEgZvXwnw==}
+    engines: {node: '>=22.0.0'}
 
-  '@salesforce/kit@3.2.6':
-    resolution: {integrity: sha512-O8S4LWerHa9Zosqh+IoQjgLtpxMOfObRxaRnUdRV4MLtFUi+bQxQiyFvve6eEaBaMP1b1xVDQpvSvQ+PXEDGFQ==}
+  '@salesforce/kit@4.0.0':
+    resolution: {integrity: sha512-VwxhSH/8PQ5YmPAdhmLaJGCgR0n/pOm8T2y+/odMFthd5SA0xsO/kTdaRLFnFQAxxNj1nYtNHRb+BoMuAatzew==}
+    engines: {node: '>=22.0.0'}
 
-  '@salesforce/ts-types@2.0.12':
-    resolution: {integrity: sha512-BIJyduJC18Kc8z+arUm5AZ9VkPRyw1KKAm+Tk+9LT99eOzhNilyfKzhZ4t+tG2lIGgnJpmytZfVDZ0e2kFul8g==}
-    engines: {node: '>=18.0.0'}
+  '@salesforce/ts-types@3.2.0':
+    resolution: {integrity: sha512-3xdKt4nlthDC8nCHVWpVDwM5mmPlk8kDyJ1E3dWMk7FLRdQqhLgaHZgS+AMqcowWiKUC1l1d5YIhGhQM7dw3Bw==}
+    engines: {node: '>=22.0.0'}
 
   '@sinclair/typebox@0.34.48':
     resolution: {integrity: sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==}
@@ -3104,7 +3105,7 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
     optional: true
 
-  '@jsforce/jsforce-node@3.10.19':
+  '@jsforce/jsforce-node@3.10.25':
     dependencies:
       '@sindresorhus/is': 4.6.0
       base64url: 3.0.1
@@ -3185,11 +3186,11 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
-  '@salesforce/core@8.32.6':
+  '@salesforce/core@9.1.11':
     dependencies:
-      '@jsforce/jsforce-node': 3.10.19
-      '@salesforce/kit': 3.2.6
-      '@salesforce/ts-types': 2.0.12
+      '@jsforce/jsforce-node': 3.10.25
+      '@salesforce/kit': 4.0.0
+      '@salesforce/ts-types': 3.2.0
       ajv: 8.20.0
       change-case: 4.1.2
       fast-levenshtein: 3.0.0
@@ -3207,11 +3208,11 @@ snapshots:
       ts-retry-promise: 0.8.1
       zod: 4.4.3
 
-  '@salesforce/kit@3.2.6':
+  '@salesforce/kit@4.0.0':
     dependencies:
-      '@salesforce/ts-types': 2.0.12
+      '@salesforce/ts-types': 3.2.0
 
-  '@salesforce/ts-types@2.0.12': {}
+  '@salesforce/ts-types@3.2.0': {}
 
   '@sinclair/typebox@0.34.48': {}
 


### PR DESCRIPTION
## 📝 What & why

Bumps `@salesforce/core` from 8.32.6 to 9.1.11. Supersedes #112, which pins 9.1.0.

9.0.0's only breaking change raises the minimum Node to 22. `engines` already requires `>=22`, and CI runs 22, 24 and 26, so no code changes are needed.

Going to 9.1.11 rather than 9.1.0 takes four fixes that 9.1.0 does not have:

- 9.1.2 tightens `sfdcLoginUrl` validation against OAuth relay attacks
- 9.1.1 fixes a `pino` TS2694 type error in the emitted `.d.ts`
- 9.1.9 allowlists `salesforce.mil`
- 9.1.11 speeds up org login

No API to adopt. 9.1.0's one feature is env vars overriding the scratch org signup Connected App, and this server never creates an org. Everything we import — `Org`, `Connection`, `ConfigAggregator`, `OrgConfigProperties`, `StateAggregator` — is unchanged.

Transitive majors, none imported directly: `@salesforce/kit` 3.2.6 → 4.0.0, `@salesforce/ts-types` 2.0.12 → 3.2.0, `@jsforce/jsforce-node` 3.10.19 → 3.10.25.

## 🧩 Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance
- [ ] 📝 Docs
- [x] 🔧 Chore (tooling, CI, deps)
- [ ] 💥 Breaking change

## 🔗 Related issues

Closes #112

## 🧪 How was this tested?

- [x] `pnpm run build`
- [x] `pnpm run test` — 369 tests, 21 suites
- [x] `pnpm run lint`
- [x] Manually tested against an MCP client / debug log

`pnpm run eval` also passes: 9 cases, tool definitions ~1232 tokens, and the startup check still shows the Salesforce SDK is not loaded to list tools.

The unit tests mock `@salesforce/core`, so the bump was also driven from a stdio MCP client against the built server:

- `apexlog_get_summary` and `apexlog_list_limit_risks` over the eval fixtures
- `apexlog_execute_anonymous` with an unknown alias, which returns a clean `No authorization information found for …` from 9.1.11 through the lazy import
- `apexlog_execute_anonymous` against a connected scratch org: `orgType: scratch`, `succeeded: true`, log written, then fed back to `apexlog_get_summary` and parsed clean

## ✅ Checklist

- [x] Added or updated tests (or not needed) — not needed, no behaviour changes
- [x] Updated docs - README / CHANGELOG (or not needed) — not needed, no user-facing change
