### PR TITLE
chore: release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Common Changelog](https://common-changelog.org/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - 2026-09-11
+## [2.0.1] - 2026-09-11
 
 _Upgrading from 1.x? Every tool is renamed, and `--allowed-orgs` is gone. See [Migrating from 1.x](MIGRATING.md)._
 
@@ -47,6 +47,10 @@ _Upgrading from 1.x? Every tool is renamed, and `--allowed-orgs` is gone. See [M
 - **Breaking:** drop Node.js 20 (end of life April 2026) - Node.js 22 is the minimum
 - Remove the canned recommendations of `analyze_apex_log_performance` - an agent advises better from the numbers ([#86])
 
+## [2.0.0] - 2026-09-11
+
+_There is no 2.0.0 on npm. Its release failed, and the tag cannot be reused._
+
 ## [1.0.0] - 2026-03-20
 
 ### Added
@@ -59,7 +63,7 @@ _Upgrading from 1.x? Every tool is renamed, and `--allowed-orgs` is gone. See [M
   - **Debug levels** - Configurable via the `debugLevel` parameter. Set all categories at once (e.g. `"FINEST"`), reset to defaults, or override specific categories like apexCode, database, and nba.
   - **Output directory** - Configurable via the `outputDir` parameter. Defaults to `.apex-log-mcp/` in the project root.
 
-<!-- 2.0.0 -->
+<!-- 2.0.1 -->
 
 [#52]: https://github.com/certinia/debug-log-analyzer-mcp/issues/52
 [#62]: https://github.com/certinia/debug-log-analyzer-mcp/issues/62

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@certinia/apex-log-mcp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "MCP server that gives AI assistants tools to analyze Salesforce Apex debug logs for performance bottlenecks, slow methods, and governor limit usage.",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## 📝 What & why

Releases 2.0.1 instead of 2.0.0.

The 2.0.0 release job failed. `scripts/release-tag.mjs` stopped it because the tag said `2.0.0` while `package.json` still said `2.0.0-beta.2`. That guard ran before `pnpm install`, so nothing was published — npm still holds only `1.0.0`, `2.0.0-beta.1` and `2.0.0-beta.2`, and `latest` points at `1.0.0`.

#200 bumped `package.json` to `2.0.0`, but the `2.0.0` tag cannot be recreated. So this ships the same content as `2.0.1`, and the changelog keeps a `2.0.0` heading that says why it is empty.

`^2.0.0` ranges resolve to `2.0.1`, so the skipped number reaches no one.

## 🧩 Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance
- [ ] 📝 Docs
- [x] 🔧 Chore (tooling, CI, deps)
- [ ] 💥 Breaking change

## 🔗 Related issues

Follows #200.

## 🧪 How was this tested?

- [x] `pnpm run build`
- [x] `pnpm run test` — 369 tests pass
- [x] `pnpm run lint`
- [ ] Manually tested against an MCP client / debug log

Also `pnpm run eval` — 9 cases pass.

## ✅ Checklist

- [x] Added or updated tests (or not needed)
- [x] Updated docs - README / CHANGELOG (or not needed)

---

Note for whoever cuts the release: do not push the tag. Tag creation by push is restricted on this repo — `git push upstream refs/tags/2.0.0` was rejected with `GH013 ... creations being restricted`. Use `gh release create 2.0.1 --target <merge commit>`, which creates the tag, as `1.0.0` and both betas were made.
