### PR TITLE
docs(changelog): mark the 2.0.0 release, dated 2026-09-11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Common Changelog](https://common-changelog.org/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2026-09-11
 
 _Upgrading from 1.x? Every tool is renamed, and `--allowed-orgs` is gone. See [Migrating from 1.x](MIGRATING.md)._
 
@@ -59,7 +59,7 @@ _Upgrading from 1.x? Every tool is renamed, and `--allowed-orgs` is gone. See [M
   - **Debug levels** - Configurable via the `debugLevel` parameter. Set all categories at once (e.g. `"FINEST"`), reset to defaults, or override specific categories like apexCode, database, and nba.
   - **Output directory** - Configurable via the `outputDir` parameter. Defaults to `.apex-log-mcp/` in the project root.
 
-<!-- Unreleased -->
+<!-- 2.0.0 -->
 
 [#52]: https://github.com/certinia/debug-log-analyzer-mcp/issues/52
 [#62]: https://github.com/certinia/debug-log-analyzer-mcp/issues/62


### PR DESCRIPTION
## 📝 What & why

The changelog still heads the 1.x to 2.0 work as `## [Unreleased]`. A reader cannot tell the beta content is what 2.0.0 ships, and the release flow in [DEVELOPING.md](DEVELOPING.md) asks for the heading to name the version and its date when the stable release is tagged.

This dates the section `2026-09-11` and names it `2.0.0`. The reference block below it follows the heading. No entry text changes.

## 🧩 Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance
- [x] 📝 Docs
- [ ] 🔧 Chore (tooling, CI, deps)
- [ ] 💥 Breaking change

## 🔗 Related issues

None.

## 🧪 How was this tested?

- [ ] `pnpm run build`
- [ ] `pnpm run test`
- [ ] `pnpm run lint`
- [ ] Manually tested against an MCP client / debug log

Docs only - two lines of `CHANGELOG.md`, no code path touched. Checked that every issue reference in the section still resolves.

## ✅ Checklist

- [x] Added or updated tests (or not needed) - not needed
- [x] Updated docs - README / CHANGELOG (or not needed) - this is the changelog change

## Before tagging

`package.json` still says `2.0.0-beta.2`. `scripts/release-tag.mjs` refuses a release whose git tag and package version disagree, so the version bump (`pnpm version major --no-git-tag-version`) still has to land before the `2.0.0` tag. Deliberately not in this PR.