### PR TITLE
chore(skills): allow up to three sub-bullets under a changelog headline

### DIFF
--- a/.claude/skills/changelog-entry/SKILL.md
+++ b/.claude/skills/changelog-entry/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changelog-entry
-description: Write, review or trim CHANGELOG.md entries so a reader understands them. Use when a pull request needs a changelog line, when an Unreleased section is too long or too technical to read, when deciding if a change is breaking, or when a changelog conflict appears while rebasing.
+description: Write, review or trim CHANGELOG.md entries. Use when editing CHANGELOG.md, when a PR needs a changelog line, when a section is too long or a change may be breaking, or on a changelog conflict.
 ---
 
 # Changelog entry
@@ -25,7 +25,9 @@ files moved belong in the issue and the pull request.
 [#86]: https://github.com/owner/repo/issues/86
 ```
 
-- **One sentence, no sub-bullets.** No semicolon joining two facts. Two wrapped lines is the ceiling.
+- **One sentence.** No semicolon joining two facts. Two wrapped lines is the ceiling.
+- **Sub-bullets only where one feature has distinct parts** - three at most, each naming one
+  capability. Never how it was built.
 - **Present tense.** "Add", "Reduce", "Refuse" - not "Added", "Reduced".
 - **Breaking entries first** in their section, prefixed `**Breaking:**`.
 - **Then most impactful first.** The entry that changes the most readers' day leads its
@@ -34,9 +36,8 @@ files moved belong in the issue and the pull request.
 - **A reference link on every substantial entry**, defined under `<!-- Unreleased -->` at the end of
   the file. Never an inline URL.
 
-**The file outranks this skill on style.** Read the released sections first. If they carry an emoji
-and a bold label, or past tense, match them - a changelog that switches voice mid-file reads worse
-than one in the wrong voice. Length and jargon are not style: those rules hold everywhere.
+**The file outranks this skill on style.** Match the released sections - their emoji, labels and
+tense. Length and jargon are not style: those rules always hold.
 
 ## Write for the reader, not the author
 
@@ -45,7 +46,8 @@ The reader upgrades the package; they did not write it. Name the outcome they ca
 - **No internal jargon.** No module, class, library or algorithm names. If the reader cannot find
   the word in the product, cut it.
 - **A fix names the symptom, not the cause.**
-- **A big feature gets one headline entry**, not a tour of every facet. Detail belongs in the docs.
+- **A big feature gets one headline entry**, plus up to three sub-bullets for its parts. Detail
+  belongs in the docs.
 
 ## What earns an entry
 
@@ -65,16 +67,16 @@ No issue fits? File one, then reference it.
 
 ## Wrong, then right
 
-| Wrong                                                                                                         | Right                                                           |
-| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| `- Removed destructiveHint from three tools, since the spec says it is meaningless when readOnlyHint is true` | no entry - the user sees no difference                          |
-| `- Replaced ten per-category properties with one z.partialRecord, cutting ~844 to ~428 tokens`                | fold the result into the one user-facing entry                  |
-| `- Reduced the cost by 31% ([#87](https://.../87))`                                                           | `- Reduce the cost by 31% ([#87])`, plus a reference definition |
-| `- Refactor CSV parsing to process dataset arrays asynchronously`                                             | `- Fix the freeze on a large CSV export`                        |
-| `- Replace webview-ui-toolkit with vscode-elements`                                                           | `- Match the host's controls more closely`                      |
-| a feature with six nested sub-bullets                                                                         | one headline sentence, plus a docs link                         |
-| `- Improve search performance`                                                                                | `- Search a 100MB log 10× faster`                               |
-| `- Optimise the parser`                                                                                       | `- Cut parse time on a large log by 31%`                        |
+| Wrong                                                                                                         | Right                                                                    |
+| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `- Removed destructiveHint from three tools, since the spec says it is meaningless when readOnlyHint is true` | no entry - the user sees no difference                                   |
+| `- Replaced ten per-category properties with one z.partialRecord, cutting ~844 to ~428 tokens`                | fold the result into the one user-facing entry                           |
+| `- Reduced the cost by 31% ([#87](https://.../87))`                                                           | `- Reduce the cost by 31% ([#87])`, plus a reference definition          |
+| `- Refactor CSV parsing to process dataset arrays asynchronously`                                             | `- Fix the freeze on a large CSV export`                                 |
+| `- Replace webview-ui-toolkit with vscode-elements`                                                           | `- Match the host's controls more closely`                               |
+| a feature with six nested sub-bullets                                                                         | a headline sentence, then three sub-bullets at most, one capability each |
+| `- Improve search performance`                                                                                | `- Search a 100MB log 10× faster`                                        |
+| `- Optimise the parser`                                                                                       | `- Cut parse time on a large log by 31%`                                 |
 
 ## Trim a section nobody will read
 
@@ -83,7 +85,8 @@ anything, and merging is most of the win.
 
 1. Find the bounds: `grep -n '^## \[' CHANGELOG.md`.
 2. Read the whole section before changing a word.
-3. Draft the replacement in one pass. Fold every sub-bullet into its headline, or drop it.
+3. Draft the replacement in one pass. Three sub-bullets at most under a headline; fold or drop
+   the rest.
 4. Merge entries that name the same surface or the same fix. Three styling entries are one entry.
 5. Drop what the reader cannot see, by the rules above.
 6. Re-order each section by impact. A trimmed section in the old order still buries the lead.


### PR DESCRIPTION
## 📝 What & why

The `changelog-entry` skill banned sub-bullets outright: "One sentence, no sub-bullets." That left a multi-part feature with two bad options — squeeze every part into one sentence, or hide the parts behind a docs link.

This allows up to three sub-bullets under a headline entry, each naming one capability, never how it was built. The one-sentence rule still holds per bullet, and every other rule is unchanged: no jargon, present tense, breaking first, a reference link on substantial entries.

Also shortens the skill description, which had grown long enough to bury when it should trigger.

## 🧩 Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance
- [ ] 📝 Docs
- [x] 🔧 Chore (tooling, CI, deps)
- [ ] 💥 Breaking change

## 🔗 Related issues

None.

## 🧪 How was this tested?

- [ ] `pnpm run build`
- [ ] `pnpm run test`
- [ ] `pnpm run lint`
- [ ] Manually tested against an MCP client / debug log

None apply. This changes agent instructions only — no source, no build input, nothing the test suite or eval reads.

## ✅ Checklist

- [x] Added or updated tests (or not needed) — not needed, prose only
- [x] Updated docs - README / CHANGELOG (or not needed) — not needed, agent tooling is not user-facing
