### PR TITLE
feat: deny anonymous Apex against named orgs and org types

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -9,4 +9,4 @@ Include the affected version and steps to reproduce. We'll acknowledge your repo
 ## Good to know
 
 - The server runs locally, makes no network calls of its own, and needs no API keys.
-- `apexlog_execute_anonymous` runs Apex against real Salesforce orgs. Every call is authorized by the type of the org it targets: a production org, or one whose type cannot be read, needs `--allow-production-orgs` or a per-call confirmation. `--no-apex-execution` refuses every call.
+- `apexlog_execute_anonymous` runs Apex against real Salesforce orgs. Every call is authorized by the type of the org it targets: a production org, or one whose type cannot be read, needs `--allow-production-orgs` or a per-call confirmation. `--no-apex-execution` refuses every call. `--deny-orgs` and `--deny-org-types` refuse named orgs and whole org types, and nothing lifts a deny.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Common Changelog](https://common-changelog.org/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add `--deny-orgs` and `--deny-org-types`, which refuse anonymous Apex whatever the org type. Nothing lifts a deny, and a denied org is never contacted ([#186])
+
 ## [2.0.1] - 2026-09-11
 
 _Upgrading from 1.x? Every tool is renamed, and `--allowed-orgs` is gone. See [Migrating from 1.x](MIGRATING.md)._
@@ -93,3 +99,4 @@ _There is no 2.0.0 on npm. Its release failed, and the tag cannot be reused._
 [#188]: https://github.com/certinia/debug-log-analyzer-mcp/issues/188
 [#189]: https://github.com/certinia/debug-log-analyzer-mcp/issues/189
 [#191]: https://github.com/certinia/debug-log-analyzer-mcp/issues/191
+[#186]: https://github.com/certinia/debug-log-analyzer-mcp/issues/186

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,4 +96,6 @@ The tool definitions follow the same rule and are charged on every turn, called 
 
 It is always registered so agents can discover it; each call is authorized in `src/policy/orgExecutionPolicy.ts`. A production org, or one whose type cannot be read, needs `--allow-production-orgs` or a per-call confirmation, decided before any `DebugLevel` or `TraceFlag` is written. `--no-apex-execution` refuses every call; the 1.x `--allowed-orgs` is accepted, ignored and warned about.
 
+`--deny-orgs` and `--deny-org-types` refuse outright, in `src/policy/orgDenyList.ts`. A deny beats `--allow-production-orgs` and beats a confirmation. Identity matches before `classifyOrg`, off the local auth file, so a denied org is never contacted; the type matches inside `authorizeExecution`. Only an org id is unspoofable, so the README documents the rest as convenience.
+
 `@salesforce/core` loads only for this tool: `src/server.ts` reaches it through `await import()`, and `executeAnonymousDefinition.ts` holds the wire definition so registration stays synchronous. Startup is 55 ms, not 290 ms; an ESLint rule, `tests/salesforceCoreIsLazy.test.ts` and the `pnpm run eval` startup check keep it there.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -108,7 +108,7 @@ Once you’ve built the server or run the watcher, you can run the MCP server fo
    node dist/index.js --allow-production-orgs
    ```
 
-   To disable Apex execution altogether, use `--no-apex-execution`. See the [README](README.md#production-safety) for the full policy.
+   To disable Apex execution altogether, use `--no-apex-execution`. To refuse named orgs or whole org types, whatever `--allow-production-orgs` says, use `--deny-orgs` and `--deny-org-types`. See the [README](README.md#production-safety) for the full policy.
 
 ## 🔤 Naming Tools and Fields
 

--- a/README.md
+++ b/README.md
@@ -246,12 +246,37 @@ For a production org, `--allow-production-orgs` runs it anyway. Otherwise the se
 
 An org that cannot be identified is treated as production, so a network or permissions problem can never quietly downgrade one.
 
+### Deny lists
+
+Org type says nothing about whose data an org holds: a customer sandbox runs with no prompt. Two flags refuse an org outright.
+
+```json
+"args": [
+  "-y",
+  "@certinia/apex-log-mcp",
+  "--deny-orgs",
+  "prod-*-org@mycompany.com,*.my.salesforce.com",
+  "--deny-org-types",
+  "production,unknown"
+]
+```
+
+`--deny-orgs` matches the org id, username, alias or instance URL. `*` is a glob, and the match is anchored and ignores case, so `prod-*@acme.com` denies `prod-eu@acme.com` and not `xprod-eu@acme.com`. Every value comes from the local auth file, so a denied org is never contacted.
+
+`--deny-org-types` takes the types in the table above. An unknown value stops the server.
+
+Nothing lifts a deny - not `--allow-production-orgs`, not a confirmation. The refusal names what matched.
+
+Only the org id is unspoofable. An alias can be re-pointed, so treat the rest as convenience, not a security boundary.
+
 ### Server flags
 
 | Flag                      | Description                                                                                                              |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `--allow-production-orgs` | Treat production orgs like any other - no confirmation, no refusal. Only set this if production targets are intentional. |
 | `--no-apex-execution`     | Refuse every Apex execution. The tool stays visible so agents know it exists. The three analysis tools are unaffected.   |
+| `--deny-orgs`             | Refuse these orgs, whatever their type. Org id, username, alias or instance URL, with `*` as a glob. |
+| `--deny-org-types`        | Refuse these org types, from the table above. |
 
 For an analysis-only deployment:
 

--- a/src/policy/orgDenyList.ts
+++ b/src/policy/orgDenyList.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+import {
+  isOrgClassification,
+  ORG_CLASSIFICATIONS,
+  type OrgClassification,
+} from "../salesforce/orgClassification.js";
+
+/**
+ * A deny pattern, kept beside its matcher so a refusal can name what matched.
+ *
+ * `source` is the pattern as the user wrote it. `RegExp.source` holds the
+ * compiled form, which nobody typed and nobody would recognise.
+ */
+export type DenyPattern = {
+  source: string;
+  regexp: RegExp;
+};
+
+/**
+ * What is known about the target org before it is queried.
+ *
+ * Every field comes from the local auth file, so a deny is decided without
+ * contacting the org. Only `orgId` is unspoofable - an alias can be re-pointed
+ * at another org - so the rest are a convenience, not a security boundary.
+ */
+export type OrgIdentity = {
+  orgId: string;
+  username: string;
+  alias?: string;
+  instanceUrl?: string;
+};
+
+/** Every character `RegExp` reads as syntax, less `*`, which is the glob. */
+const REGEXP_METACHARACTERS = /[.+?^${}()|[\]\\]/g;
+
+export const DENY_IS_ABSOLUTE =
+  "A deny is absolute: no flag and no confirmation lifts it.";
+
+/**
+ * Compile one pattern.
+ *
+ * `*` matches any run of characters and every other metacharacter is literal.
+ * Anchored and case-insensitive, so `prod-*@acme.com` denies `PROD-a@acme.com`
+ * and not `xprod-a@acme.com`.
+ */
+function compile(source: string): RegExp {
+  const body = source
+    .split("*")
+    .map((literal) => literal.replace(REGEXP_METACHARACTERS, "\\$&"))
+    .join(".*");
+  return new RegExp(`^${body}$`, "i");
+}
+
+/**
+ * Split a repeatable, comma-separated flag into its values.
+ *
+ * Case is left as written, because `compile` matches without regard to it and
+ * a refusal has to echo the pattern the user typed.
+ */
+export function parseDenyOrgPatterns(raw: string[]): string[] {
+  return raw
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+/**
+ * Validate `--deny-org-types`.
+ *
+ * Throws, so a typo fails the server at startup. A pattern cannot be validated
+ * this way - one that matches nothing is indistinguishable from one that has
+ * yet to match - which is why the two are separate flags.
+ */
+export function parseDenyOrgTypes(raw: string[]): OrgClassification[] {
+  return parseDenyOrgPatterns(raw).map((value) => {
+    const type = value.toLowerCase();
+    if (!isOrgClassification(type)) {
+      throw new Error(
+        `--deny-org-types: '${value}' is not an org type. Use one of: ${ORG_CLASSIFICATIONS.join(", ")}.`,
+      );
+    }
+    return type;
+  });
+}
+
+/** Cleans its input, so a hand-built configuration behaves like a parsed one. */
+export function compileDenyOrgs(sources: string[]): DenyPattern[] {
+  return parseDenyOrgPatterns(sources).map((source) => ({
+    source,
+    regexp: compile(source),
+  }));
+}
+
+/**
+ * The first pattern that denies this org, or `undefined`.
+ *
+ * Matched against everything the auth file knows, so a deny on the username
+ * cannot be dodged by naming the alias.
+ */
+export function matchDeniedOrg(
+  patterns: DenyPattern[],
+  identity: OrgIdentity,
+): DenyPattern | undefined {
+  const fields = [
+    identity.orgId,
+    identity.username,
+    identity.alias,
+    identity.instanceUrl,
+  ].filter((field): field is string => !!field);
+
+  return patterns.find((pattern) =>
+    fields.some((field) => pattern.regexp.test(field)),
+  );
+}
+
+function denyRefusal(orgLabel: string, because: string): string {
+  return `Cannot execute anonymous Apex against org '${orgLabel}': ${because}.\n${DENY_IS_ABSOLUTE}`;
+}
+
+export function denyOrgRefusal(orgLabel: string, pattern: DenyPattern): string {
+  return denyRefusal(
+    orgLabel,
+    `it matches the --deny-orgs pattern '${pattern.source}'`,
+  );
+}
+
+export function denyOrgTypeRefusal(
+  orgLabel: string,
+  classification: OrgClassification,
+): string {
+  return denyRefusal(
+    orgLabel,
+    `its type is '${classification}', which --deny-org-types denies`,
+  );
+}

--- a/src/policy/orgExecutionPolicy.ts
+++ b/src/policy/orgExecutionPolicy.ts
@@ -12,6 +12,7 @@ import {
 } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import type { OrgClassification } from "../salesforce/orgClassification.js";
+import { denyOrgTypeRefusal } from "./orgDenyList.js";
 
 export type PolicyDecision =
   | { outcome: "allowed" }
@@ -174,9 +175,15 @@ function confirmationRequest(
 /**
  * Decide whether anonymous Apex may run against the classified target org.
  *
- * Non-production orgs run silently. Production orgs (and orgs whose type could
- * not be verified) need either the --allow-production-orgs flag or an explicit,
- * per-call user confirmation.
+ * A denied org type refuses first, before any allow path: --deny-org-types is
+ * absolute, and neither --allow-production-orgs nor a confirmation lifts it.
+ * The --deny-orgs half is enforced by the caller instead, before it classifies
+ * the org, because it reads the auth file alone and so refuses a denied org
+ * without contacting it.
+ *
+ * Otherwise non-production orgs run silently. Production orgs (and orgs whose
+ * type could not be verified) need either the --allow-production-orgs flag or
+ * an explicit, per-call user confirmation.
  *
  * The confirmation is a multi-round-trip: the first call returns the request,
  * and the client re-sends the same call carrying the answer. The whole handler
@@ -195,11 +202,19 @@ export async function authorizeExecution(opts: {
   orgLabel: string;
   apex: string;
   allowProductionOrgs: boolean;
+  denyOrgTypes: OrgClassification[];
   consumeConfirmation: ConsumeConfirmation;
   unverifiedReason?: string;
 }): Promise<PolicyDecision> {
   const { ctx, classification, orgId, orgLabel, apex, allowProductionOrgs } =
     opts;
+
+  if (opts.denyOrgTypes.includes(classification)) {
+    return {
+      outcome: "refused",
+      reason: denyOrgTypeRefusal(orgLabel, classification),
+    };
+  }
 
   if (classification !== "production" && classification !== "unknown") {
     return { outcome: "allowed" };

--- a/src/salesforce/orgClassification.ts
+++ b/src/salesforce/orgClassification.ts
@@ -16,13 +16,25 @@ export type OrganizationRecord = {
   OrganizationType: string;
 };
 
-export type OrgClassification =
-  | "sandbox"
-  | "scratch"
-  | "developer"
-  | "trial"
-  | "production"
-  | "unknown";
+/**
+ * Every classification, for a caller that must validate one against user input.
+ * `OrgClassification` is derived from it, so the two cannot drift apart.
+ */
+export const ORG_CLASSIFICATIONS = [
+  "sandbox",
+  "scratch",
+  "developer",
+  "trial",
+  "production",
+  "unknown",
+] as const;
+
+export type OrgClassification = (typeof ORG_CLASSIFICATIONS)[number];
+
+/** Whether a string names one of them. */
+export function isOrgClassification(value: string): value is OrgClassification {
+  return (ORG_CLASSIFICATIONS as readonly string[]).includes(value);
+}
 
 export type OrgTypeResult = {
   classification: OrgClassification;

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,12 +32,20 @@ import {
   createConfirmationLedger,
   type ConfirmationState,
 } from "./policy/orgExecutionPolicy.js";
+import {
+  compileDenyOrgs,
+  parseDenyOrgPatterns,
+  parseDenyOrgTypes,
+} from "./policy/orgDenyList.js";
 import type { OrgClassification } from "./salesforce/orgClassification.js";
 import packageJson from "../package.json" with { type: "json" };
 
 export type ServerConfig = {
   allowProductionOrgs?: boolean;
   apexExecutionDisabled?: boolean;
+  /** `--deny-orgs` patterns, cleaned. Compiled once per server. */
+  denyOrgs?: string[];
+  denyOrgTypes?: OrgClassification[];
 };
 
 // An org id maps to one classification for the life of the process, so this
@@ -76,6 +84,9 @@ function definitionsVaryByConfig(config: Required<ServerConfig>): boolean {
 export function createApexLogServer(config: ServerConfig = {}): McpServer {
   const allowProductionOrgs = config.allowProductionOrgs ?? false;
   const apexExecutionDisabled = config.apexExecutionDisabled ?? false;
+  const denyOrgs = config.denyOrgs ?? [];
+  const denyOrgTypes = config.denyOrgTypes ?? [];
+  const denyOrgPatterns = compileDenyOrgs(denyOrgs);
   const server = new McpServer(
     {
       name: "apex-log-mcp",
@@ -101,6 +112,8 @@ export function createApexLogServer(config: ServerConfig = {}): McpServer {
           cacheScope: definitionsVaryByConfig({
             allowProductionOrgs,
             apexExecutionDisabled,
+            denyOrgs,
+            denyOrgTypes,
           })
             ? "private"
             : "public",
@@ -143,6 +156,8 @@ export function createApexLogServer(config: ServerConfig = {}): McpServer {
       const { executeAnonymous } = await import("./tools/executeAnonymous.js");
       return executeAnonymous(server, args as ExecuteAnonymousArgs, ctx, {
         allowProductionOrgs,
+        denyOrgs: denyOrgPatterns,
+        denyOrgTypes,
         apexExecutionDisabled,
         classificationCache,
         mintConfirmationState: (payload, ctx) =>
@@ -187,6 +202,9 @@ export function runStdioServer(config: ServerConfig = {}): void {
  * `--allowed-orgs` is deprecated and ignored, but is still declared here because
  * parseArgs is strict: leaving it out would make existing client configurations
  * fail to start.
+ *
+ * Throws on an unrecognised `--deny-org-types` value, so a typo stops the server
+ * rather than leaving a deny that silently never matches.
  */
 export function parseServerConfig(argv: string[]): ServerConfig {
   const { values } = parseArgs({
@@ -195,6 +213,8 @@ export function parseServerConfig(argv: string[]): ServerConfig {
       "allowed-orgs": { type: "string" },
       "allow-production-orgs": { type: "boolean" },
       "no-apex-execution": { type: "boolean" },
+      "deny-orgs": { type: "string", multiple: true },
+      "deny-org-types": { type: "string", multiple: true },
     },
   });
 
@@ -208,5 +228,7 @@ export function parseServerConfig(argv: string[]): ServerConfig {
   return {
     allowProductionOrgs: values["allow-production-orgs"] ?? false,
     apexExecutionDisabled: values["no-apex-execution"] ?? false,
+    denyOrgs: parseDenyOrgPatterns(values["deny-orgs"] ?? []),
+    denyOrgTypes: parseDenyOrgTypes(values["deny-org-types"] ?? []),
   };
 }

--- a/src/tools/executeAnonymous.ts
+++ b/src/tools/executeAnonymous.ts
@@ -33,6 +33,11 @@ import {
   type ConsumeConfirmation,
   type MintConfirmationState,
 } from "../policy/orgExecutionPolicy.js";
+import {
+  denyOrgRefusal,
+  matchDeniedOrg,
+  type DenyPattern,
+} from "../policy/orgDenyList.js";
 import type { ExecuteAnonymousArgs } from "./executeAnonymousDefinition.js";
 
 /** Connect, set the trace flag, execute, write. */
@@ -46,6 +51,8 @@ const NO_LOG_CAPTURED_WARNING =
 
 export type ExecuteAnonymousPolicy = {
   allowProductionOrgs: boolean;
+  denyOrgs: DenyPattern[];
+  denyOrgTypes: OrgClassification[];
   apexExecutionDisabled: boolean;
   classificationCache: Map<string, OrgClassification>;
   mintConfirmationState: MintConfirmationState;
@@ -139,6 +146,19 @@ export async function executeAnonymous(
   const alias = await getAliasForUsername(username);
   const orgLabel = alias ? `${username} (${alias})` : username;
 
+  // Everything a pattern matches comes from the local auth file, so a denied
+  // org is refused without being contacted at all.
+  const orgId = org.getOrgId();
+  const denied = matchDeniedOrg(policy.denyOrgs, {
+    orgId,
+    username,
+    alias,
+    instanceUrl: connection.instanceUrl,
+  });
+  if (denied) {
+    return toolError(denyOrgRefusal(orgLabel, denied));
+  }
+
   // Authorize before creating any DebugLevel or TraceFlag records, so a refused
   // call leaves the target org untouched.
   const { classification, unverifiedReason } = await classifyOrg(
@@ -150,10 +170,11 @@ export async function executeAnonymous(
     mintConfirmationState: policy.mintConfirmationState,
     consumeConfirmation: policy.consumeConfirmation,
     classification,
-    orgId: org.getOrgId(),
+    orgId,
     orgLabel,
     apex,
     allowProductionOrgs: policy.allowProductionOrgs,
+    denyOrgTypes: policy.denyOrgTypes,
     unverifiedReason,
   });
 

--- a/tests/executeAnonymous.test.ts
+++ b/tests/executeAnonymous.test.ts
@@ -73,6 +73,10 @@ import { loadApexLog } from "../src/tools/apexLogSource";
 import type { ApexLog } from "@apexdevtools/apex-log-parser";
 import type { OrgClassification } from "../src/salesforce/orgClassification";
 import {
+  compileDenyOrgs,
+  type DenyPattern,
+} from "../src/policy/orgDenyList";
+import {
   createConfirmationLedger,
   type ConfirmationState,
 } from "../src/policy/orgExecutionPolicy";
@@ -139,12 +143,16 @@ function policy(
   overrides: {
     allowProductionOrgs?: boolean;
     apexExecutionDisabled?: boolean;
+    denyOrgs?: DenyPattern[];
+    denyOrgTypes?: OrgClassification[];
     classificationCache?: Map<string, OrgClassification>;
   } = {},
 ) {
   return {
     allowProductionOrgs: false,
     apexExecutionDisabled: false,
+    denyOrgs: [],
+    denyOrgTypes: [],
     classificationCache: new Map<string, OrgClassification>(),
     mintConfirmationState: (payload: ConfirmationState) => codec.mint(payload),
     consumeConfirmation: createConfirmationLedger(),
@@ -798,6 +806,45 @@ describe("Execute Anonymous", () => {
 
       expect(toonDecode(result).orgType).toBe("sandbox");
       expectPostedApex(testApexCode);
+    });
+
+    // A deny turns on these three reaching the matcher before classifyOrg
+    // does. The classification query and the Apex both need a round trip, and
+    // neither is worth making for an org the configuration already refused.
+    it.each([
+      ["org id", TEST_ORG_ID],
+      ["username", "test@*.com"],
+      ["instance URL", "*.my.salesforce.com"],
+    ])("should deny on the %s the auth file already knows", async (_f, p) => {
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+
+      const result: any = await executeAnonymous(
+        mockServer,
+        args,
+        ctx,
+        policy({ denyOrgs: compileDenyOrgs([p]) }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain(`--deny-orgs pattern '${p}'`);
+      expect(mockRetrieveOrgInfo).not.toHaveBeenCalled();
+      expect(mockRequest).not.toHaveBeenCalled();
+    });
+
+    it("should deny an org type even with --allow-production-orgs", async () => {
+      mockRetrieveOrgInfo.mockResolvedValue(PRODUCTION_ORG_INFO);
+      const args: ExecuteAnonymousArgs = { apex: testApexCode };
+
+      const result: any = await executeAnonymous(
+        mockServer,
+        args,
+        ctx,
+        policy({ allowProductionOrgs: true, denyOrgTypes: ["production"] }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("its type is 'production'");
+      expect(mockRequest).not.toHaveBeenCalled();
     });
 
     it("should ask for confirmation on the first production call", async () => {

--- a/tests/policy/orgDenyList.test.ts
+++ b/tests/policy/orgDenyList.test.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+import {
+  compileDenyOrgs,
+  denyOrgRefusal,
+  denyOrgTypeRefusal,
+  matchDeniedOrg,
+  parseDenyOrgPatterns,
+  parseDenyOrgTypes,
+  type OrgIdentity,
+} from "../../src/policy/orgDenyList";
+
+const identity: OrgIdentity = {
+  orgId: "00D000000000001",
+  username: "prod-eu-org@mycompany.com",
+  alias: "euProd",
+  instanceUrl: "https://acme.my.salesforce.com",
+};
+
+/** A config's worth of patterns, cleaned and compiled the way the server does. */
+function deny(...patterns: string[]) {
+  return compileDenyOrgs(parseDenyOrgPatterns(patterns));
+}
+
+describe("parseDenyOrgPatterns", () => {
+  it("should split one comma-separated value", () => {
+    expect(parseDenyOrgPatterns(["a@x.com,b@x.com"])).toEqual([
+      "a@x.com",
+      "b@x.com",
+    ]);
+  });
+
+  it("should gather a repeated flag", () => {
+    expect(parseDenyOrgPatterns(["a@x.com", "b@x.com"])).toEqual([
+      "a@x.com",
+      "b@x.com",
+    ]);
+  });
+
+  it("should trim and drop empty values", () => {
+    expect(parseDenyOrgPatterns([" a@x.com , ,b@x.com "])).toEqual([
+      "a@x.com",
+      "b@x.com",
+    ]);
+  });
+
+  // The refusal echoes this back, so it has to be what the user typed.
+  it("should leave the case the user wrote", () => {
+    expect(parseDenyOrgPatterns(["Prod-EU@Acme.com"])).toEqual([
+      "Prod-EU@Acme.com",
+    ]);
+  });
+});
+
+describe("matchDeniedOrg", () => {
+  it.each([
+    ["org id", "00d000000000001"],
+    ["username", "prod-eu-org@mycompany.com"],
+    ["alias", "euprod"],
+    ["instance URL", "https://acme.my.salesforce.com"],
+  ])("should deny on an exact %s", (_field, pattern) => {
+    expect(matchDeniedOrg(deny(pattern), identity)?.source).toBe(pattern);
+  });
+
+  it("should deny on a username glob", () => {
+    expect(
+      matchDeniedOrg(deny("prod-*-org@mycompany.com"), identity)?.source,
+    ).toBe("prod-*-org@mycompany.com");
+  });
+
+  it("should deny on an instance URL glob", () => {
+    expect(matchDeniedOrg(deny("*.my.salesforce.com"), identity)).toBeDefined();
+  });
+
+  it("should match whatever the case", () => {
+    expect(matchDeniedOrg(deny("EUPROD"), identity)?.source).toBe("EUPROD");
+  });
+
+  // A configuration built by hand never passes through parseServerConfig, and
+  // must not get a pattern that silently matches nothing.
+  it("should clean a pattern that was not parsed from a flag", () => {
+    expect(
+      matchDeniedOrg(compileDenyOrgs([" euprod , other@x.com "]), identity)
+        ?.source,
+    ).toBe("euprod");
+  });
+
+  it("should anchor a glob, so it cannot match a longer name", () => {
+    expect(
+      matchDeniedOrg(deny("prod-*-org@mycompany.com"), {
+        orgId: "00D000000000002",
+        username: "xprod-eu-org@mycompany.com",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("should read a dot as a dot and not as any character", () => {
+    expect(
+      matchDeniedOrg(deny("prod-eu-org@mycompany.com"), {
+        orgId: "00D000000000002",
+        username: "prod-eu-org@mycompanyxcom",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("should read every other regex metacharacter literally", () => {
+    const plus = { orgId: "00D000000000002", username: "a+b@x.com" };
+
+    expect(matchDeniedOrg(deny("a+b@x.com"), plus)?.source).toBe("a+b@x.com");
+    expect(matchDeniedOrg(deny("aab@x.com"), plus)).toBeUndefined();
+  });
+
+  it("should name the first pattern that matched", () => {
+    expect(matchDeniedOrg(deny("nothing@x.com", "euprod"), identity)?.source).toBe(
+      "euprod",
+    );
+  });
+
+  it("should deny nothing when no pattern matches", () => {
+    expect(matchDeniedOrg(deny("other@x.com"), identity)).toBeUndefined();
+  });
+
+  it("should deny nothing when no pattern is configured", () => {
+    expect(matchDeniedOrg([], identity)).toBeUndefined();
+  });
+
+  it("should cope with an org that carries no alias or instance URL", () => {
+    expect(
+      matchDeniedOrg(deny("euprod"), {
+        orgId: identity.orgId,
+        username: identity.username,
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("parseDenyOrgTypes", () => {
+  it("should accept a comma-separated list of classifications", () => {
+    expect(parseDenyOrgTypes(["production,unknown"])).toEqual([
+      "production",
+      "unknown",
+    ]);
+  });
+
+  it("should throw on a value that is not an org type", () => {
+    expect(() => parseDenyOrgTypes(["prodction"])).toThrow(
+      "'prodction' is not an org type",
+    );
+  });
+
+  it("should name the values it accepts", () => {
+    expect(() => parseDenyOrgTypes(["nope"])).toThrow(
+      "sandbox, scratch, developer, trial, production, unknown",
+    );
+  });
+});
+
+describe("the deny refusals", () => {
+  const pattern = deny("prod-*")[0]!;
+
+  it("should name the pattern that matched", () => {
+    expect(denyOrgRefusal("me@x.com", pattern)).toContain(
+      "--deny-orgs pattern 'prod-*'",
+    );
+  });
+
+  it("should name the type that was denied", () => {
+    expect(denyOrgTypeRefusal("me@x.com", "production")).toContain(
+      "its type is 'production'",
+    );
+  });
+
+  it("should say that nothing lifts a deny", () => {
+    expect(denyOrgRefusal("me@x.com", pattern)).toContain(
+      "no flag and no confirmation lifts it",
+    );
+  });
+
+  it("should not point at --allow-production-orgs, which cannot lift a deny", () => {
+    expect(denyOrgRefusal("me@x.com", pattern)).not.toContain(
+      "--allow-production-orgs",
+    );
+    expect(denyOrgTypeRefusal("me@x.com", "production")).not.toContain(
+      "--allow-production-orgs",
+    );
+  });
+});

--- a/tests/policy/orgExecutionPolicy.test.ts
+++ b/tests/policy/orgExecutionPolicy.test.ts
@@ -47,6 +47,7 @@ describe("authorizeExecution", () => {
       ctx?: ServerContext;
       classification?: OrgClassification;
       allowProductionOrgs?: boolean;
+      denyOrgTypes?: OrgClassification[];
       apex?: string;
       orgId?: string;
       unverifiedReason?: string;
@@ -63,6 +64,7 @@ describe("authorizeExecution", () => {
       orgLabel,
       apex: overrides.apex ?? apex,
       allowProductionOrgs: overrides.allowProductionOrgs ?? false,
+      denyOrgTypes: overrides.denyOrgTypes ?? [],
       unverifiedReason: overrides.unverifiedReason,
     });
   }
@@ -73,6 +75,7 @@ describe("authorizeExecution", () => {
       ctx?: ServerContext;
       reason?: string;
       allowProductionOrgs?: boolean;
+      denyOrgTypes?: OrgClassification[];
     } = {},
   ) {
     return authorize({
@@ -80,6 +83,7 @@ describe("authorizeExecution", () => {
       classification: "unknown",
       unverifiedReason: overrides.reason ?? "inactive organization",
       allowProductionOrgs: overrides.allowProductionOrgs,
+      denyOrgTypes: overrides.denyOrgTypes,
     });
   }
 
@@ -148,6 +152,39 @@ describe("authorizeExecution", () => {
     await expect(
       authorizeUnknown({ allowProductionOrgs: true }),
     ).resolves.toEqual({ outcome: "allowed" });
+  });
+
+  describe("a denied org type", () => {
+    it("should beat --allow-production-orgs", async () => {
+      await expect(
+        authorize({ allowProductionOrgs: true, denyOrgTypes: ["production"] }),
+      ).resolves.toMatchObject({ outcome: "refused" });
+    });
+
+    it("should refuse instead of asking for a confirmation", async () => {
+      await expect(
+        authorize({ denyOrgTypes: ["production"] }),
+      ).resolves.toMatchObject({ outcome: "refused" });
+      expect(mintConfirmationState).not.toHaveBeenCalled();
+    });
+
+    it("should deny a sandbox, which the type gate alone allows", async () => {
+      await expect(
+        authorize({ classification: "sandbox", denyOrgTypes: ["sandbox"] }),
+      ).resolves.toMatchObject({ outcome: "refused" });
+    });
+
+    it("should deny an org whose type could not be verified", async () => {
+      await expect(
+        authorizeUnknown({ denyOrgTypes: ["unknown"] }),
+      ).resolves.toMatchObject({ outcome: "refused" });
+    });
+
+    it("should allow a classification the list does not name", async () => {
+      await expect(
+        authorize({ classification: "sandbox", denyOrgTypes: ["production"] }),
+      ).resolves.toEqual({ outcome: "allowed" });
+    });
   });
 
   describe("the first round", () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -408,6 +408,8 @@ describe("createApexLogServer", () => {
         {
           allowProductionOrgs: false,
           apexExecutionDisabled: false,
+          denyOrgs: [],
+          denyOrgTypes: [],
           classificationCache: expect.any(Map),
           mintConfirmationState: expect.any(Function),
           consumeConfirmation: expect.any(Function),
@@ -586,6 +588,8 @@ describe("parseServerConfig", () => {
     expect(parseServerConfig([])).toEqual({
       allowProductionOrgs: false,
       apexExecutionDisabled: false,
+      denyOrgs: [],
+      denyOrgTypes: [],
     });
   });
 
@@ -593,6 +597,8 @@ describe("parseServerConfig", () => {
     expect(parseServerConfig(["--allow-production-orgs"])).toEqual({
       allowProductionOrgs: true,
       apexExecutionDisabled: false,
+      denyOrgs: [],
+      denyOrgTypes: [],
     });
   });
 
@@ -600,7 +606,44 @@ describe("parseServerConfig", () => {
     expect(parseServerConfig(["--no-apex-execution"])).toEqual({
       allowProductionOrgs: false,
       apexExecutionDisabled: true,
+      denyOrgs: [],
+      denyOrgTypes: [],
     });
+  });
+
+  it("should read --deny-orgs, comma-separated and repeated", () => {
+    expect(
+      parseServerConfig([
+        "--deny-orgs",
+        "A@x.com, b@x.com",
+        "--deny-orgs",
+        "prod-*@x.com",
+      ]),
+    ).toEqual({
+      allowProductionOrgs: false,
+      apexExecutionDisabled: false,
+      denyOrgs: ["A@x.com", "b@x.com", "prod-*@x.com"],
+      denyOrgTypes: [],
+    });
+  });
+
+  it("should read --deny-org-types", () => {
+    expect(
+      parseServerConfig(["--deny-org-types", "production,unknown"]),
+    ).toEqual({
+      allowProductionOrgs: false,
+      apexExecutionDisabled: false,
+      denyOrgs: [],
+      denyOrgTypes: ["production", "unknown"],
+    });
+  });
+
+  // A pattern that matches nothing looks the same as one that has yet to match,
+  // so only the closed set can be checked, and it is checked before startup.
+  it("should refuse to start on a --deny-org-types value that is not an org type", () => {
+    expect(() => parseServerConfig(["--deny-org-types", "prodction"])).toThrow(
+      "'prodction' is not an org type",
+    );
   });
 
   it("should still start when the deprecated --allowed-orgs is passed", () => {
@@ -609,6 +652,8 @@ describe("parseServerConfig", () => {
     ).toEqual({
       allowProductionOrgs: false,
       apexExecutionDisabled: false,
+      denyOrgs: [],
+      denyOrgTypes: [],
     });
   });
 


### PR DESCRIPTION
## 📝 What & why

Org type says nothing about whose data an org holds. A customer sandbox, or a scratch org seeded with real records, classifies `sandbox` and runs anonymous Apex with no prompt.

Adds `--deny-orgs` and `--deny-org-types`. Nothing lifts a deny — not `--allow-production-orgs`, not a confirmation.

`--deny-orgs` matches the org id, username, alias or instance URL, `*` as a glob, anchored and ignoring case. Every value comes from the local auth file, so a denied org is matched **before** it is classified: no round trip, no `DebugLevel`, no `TraceFlag`.

`--deny-org-types` validates against the closed set, so a typo stops the server rather than leaving a deny that never matches.

Two notes:

- The issue expects org id and instance URL to need the org query. They do not — both come from the auth file, so identity matches once, pre-query. A test pins all three fields.
- `--deny-orgs-file` is out of scope: a second input source for the same matcher, no design consequence.

## 🧩 Type of change

- [x] ✨ New feature

## 🔗 Related issues

Closes #186

## 🧪 How was this tested?

- [x] `pnpm run build`
- [x] `pnpm run test` — 407 pass, was 369
- [x] `pnpm run lint`
- [ ] Manually tested against an MCP client / debug log — not done; no org exercised

`pnpm run eval` also passes: tool definitions unchanged at ~1232 tokens, and startup still loads no Salesforce SDK.

## ✅ Checklist

- [x] Added or updated tests (or not needed)
- [x] Updated docs - README / CHANGELOG (or not needed)
